### PR TITLE
v0.6.5: Fix bootloop - static file 404, encoding, version bump

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.4"
+version: "0.6.5"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/routes/system.py
+++ b/addon/rootfs/opt/mindhome/routes/system.py
@@ -751,6 +751,9 @@ def serve_frontend(path):
             response.headers["Content-Type"] = "text/javascript; charset=utf-8"
             response.headers["Access-Control-Allow-Origin"] = "*"
         return response
+    # Static assets (js/css/images) must return 404 if missing, not index.html
+    if path and any(path.endswith(ext) for ext in (".js", ".css", ".map", ".png", ".jpg", ".ico", ".svg", ".woff", ".woff2", ".ttf")):
+        return jsonify({"error": "not found"}), 404
     return send_from_directory(os.path.join(current_app.static_folder, "frontend"), "index.html")
 
 

--- a/addon/rootfs/opt/mindhome/static/frontend/app.jsx
+++ b/addon/rootfs/opt/mindhome/static/frontend/app.jsx
@@ -1,6 +1,6 @@
-// MindHome Frontend v0.6.2 (2026-02-10) - app.jsx
+// MindHome Frontend v0.6.5 (2026-02-10) - app.jsx
 // ================================================================
-// MindHome - React Frontend Application v0.6.2
+// MindHome - React Frontend Application v0.6.5
 // ================================================================
 
 const { useState, useEffect, useCallback, createContext, useContext, useRef, useMemo, useReducer } = React;

--- a/addon/rootfs/opt/mindhome/static/frontend/index.html
+++ b/addon/rootfs/opt/mindhome/static/frontend/index.html
@@ -860,7 +860,7 @@
                 showError(
                     'Laden fehlgeschlagen (Timeout)',
                     'Die App konnte nicht innerhalb von 30 Sekunden geladen werden. ' +
-                    'MÃ¶gliche Ursachen: CDN nicht erreichbar, JavaScript-Fehler, oder Netzwerkproblem.\n\n' +
+                    'Mögliche Ursachen: CDN nicht erreichbar, JavaScript-Fehler, oder Netzwerkproblem.\n\n' +
                     'Geladene Schritte: ' + window._loadSteps.join(', ') + '\n' +
                     'Fehler: ' + (window._loadErrors.length ? window._loadErrors.join(', ') : 'keine')
                 );
@@ -905,11 +905,11 @@
         logStep('App wird kompiliert...');
         // Verify libraries loaded
         if (typeof React === 'undefined') {
-            showError('React nicht verfÃ¼gbar', 'Die React-Bibliothek konnte nicht geladen werden. CDN blockiert?');
+            showError('React nicht verfügbar', 'Die React-Bibliothek konnte nicht geladen werden. CDN blockiert?');
         } else if (typeof ReactDOM === 'undefined') {
-            showError('ReactDOM nicht verfÃ¼gbar', 'Die ReactDOM-Bibliothek konnte nicht geladen werden.');
+            showError('ReactDOM nicht verfügbar', 'Die ReactDOM-Bibliothek konnte nicht geladen werden.');
         } else if (typeof Babel === 'undefined') {
-            showError('Babel nicht verfÃ¼gbar', 'Der JSX-Compiler konnte nicht geladen werden.');
+            showError('Babel nicht verfügbar', 'Der JSX-Compiler konnte nicht geladen werden.');
         } else {
             // Manual Babel transformation with full error catching
             var jsxEl = document.getElementById('app-jsx-source');
@@ -921,7 +921,7 @@
                         presets: ['react'],
                         filename: 'app.jsx'
                     });
-                    logStep('Code wird ausgefÃ¼hrt...');
+                    logStep('Code wird ausgeführt...');
                     eval(transformed.code);
                 } catch (e) {
                     var detail = e.message || String(e);
@@ -936,7 +936,7 @@
                     } catch(ex) {}
                 }
             } else {
-                showError('App-Code fehlt', 'Der JSX-Quellcode wurde nicht in die Seite eingebettet. Bitte app.jsx prÃ¼fen.');
+                showError('App-Code fehlt', 'Der JSX-Quellcode wurde nicht in die Seite eingebettet. Bitte app.jsx prüfen.');
             }
         }
     </script>

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,19 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.4"
-BUILD = 5
+VERSION = "0.6.5"
+BUILD = 6
 BUILD_DATE = "2026-02-10"
-CODENAME = "Phase 3.5 - Stabilisierung"
+CODENAME = "Phase 3.5 - Bootloop Fix"
 
 # Changelog
+# Build 6: v0.6.5 Bootloop Fix
+#   - Fix: JSX-Syntaxfehler (fehlende { in Zeile 4459) verhinderte Babel-Kompilierung
+#   - Fix: Frontend-Bibliotheken (React/ReactDOM/Babel) lokal gebündelt statt CDN
+#   - Fix: Translations-Endpoint suchte in falschem Verzeichnis (routes/ statt ../)
+#   - Fix: serve_frontend gab index.html statt 404 für fehlende .js-Dateien zurück
+#   - Fix: Mojibake in index.html Fehlermeldungen (ü/ö/ä)
+#
 # Build 5: v0.6.4 Stabilisierung
 #   - Mustererkennung: Confidence Decay 1x/Tag, Cap 10%/Tag, Sequenz-Formel, Korrelation erweitert
 #   - Mustererkennung: Motion-Debounce, Merge-Zeitfenster, Time-Parsing, Context-Tags Update


### PR DESCRIPTION
- serve_frontend: Return proper 404 for missing .js/.css files instead of serving index.html as JavaScript (caused broken library loading)
- Fix mojibake in index.html error messages (ü/ö/ä)
- Bump version to 0.6.5 (Build 6) for HA update detection

https://claude.ai/code/session_01HTGxqG1ZNXSMvMy6oWRUxb