### PR TITLE
fix: Schicht-Kalender Datum off-by-one + alte Events loeschen (v0.6.23)

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.22"
+version: "0.6.23"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/routes/schedules.py
+++ b/addon/rootfs/opt/mindhome/routes/schedules.py
@@ -556,7 +556,9 @@ def api_export_ical():
 
     session = get_db()
     try:
-        now = datetime.now(timezone.utc)
+        from helpers import get_ha_timezone
+        local_tz = get_ha_timezone()
+        now = datetime.now(local_tz)
         lines = [
             "BEGIN:VCALENDAR",
             "VERSION:2.0",
@@ -639,7 +641,7 @@ def api_export_ical():
             if not pattern or not rotation_start:
                 continue
             try:
-                start_dt = datetime.strptime(rotation_start, "%Y-%m-%d")
+                start_dt = datetime.strptime(rotation_start, "%Y-%m-%d").replace(tzinfo=local_tz)
             except (ValueError, TypeError):
                 continue
             # Generate shift events for configurable days from now
@@ -648,7 +650,7 @@ def api_export_ical():
             user_name = users.get(sched.user_id, "")
             for day_offset in range(export_days):
                 day = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=day_offset)
-                diff = (day - start_dt.replace(tzinfo=timezone.utc)).days
+                diff = (day - start_dt).days
                 if diff < 0:
                     continue
                 idx = diff % len(pattern)

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,18 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.22"
-BUILD = 23
+VERSION = "0.6.23"
+BUILD = 24
 BUILD_DATE = "2026-02-13"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 
 # Changelog
+# Build 24: v0.6.23 Fix Schicht-Kalender Datum off-by-one + alte Events loeschen
+#   - Fix: Schicht-Startdatum wurde 1 Tag zu frueh in Kalender geschrieben (UTC vs Lokalzeit)
+#   - Fix: Kalender-Sync nutzt jetzt HA-Timezone statt UTC fuer Datumsberechnung
+#   - Fix: Alte Kalender-Eintraege werden jetzt bei Aenderung automatisch geloescht
+#   - Fix: iCal Export hatte gleichen Timezone-Bug (ebenfalls gefixt)
+#
 # Build 23: v0.6.22 Fix Anwesenheitserkennung (7 Bugs)
 #   - Fix: get_current_mode() ignorierte Logs ohne mode_id - mode_name Fallback + Backfill
 #   - Fix: auto_detect Endpoint schrieb kein mode_id in PresenceLog


### PR DESCRIPTION
- Datum-Bug: Kalender-Sync nutzte UTC statt HA-Lokalzeit, dadurch wurde das Startdatum 1 Tag zu frueh berechnet (z.B. 16.02 → 15.02)
- Alte Events: Bei Schichtplan-Aenderung werden obsolete Kalender-Eintraege jetzt automatisch aus dem HA-Kalender geloescht
- iCal Export: Gleicher Timezone-Bug gefixt

https://claude.ai/code/session_01AX5vEpvzf6NvXQEiZx3sTz