### PR TITLE
v0.6.9 (Build 10): Debug Ladescreen — Cache-Control + Error-Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <strong>v0.6.8</strong> · Phase 3.5 – Stabilisierung & Refactoring<br>
+  <strong>v0.6.9</strong> · Phase 3.5 – Stabilisierung & Refactoring<br>
   ~130 Features · 14 Domain-Plugins · 100% lokal
 </p>
 
@@ -167,7 +167,7 @@ Alle Daten werden **ausschließlich lokal** gespeichert. MindHome sendet keine D
 # MindHome — Your Home Thinks Ahead!
 
 <p align="center">
-  <strong>v0.6.8</strong> · Phase 3.5 – Stabilization & Refactoring<br>
+  <strong>v0.6.9</strong> · Phase 3.5 – Stabilization & Refactoring<br>
   ~130 Features · 14 Domain Plugins · 100% local
 </p>
 

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.6.8"
+  org.opencontainers.image.version: "0.6.9"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.8"
+version: "0.6.9"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/routes/system.py
+++ b/addon/rootfs/opt/mindhome/routes/system.py
@@ -707,7 +707,11 @@ def serve_index():
             # Fallback: insert before </body>
             html = html.replace('</body>', jsx_block + '\n</body>')
 
-        return html, 200, {"Content-Type": "text/html; charset=utf-8"}
+        return html, 200, {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+        }
     except FileNotFoundError as e:
         logger.error(f"Frontend file not found: {e}")
         return f"<h1>Frontend Error</h1><p>File not found: {e}</p>", 500

--- a/addon/rootfs/opt/mindhome/static/frontend/index.html
+++ b/addon/rootfs/opt/mindhome/static/frontend/index.html
@@ -912,40 +912,48 @@
 
     <script>
         logStep('App wird kompiliert...');
-        // Verify libraries loaded
+
+        function reportError(msg, src) {
+            try {
+                fetch((window._apiBase || '') + '/api/system/frontend-error', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({error: msg, source: src || 'unknown'})
+                });
+            } catch(ex) {}
+        }
+
         if (typeof React === 'undefined') {
-            showError('React nicht verfügbar', 'Die React-Bibliothek konnte nicht geladen werden. CDN blockiert?');
+            showError('React nicht verfuegbar', 'React konnte nicht geladen werden.');
+            reportError('React undefined after all load attempts', 'lib-check');
         } else if (typeof ReactDOM === 'undefined') {
-            showError('ReactDOM nicht verfügbar', 'Die ReactDOM-Bibliothek konnte nicht geladen werden.');
+            showError('ReactDOM nicht verfuegbar', 'ReactDOM konnte nicht geladen werden.');
+            reportError('ReactDOM undefined', 'lib-check');
         } else if (typeof Babel === 'undefined') {
-            showError('Babel nicht verfügbar', 'Der JSX-Compiler konnte nicht geladen werden.');
+            showError('Babel nicht verfuegbar', 'JSX-Compiler konnte nicht geladen werden.');
+            reportError('Babel undefined', 'lib-check');
         } else {
-            // Manual Babel transformation with full error catching
             var jsxEl = document.getElementById('app-jsx-source');
-            if (jsxEl) {
+            if (!jsxEl) {
+                showError('App-Code fehlt', 'JSX-Quellcode nicht eingebettet.');
+                reportError('app-jsx-source element not found', 'jsx-inject');
+            } else {
                 try {
                     var jsxCode = jsxEl.textContent;
                     logStep('Babel transformiert ' + Math.round(jsxCode.length/1024) + 'KB JSX...');
+                    var t0 = Date.now();
                     var transformed = Babel.transform(jsxCode, {
                         presets: ['react'],
                         filename: 'app.jsx'
                     });
-                    logStep('Code wird ausgeführt...');
+                    logStep('Kompiliert in ' + ((Date.now()-t0)/1000).toFixed(1) + 's, starte App...');
                     eval(transformed.code);
                 } catch (e) {
                     var detail = e.message || String(e);
-                    if (e.loc) detail += '\n\nZeile: ' + e.loc.line + ', Spalte: ' + e.loc.column;
+                    if (e.loc) detail += ' (Zeile: ' + e.loc.line + ', Spalte: ' + e.loc.column + ')';
                     showError('JSX Fehler', detail);
-                    try {
-                        fetch((window._apiBase || '') + '/api/system/frontend-error', {
-                            method: 'POST',
-                            headers: {'Content-Type': 'application/json'},
-                            body: JSON.stringify({error: detail, source: 'babel-transform'})
-                        });
-                    } catch(ex) {}
+                    reportError(detail, 'babel-transform');
                 }
-            } else {
-                showError('App-Code fehlt', 'Der JSX-Quellcode wurde nicht in die Seite eingebettet. Bitte app.jsx prüfen.');
             }
         }
     </script>

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,18 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.8"
-BUILD = 9
+VERSION = "0.6.9"
+BUILD = 10
 BUILD_DATE = "2026-02-10"
 CODENAME = "Phase 3.5 - Bootloop Fix"
 
 # Changelog
+# Build 10: v0.6.9 Debug
+#   - Cache-Control no-cache auf serve_index (kein Browser-Caching)
+#   - Besseres Error-Reporting: reportError() sendet alle Fehler ans Backend
+#   - Babel Kompilierzeit wird angezeigt
+#   - Mojibake in Fehlermeldungen entfernt (ue statt ü)
+#
 # Build 9: v0.6.8 Bugfix
 #   - Fix Ladescreen: onerror-Handler fuer lokale lib-Dateien (CDN-Fallback)
 #   - Fix 404 fuer fehlende .js-Dateien: leerer Body statt JSON (Browser-kompatibel)


### PR DESCRIPTION
- Cache-Control: no-cache auf serve_index (verhindert Browser-Caching)
- reportError() sendet alle Frontend-Fehler ans Backend-Log
- Babel Kompilierzeit wird im Ladescreen angezeigt
- Mojibake in Fehlermeldungen entfernt

https://claude.ai/code/session_01VxKS33npYkFdTYT9nqBcjm