### PR TITLE
v0.6.16 (Build 17): UI-Fixes — Schicht/Geraete/Domains/Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <strong>v0.6.15</strong> · Phase 3.5 – Stabilisierung & Refactoring<br>
+  <strong>v0.6.16</strong> · Phase 3.5 – Stabilisierung & Refactoring<br>
   ~130 Features · 14 Domain-Plugins · 100% lokal
 </p>
 
@@ -167,7 +167,7 @@ Alle Daten werden **ausschließlich lokal** gespeichert. MindHome sendet keine D
 # MindHome — Your Home Thinks Ahead!
 
 <p align="center">
-  <strong>v0.6.15</strong> · Phase 3.5 – Stabilization & Refactoring<br>
+  <strong>v0.6.16</strong> · Phase 3.5 – Stabilization & Refactoring<br>
   ~130 Features · 14 Domain Plugins · 100% local
 </p>
 

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.6.15"
+  org.opencontainers.image.version: "0.6.16"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.15"
+version: "0.6.16"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/static/frontend/index.html
+++ b/addon/rootfs/opt/mindhome/static/frontend/index.html
@@ -378,8 +378,7 @@
         }
 
         .stat-card {
-            background: var(--bg-card);
-            border: 1px solid var(--border);
+            background: var(--bg-tertiary);
             border-radius: var(--radius-md);
             padding: 20px;
             display: flex;

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,18 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.15"
-BUILD = 16
+VERSION = "0.6.16"
+BUILD = 17
 BUILD_DATE = "2026-02-11"
 CODENAME = "Phase 3.5 - Bugfix"
 
 # Changelog
+# Build 17: v0.6.16 UI-Fixes
+#   - Fix Schichttypen: Person-Dropdown (users→persons), Edit-Modal, Date-Grid
+#   - Fix Geraete: Tabelle fixed-layout, Entity-ID truncate, overflow-x scroll
+#   - Fix Domains: Trennstrich zwischen Steuerung/Sensoren, Custom-Domain Info
+#   - Fix Dashboard: stat-card bg-tertiary (einheitlich mit Domains/Lernfortschritt)
+#
 # Build 16: v0.6.15 Refactoring
 #   - ml/ Verzeichnis entfernt — alle Imports auf Root-Module umgestellt
 #   - Root automation_engine.py + pattern_engine.py werden jetzt direkt verwendet


### PR DESCRIPTION
- Schichttypen: Person-Dropdown gefixt (users→persons), Edit-Modal
  + Bearbeiten-Button hinzugefuegt, Date-Felder Grid statt Flex
- Geraete: Tabelle fixed-layout + overflow-x scroll, Entity-ID truncate
- Domains: Trennstrich zwischen Steuerung- und Sensor-Badges, Custom-Domains zeigen "X Geraete zugewiesen" wenn keine Capabilities
- Dashboard: stat-card benutzt bg-tertiary (einheitlich mit Domains)

https://claude.ai/code/session_01VxKS33npYkFdTYT9nqBcjm