### PR TITLE
fix: Addon config.yaml Version auf 0.6.27 + Domain Icon-Format korrig…

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.26"
+version: "0.6.27"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/static/frontend/app.jsx
+++ b/addon/rootfs/opt/mindhome/static/frontend/app.jsx
@@ -1308,7 +1308,7 @@ const DomainsPage = () => {
                                         background: domain.is_enabled ? 'var(--accent-primary-dim)' : 'var(--bg-tertiary)',
                                         color: domain.is_enabled ? 'var(--accent-primary)' : 'var(--text-muted)'
                                     }}>
-                                        <span className={`mdi ${domain.icon}`} />
+                                        <span className={`mdi ${(domain.icon || 'mdi-puzzle').replace('mdi:', 'mdi-')}`} />
                                     </div>
                                     <div>
                                         <div className="card-title">{domain.display_name}</div>


### PR DESCRIPTION
…iert

- config.yaml version 0.6.26 → 0.6.27 (HA zeigt sonst kein Update an)
- Domain-Karten: icon replace mdi: → mdi- (wie bei Raeumen)

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp