### PR TITLE
v0.6.10 (Build 11): Debug-Beacon vor Babel-Kompilierung

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <strong>v0.6.9</strong> · Phase 3.5 – Stabilisierung & Refactoring<br>
+  <strong>v0.6.10</strong> · Phase 3.5 – Stabilisierung & Refactoring<br>
   ~130 Features · 14 Domain-Plugins · 100% lokal
 </p>
 
@@ -167,7 +167,7 @@ Alle Daten werden **ausschließlich lokal** gespeichert. MindHome sendet keine D
 # MindHome — Your Home Thinks Ahead!
 
 <p align="center">
-  <strong>v0.6.9</strong> · Phase 3.5 – Stabilization & Refactoring<br>
+  <strong>v0.6.10</strong> · Phase 3.5 – Stabilization & Refactoring<br>
   ~130 Features · 14 Domain Plugins · 100% local
 </p>
 

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.6.9"
+  org.opencontainers.image.version: "0.6.10"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.9"
+version: "0.6.10"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/static/frontend/index.html
+++ b/addon/rootfs/opt/mindhome/static/frontend/index.html
@@ -911,6 +911,16 @@
     </script>
 
     <script>
+        // Debug beacon: this POST tells us the code reached this point
+        fetch((window._apiBase || '') + '/api/system/frontend-error', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                error: 'DEBUG: Babel start. React=' + (typeof React) + ' ReactDOM=' + (typeof ReactDOM) + ' Babel=' + (typeof Babel) + ' jsx-source=' + (!!document.getElementById('app-jsx-source')),
+                source: 'debug-beacon'
+            })
+        }).catch(function(){});
+
         logStep('App wird kompiliert...');
 
         function reportError(msg, src) {

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,15 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.9"
-BUILD = 10
+VERSION = "0.6.10"
+BUILD = 11
 BUILD_DATE = "2026-02-10"
 CODENAME = "Phase 3.5 - Bootloop Fix"
 
 # Changelog
+# Build 11: v0.6.10 Debug
+#   - Debug-Beacon POST vor Babel-Kompilierung (zeigt ob Code dort ankommt)
+#
 # Build 10: v0.6.9 Debug
 #   - Cache-Control no-cache auf serve_index (kein Browser-Caching)
 #   - Besseres Error-Reporting: reportError() sendet alle Fehler ans Backend


### PR DESCRIPTION
- POST an /api/system/frontend-error mit Debug-Info direkt vor Babel.transform
- Zeigt ob React/ReactDOM/Babel geladen und jsx-source vorhanden

https://claude.ai/code/session_01VxKS33npYkFdTYT9nqBcjm