### PR TITLE
v0.6.1 Hotfix: Pattern settings, confidence decay, mojibake fixes, UI improvements

### DIFF
--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.6.0"
+  org.opencontainers.image.version: "0.6.1"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.0"
+version: "0.6.1"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/ha_connection.py
+++ b/addon/rootfs/opt/mindhome/ha_connection.py
@@ -142,10 +142,10 @@ class HAConnection:
                 max_t = attrs.get("max_temp", 35)
                 temp = float(temp)
                 if temp < min_t:
-                    logger.warning(f"Climate {eid}: clamped {temp}→ â€™{min_t}°C (min)")
+                    logger.warning(f"Climate {eid}: clamped {temp}→{min_t}°C (min)")
                     temp = min_t
                 elif temp > max_t:
-                    logger.warning(f"Climate {eid}: clamped {temp}→ â€™{max_t}°C (max)")
+                    logger.warning(f"Climate {eid}: clamped {temp}→{max_t}°C (max)")
                     temp = max_t
                 payload["temperature"] = temp
         except Exception as e:

--- a/addon/rootfs/opt/mindhome/init_db.py
+++ b/addon/rootfs/opt/mindhome/init_db.py
@@ -1,3 +1,4 @@
+# MindHome init_db v0.6.1 (2026-02-10) - init_db.py
 """
 MindHome - Database Initialization
 Creates tables and populates default data on first run.
@@ -5,11 +6,14 @@ Creates tables and populates default data on first run.
 
 import os
 import sys
+import logging
 from models import (
     init_database, get_engine, get_session,
     Domain, QuickAction, SystemSetting, UserRole, User,
     NotificationSetting, NotificationType
 )
+
+logger = logging.getLogger("mindhome.init_db")
 
 
 def create_default_domains(session):
@@ -33,10 +37,10 @@ def create_default_domains(session):
         },
         {
             "name": "cover",
-            "display_name_de": "RolllÃ¤den & Abdeckungen",
+            "display_name_de": "Rollläden & Abdeckungen",
             "display_name_en": "Covers & Blinds",
             "icon": "mdi:blinds",
-            "description_de": "RolllÃ¤den, Jalousien, Markisen, Garagentore",
+            "description_de": "Rollläden, Jalousien, Markisen, Garagentore",
             "description_en": "Blinds, shutters, awnings, garage doors"
         },
         {
@@ -57,10 +61,10 @@ def create_default_domains(session):
         },
         {
             "name": "door_window",
-            "display_name_de": "TÃ¼ren & Fenster",
+            "display_name_de": "Türen & Fenster",
             "display_name_en": "Doors & Windows",
             "icon": "mdi:door-open",
-            "description_de": "Kontaktsensoren fÃ¼r TÃ¼ren und Fenster",
+            "description_de": "Kontaktsensoren für Türen und Fenster",
             "description_en": "Contact sensors for doors and windows"
         },
         {
@@ -89,10 +93,10 @@ def create_default_domains(session):
         },
         {
             "name": "lock",
-            "display_name_de": "SchlÃ¶sser & Sicherheit",
+            "display_name_de": "Schlösser & Sicherheit",
             "display_name_en": "Locks & Security",
             "icon": "mdi:lock",
-            "description_de": "TÃ¼rschlÃ¶sser, Alarmanlagen",
+            "description_de": "Türschlösser, Alarmanlagen",
             "description_en": "Door locks, alarm systems"
         },
         {
@@ -105,7 +109,7 @@ def create_default_domains(session):
         },
         {
             "name": "air_quality",
-            "display_name_de": "LuftqualitÃ¤t",
+            "display_name_de": "Luftqualität",
             "display_name_en": "Air Quality",
             "icon": "mdi:air-filter",
             "description_de": "CO2, VOC, Feuchtigkeit, Feinstaub",
@@ -113,10 +117,10 @@ def create_default_domains(session):
         },
         {
             "name": "ventilation",
-            "display_name_de": "LÃ¼ftungsanlage",
+            "display_name_de": "Lüftungsanlage",
             "display_name_en": "Ventilation",
             "icon": "mdi:fan",
-            "description_de": "KWL, LÃ¼ftungsanlage mit WÃ¤rmerÃ¼ckgewinnung",
+            "description_de": "KWL, Lüftungsanlage mit Wärmerückgewinnung",
             "description_en": "HRV, ventilation with heat recovery"
         },
         {
@@ -157,7 +161,7 @@ def create_default_quick_actions(session):
             "is_system": True
         },
         {
-            "name_de": "Ich bin zurÃ¼ck",
+            "name_de": "Ich bin zurück",
             "name_en": "I'm back",
             "icon": "mdi:home",
             "action_data": {"type": "arriving_home", "targets": "all"},
@@ -165,7 +169,7 @@ def create_default_quick_actions(session):
             "is_system": True
         },
         {
-            "name_de": "GÃ¤ste kommen",
+            "name_de": "Gäste kommen",
             "name_en": "Guests arriving",
             "icon": "mdi:account-group",
             "action_data": {"type": "guest_mode_on", "targets": "all"},
@@ -182,12 +186,18 @@ def create_default_quick_actions(session):
         },
     ]
 
+    created = 0
     for action_data in actions:
+        existing = session.query(QuickAction).filter_by(name_de=action_data["name_de"]).first()
+        if existing:
+            logger.info(f"Seed skip (exists): {action_data['name_de']}")
+            continue
         action = QuickAction(**action_data)
         session.add(action)
+        created += 1
 
     session.commit()
-    print(f"Created {len(actions)} quick actions.")
+    print(f"Created {created} quick actions ({len(actions) - created} skipped).")
 
 
 def create_default_settings(session):
@@ -226,7 +236,7 @@ def create_default_settings(session):
         {
             "key": "prediction_confidence_threshold",
             "value": "0.7",
-            "description_de": "Minimale Confidence fÃ¼r automatische Aktionen (0.0 - 1.0)",
+            "description_de": "Minimale Confidence für automatische Aktionen (0.0 - 1.0)",
             "description_en": "Minimum confidence for automatic actions (0.0 - 1.0)"
         },
         {

--- a/addon/rootfs/opt/mindhome/models.py
+++ b/addon/rootfs/opt/mindhome/models.py
@@ -1,3 +1,4 @@
+# MindHome Models v0.6.1 (2026-02-10) - models.py
 """
 MindHome - Database Models
 All persistent data structures for MindHome.
