### PR TITLE
fix: Increase rate limit and remove redundant settings PUTs on page load

### DIFF
--- a/addon/rootfs/opt/mindhome/helpers.py
+++ b/addon/rootfs/opt/mindhome/helpers.py
@@ -69,7 +69,7 @@ def utc_iso(dt):
 _rate_limit_data = defaultdict(list)
 _rate_limit_lock = __import__('threading').Lock()
 _RATE_LIMIT_WINDOW = 60
-_RATE_LIMIT_MAX = 120
+_RATE_LIMIT_MAX = 300
 
 
 def rate_limit_check(ip):

--- a/addon/rootfs/opt/mindhome/static/frontend/app.jsx
+++ b/addon/rootfs/opt/mindhome/static/frontend/app.jsx
@@ -6718,21 +6718,21 @@ const App = () => {
         return () => clearInterval(interval);
     }, []);
 
-    // Apply theme
+    // Apply theme (only PUT on actual user change, not on initial load)
     useEffect(() => {
         document.documentElement.setAttribute('data-theme', theme);
         if (settingsLoaded) api.put('system/settings/theme', { value: theme });
-    }, [theme, settingsLoaded]);
+    }, [theme]);
 
-    // Save viewMode
+    // Save viewMode (only PUT on actual user change)
     useEffect(() => {
         if (settingsLoaded) api.put('system/settings/view_mode', { value: viewMode });
-    }, [viewMode, settingsLoaded]);
+    }, [viewMode]);
 
-    // Save language
+    // Save language (only PUT on actual user change)
     useEffect(() => {
         if (settingsLoaded) api.put('system/settings/language', { value: lang });
-    }, [lang, settingsLoaded]);
+    }, [lang]);
 
     const toggleDomain = async (domainId) => {
         const result = await api.post(`domains/${domainId}/toggle`);


### PR DESCRIPTION
The frontend makes ~19 API requests per page load (init + refreshData + dashboard + notifications). With a rate limit of 120/60s, just 6-7 page refreshes in a minute exhausted the limit, causing all subsequent requests to fail with 429.

Changes:
- Increase rate limit from 120 to 300 requests per 60s window
- Remove settingsLoaded from useEffect dependency arrays for theme, viewMode, and language saves. Previously, when settingsLoaded changed from false to true after 500ms, all three PUTs fired redundantly (writing back the same values just loaded from the server). Now PUTs only fire when the user actually changes a setting.

https://claude.ai/code/session_01AX5vEpvzf6NvXQEiZx3sTz