### PR TITLE
v0.6.8 (Build 9): Fix Ladescreen — robuster lib-Fallback + 404 Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <strong>v0.6.7</strong> · Phase 3.5 – Stabilisierung & Refactoring<br>
+  <strong>v0.6.8</strong> · Phase 3.5 – Stabilisierung & Refactoring<br>
   ~130 Features · 14 Domain-Plugins · 100% lokal
 </p>
 
@@ -167,7 +167,7 @@ Alle Daten werden **ausschließlich lokal** gespeichert. MindHome sendet keine D
 # MindHome — Your Home Thinks Ahead!
 
 <p align="center">
-  <strong>v0.6.7</strong> · Phase 3.5 – Stabilization & Refactoring<br>
+  <strong>v0.6.8</strong> · Phase 3.5 – Stabilization & Refactoring<br>
   ~130 Features · 14 Domain Plugins · 100% local
 </p>
 

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.6.7"
+  org.opencontainers.image.version: "0.6.8"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.7"
+version: "0.6.8"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/routes/system.py
+++ b/addon/rootfs/opt/mindhome/routes/system.py
@@ -753,7 +753,7 @@ def serve_frontend(path):
         return response
     # Static assets (js/css/images) must return 404 if missing, not index.html
     if path and any(path.endswith(ext) for ext in (".js", ".css", ".map", ".png", ".jpg", ".ico", ".svg", ".woff", ".woff2", ".ttf")):
-        return jsonify({"error": "not found"}), 404
+        return "", 404
     return send_from_directory(os.path.join(current_app.static_folder, "frontend"), "index.html")
 
 

--- a/addon/rootfs/opt/mindhome/static/frontend/index.html
+++ b/addon/rootfs/opt/mindhome/static/frontend/index.html
@@ -883,26 +883,29 @@
 
     <!-- React, ReactDOM, Babel (lokal gebündelt, CDN-Fallback) -->
     <script>logStep('React...');</script>
-    <script src="lib/react.production.min.js"></script>
+    <script src="lib/react.production.min.js"
+            onerror="logStep('React lokal nicht gefunden, lade CDN...'); var s=document.createElement('script'); s.src='https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js'; s.onerror=function(){showError('React nicht ladbar','Weder lokal noch CDN erreichbar.')}; document.head.appendChild(s);"></script>
     <script>
         if (typeof React === 'undefined') {
-            logStep('React lokal nicht gefunden, lade von CDN...');
+            logStep('React CDN Fallback...');
             document.write('<scr' + 'ipt src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"><\/scr' + 'ipt>');
         }
     </script>
     <script>logStep('ReactDOM...');</script>
-    <script src="lib/react-dom.production.min.js"></script>
+    <script src="lib/react-dom.production.min.js"
+            onerror="logStep('ReactDOM lokal nicht gefunden, lade CDN...'); var s=document.createElement('script'); s.src='https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js'; s.onerror=function(){showError('ReactDOM nicht ladbar','Weder lokal noch CDN erreichbar.')}; document.head.appendChild(s);"></script>
     <script>
         if (typeof ReactDOM === 'undefined') {
-            logStep('ReactDOM lokal nicht gefunden, lade von CDN...');
+            logStep('ReactDOM CDN Fallback...');
             document.write('<scr' + 'ipt src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"><\/scr' + 'ipt>');
         }
     </script>
     <script>logStep('Babel...');</script>
-    <script src="lib/babel.min.js"></script>
+    <script src="lib/babel.min.js"
+            onerror="logStep('Babel lokal nicht gefunden, lade CDN...'); var s=document.createElement('script'); s.src='https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.6/babel.min.js'; s.onerror=function(){showError('Babel nicht ladbar','Weder lokal noch CDN erreichbar.')}; document.head.appendChild(s);"></script>
     <script>
         if (typeof Babel === 'undefined') {
-            logStep('Babel lokal nicht gefunden, lade von CDN...');
+            logStep('Babel CDN Fallback...');
             document.write('<scr' + 'ipt src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.6/babel.min.js"><\/scr' + 'ipt>');
         }
     </script>

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,16 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.7"
-BUILD = 8
+VERSION = "0.6.8"
+BUILD = 9
 BUILD_DATE = "2026-02-10"
 CODENAME = "Phase 3.5 - Bootloop Fix"
 
 # Changelog
+# Build 9: v0.6.8 Bugfix
+#   - Fix Ladescreen: onerror-Handler fuer lokale lib-Dateien (CDN-Fallback)
+#   - Fix 404 fuer fehlende .js-Dateien: leerer Body statt JSON (Browser-kompatibel)
+#
 # Build 8: v0.6.7 Bugfix
 #   - Fix Bootloop: React/ReactDOM/Babel lokal gebundelt (Docker Build)
 #   - CDN-Fallback falls lokale Libs fehlen


### PR DESCRIPTION
- onerror-Handler auf lokale lib-Script-Tags: Bei 404 sofort CDN-Fallback
- 404 fuer fehlende .js gibt leeren Body statt JSON (verhindert Syntax-Error)
- Doppelter Fallback: onerror + typeof-Check + document.write

https://claude.ai/code/session_01VxKS33npYkFdTYT9nqBcjm