@@ -32,6 +33,7 @@ Base = declarative_base()
 class UserRole(enum.Enum):
     ADMIN = "admin"
     USER = "user"
+    GUEST = "guest"
 
 
 class LearningPhase(enum.Enum):
@@ -645,6 +647,23 @@ class PluginSetting(Base):
 
 
 # ==============================================================================
+# Pattern Settings (v0.6.1)
+# ==============================================================================
+
+class PatternSettings(Base):
+    """Configurable thresholds and settings for pattern detection engine."""
+    __tablename__ = "pattern_settings"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    key = Column(String(100), nullable=False, unique=True)
+    value = Column(Text, nullable=False)
+    description_de = Column(Text, nullable=True)
+    description_en = Column(Text, nullable=True)
+    category = Column(String(50), default="general")  # "general", "thresholds", "anomaly", "decay"
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+
+
+# ==============================================================================
 # Phase 3: Quiet Hours / Rest Periods
 # ==============================================================================
 
@@ -816,6 +835,7 @@ class DataCollection(Base):
     first_record_at = Column(DateTime, nullable=True)
     last_record_at = Column(DateTime, nullable=True)
     storage_size_bytes = Column(Integer, default=0)
+    created_at = Column(DateTime, default=_utcnow)
 
     room = relationship("Room")
     domain = relationship("Domain")
@@ -1316,6 +1336,24 @@ MIGRATIONS = [
             "ALTER TABLE users ADD COLUMN profile_type VARCHAR(20) DEFAULT 'adult'",
             "ALTER TABLE users ADD COLUMN tracking_enabled BOOLEAN DEFAULT 1",
             "ALTER TABLE users ADD COLUMN history_enabled BOOLEAN DEFAULT 1",
+        ]
+    },
+    {
+        "version": 7,
+        "description": "v0.6.1 - Pattern settings, DataCollection.created_at",
+        "sql": [
+            # PatternSettings table
+            """CREATE TABLE IF NOT EXISTS pattern_settings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                key VARCHAR(100) NOT NULL UNIQUE,
+                value TEXT NOT NULL,
+                description_de TEXT,
+                description_en TEXT,
+                category VARCHAR(50) DEFAULT 'general',
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )""",
+            # DataCollection: add created_at
+            "ALTER TABLE data_collection ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP",
         ]
     },
 ]

