### PR TITLE
Fix JSX syntax error causing Babel compilation failure (bootloop)

### DIFF
--- a/addon/rootfs/opt/mindhome/static/frontend/app.jsx
+++ b/addon/rootfs/opt/mindhome/static/frontend/app.jsx
@@ -4456,7 +4456,7 @@ const PatternsPage = () => {
                                         <div><span style={{ color: 'var(--text-muted)' }}>Entity:</span> <code style={{ fontSize: 12 }}>{p.pattern_data?.entity_id || p.pattern_data?.action_entity || '–'}</code></div>
                                         <div><span style={{ color: 'var(--text-muted)' }}>{lang === 'de' ? 'Zielzustand' : 'Target'}:</span> <strong>{p.pattern_data?.target_state || p.action_definition?.target_state || '–'}</strong></div>
                                         {p.pattern_data?.avg_hour !== undefined && (
-                                            <div><span style={{ color: 'var(--text-muted)' }}>{lang === 'de' ? 'Uhrzeit' : 'Time'}:</span> <strong>{String(p.pattern_data.avg_hour).padStart(2,'0')}:{String(p.pattern_data.avg_minute||0).padStart(2,'0')}</strong> p.pattern_data.time_window_min || 15}min</div>
+                                            <div><span style={{ color: 'var(--text-muted)' }}>{lang === 'de' ? 'Uhrzeit' : 'Time'}:</span> <strong>{String(p.pattern_data.avg_hour).padStart(2,'0')}:{String(p.pattern_data.avg_minute||0).padStart(2,'0')}</strong> ±{p.pattern_data.time_window_min || 15}min</div>
                                         )}
                                         {p.pattern_data?.weekday_filter && (
                                             <div><span style={{ color: 'var(--text-muted)' }}>{lang === 'de' ? 'Tage' : 'Days'}:</span> {p.pattern_data.weekday_filter === 'weekdays' ? (lang === 'de' ? 'Mo–Fr' : 'Mon–Fri') : p.pattern_data.weekday_filter === 'weekends' ? (lang === 'de' ? 'Sa–So' : 'Sat–Sun') : (lang === 'de' ? 'Alle' : 'All')}</div>


### PR DESCRIPTION
Missing opening brace in JSX expression at line 4459:
  Before: `</strong> p.pattern_data.time_window_min || 15}min`
  After:  `</strong> ±{p.pattern_data.time_window_min || 15}min`

This syntax error prevented Babel from compiling app.jsx, causing the frontend to get stuck at "Lade Bibliotheken" indefinitely.

https://claude.ai/code/session_01HTGxqG1ZNXSMvMy6oWRUxb