### PR TITLE
Fix bootloop: Bundle libraries locally, fix translations path

### DIFF
--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -18,6 +18,15 @@ RUN apk del gcc musl-dev python3-dev
 # Copy application files
 COPY rootfs /
 
+# Download frontend libraries locally (avoid CDN dependency at runtime)
+RUN mkdir -p /opt/mindhome/static/frontend/lib \
+    && wget -q -O /opt/mindhome/static/frontend/lib/react.production.min.js \
+       "https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" \
+    && wget -q -O /opt/mindhome/static/frontend/lib/react-dom.production.min.js \
+       "https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" \
+    && wget -q -O /opt/mindhome/static/frontend/lib/babel.min.js \
+       "https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.6/babel.min.js"
+
 # Create data directories
 RUN mkdir -p /data/mindhome/db \
     && mkdir -p /data/mindhome/models \

--- a/addon/rootfs/opt/mindhome/routes/system.py
+++ b/addon/rootfs/opt/mindhome/routes/system.py
@@ -480,7 +480,7 @@ def api_get_translations(lang_code):
     if lang_code not in ("de", "en"):
         return jsonify({"error": "Language not found"}), 404
     import json as json_lib
-    lang_file = os.path.join(os.path.dirname(__file__), "translations", f"{lang_code}.json")
+    lang_file = os.path.join(os.path.dirname(__file__), "..", "translations", f"{lang_code}.json")
     try:
         with open(lang_file, "r", encoding="utf-8") as f:
             return jsonify(json_lib.load(f))

--- a/addon/rootfs/opt/mindhome/static/frontend/index.html
+++ b/addon/rootfs/opt/mindhome/static/frontend/index.html
@@ -875,16 +875,31 @@
         })();
     </script>
 
-    <!-- React -->
+    <!-- React, ReactDOM, Babel (lokal gebündelt, CDN-Fallback) -->
     <script>logStep('React...');</script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"
-            onerror="showError('React konnte nicht geladen werden', 'CDN cdnjs.cloudflare.com ist nicht erreichbar. PrÃ¼fe die Internetverbindung des HA-Servers.')"></script>
+    <script src="lib/react.production.min.js"></script>
+    <script>
+        if (typeof React === 'undefined') {
+            logStep('React lokal nicht gefunden, lade von CDN...');
+            document.write('<scr' + 'ipt src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"><\/scr' + 'ipt>');
+        }
+    </script>
     <script>logStep('ReactDOM...');</script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"
-            onerror="showError('ReactDOM konnte nicht geladen werden', 'CDN cdnjs.cloudflare.com ist nicht erreichbar.')"></script>
+    <script src="lib/react-dom.production.min.js"></script>
+    <script>
+        if (typeof ReactDOM === 'undefined') {
+            logStep('ReactDOM lokal nicht gefunden, lade von CDN...');
+            document.write('<scr' + 'ipt src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"><\/scr' + 'ipt>');
+        }
+    </script>
     <script>logStep('Babel...');</script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.6/babel.min.js"
-            onerror="showError('Babel konnte nicht geladen werden', 'CDN cdnjs.cloudflare.com ist nicht erreichbar.')"></script>
+    <script src="lib/babel.min.js"></script>
+    <script>
+        if (typeof Babel === 'undefined') {
+            logStep('Babel lokal nicht gefunden, lade von CDN...');
+            document.write('<scr' + 'ipt src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.6/babel.min.js"><\/scr' + 'ipt>');
+        }
+    </script>
 
     <script>
         logStep('App wird kompiliert...');


### PR DESCRIPTION
- Bundle React, ReactDOM, and Babel locally during Docker build instead of loading from CDN at runtime. This fixes the "Lade Bibliotheken" bootloop on HA installations without internet access.
- CDN fallback via document.write if local files are missing.
- Fix translations endpoint path: was looking in routes/translations/ instead of the correct ../translations/ directory.

https://claude.ai/code/session_01HTGxqG1ZNXSMvMy6oWRUxb