--- a/addon/rootfs/opt/mindhome/routes/schedules.py
+++ b/addon/rootfs/opt/mindhome/routes/schedules.py
@@ -471,8 +471,8 @@ def api_seed_default_holidays():
             ("Neujahr", "01-01"), ("Heilige Drei Koenige", "01-06"),
             ("Staatsfeiertag", "05-01"), ("Christi Himmelfahrt", "05-29"),
             ("Pfingstmontag", "06-09"), ("Fronleichnam", "06-19"),
-            ("MariÃ¤ Himmelfahrt", "08-15"), ("Nationalfeiertag", "10-26"),
-            ("Allerheiligen", "11-01"), ("MariÃ¤ Empfaengnis", "12-08"),
+            ("Mariä Himmelfahrt", "08-15"), ("Nationalfeiertag", "10-26"),
+            ("Allerheiligen", "11-01"), ("Mariä Empfaengnis", "12-08"),
             ("Christtag", "12-25"), ("Stefanitag", "12-26"),
         ]
         for name, date in defaults:

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,19 +4,32 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.0"
-BUILD = 1
+VERSION = "0.6.1"
+BUILD = 2
 BUILD_DATE = "2026-02-10"
-CODENAME = "Phase 3.5 - Stabilisierung & Refactoring"
+CODENAME = "Phase 3.5 - Hotfix"
 
 # Changelog
+# Build 2: v0.6.1 Hotfix
+#   - PatternSettings (konfigurierbare Schwellenwerte)
+#   - Unified Confidence Decay (Grace 2d, 1%/w, 5%/d)
+#   - Event-Deduplizierung (#15)
+#   - Muster-Duplikat-Erkennung verbessert (#4)
+#   - Mojibake-Fixes in allen Dateien (#31)
+#   - CustomSelect ersetzt native <select> (#9)
+#   - Szenen-Detailansicht (#12)
+#   - Geraete Mobile Card Layout (#23)
+#   - Presence Auto-Detect + Manual-Override (#13/#28)
+#   - DataCollection.created_at Fix
+#   - Query.get() -> Session.get() Migration
+#
 # Build 1: Phase 3.5 - Kompletter Umbau
 #   - Bugs gefixt (duplizierte Methoden, Encoding, Session-Leaks, migration_ok)
-#   - DB Context Manager eingeführt
+#   - DB Context Manager eingefuehrt
 #   - Backend in Flask Blueprints aufgeteilt
 #   - Frontend in React Komponenten aufgeteilt
 #   - Event-Bus + Task-Scheduler erweitert
-#   - Zentrale Versionsverwaltung eingeführt
+#   - Zentrale Versionsverwaltung eingefuehrt
 
 
 def version_string():


### PR DESCRIPTION
Backend:
- Add PatternSettings model + Migration v7 (pattern_settings table, data_collection.created_at)
- Add GUEST to UserRole enum
- Configurable pattern thresholds via PatternSettings (chain_window, min_sequence, min_confidence)
- Unified confidence decay: 2d grace, 1%/week for 14d, then 5%/day
- Improved pattern duplicate detection (trigger_state/action_state for chains, condition/correlated for correlations)
- Event deduplication in state change handler (#15)
- Heatpump sensitivity + person GPS threshold in AnomalyDetector (#30)
- Presence auto-detect + manual-override endpoints (#13/#14/#26/#28)
- Pattern settings API: GET/PUT + preset endpoints (cautious/normal/aggressive) (#25/#32)
- Learning days stats endpoint (#2)
- Fix duplicate seed data in init_db and presence modes (#6/#7)
- Fix DataCollection.collected_at missing column (500 error fix)
- Query.get() -> Session.get() migration
- Remove dead code in presence routes (#35)

Frontend:
- Fix all mojibake across Python and JSX files (#31)
- CustomSelect component replaces all native <select> elements (#9)
- Scene detail view with expandable device states (#12)
- Devices mobile card layout with room/domain filter pills (#23)
- Pattern Settings section in Settings page with learning speed presets (#25/#32/#37)
- Custom badge when pattern settings differ from presets (#37)
- Tab overflow scroll for mobile (#16)
- Remove font-size S/M/L setting (#22)
- Remove persons tab from presence page (#18)
- Settings grid mobile responsive (#19)

Version:
- Bump to v0.6.1 (Build 2) in config.yaml, build.yaml, version.py

https://claude.ai/code/session_01RabQxYgyDF9a61w8LRg6Ln