### PR TITLE
feat: Raum-Domain-Modus - Hierarchische Steuerung pro Raum

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.29"
+version: "0.6.30"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/models.py
+++ b/addon/rootfs/opt/mindhome/models.py
@@ -144,6 +144,7 @@ class RoomDomainState(Base):
     phase_started_at = Column(DateTime, default=_utcnow)
     confidence_score = Column(Float, default=0.0)
     is_paused = Column(Boolean, default=False)
+    mode = Column(String(20), default="global")  # global, suggest, auto, off
 
     room = relationship("Room", back_populates="domain_states")
     domain = relationship("Domain")
@@ -1354,6 +1355,13 @@ MIGRATIONS = [
             )""",
             # DataCollection: add created_at
             "ALTER TABLE data_collection ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP",
+        ]
+    },
+    {
+        "version": 8,
+        "description": "v0.6.30 - Room-level domain mode override",
+        "sql": [
+            "ALTER TABLE room_domain_states ADD COLUMN mode VARCHAR(20) DEFAULT 'global'",
         ]
     },
 ]

--- a/addon/rootfs/opt/mindhome/routes/automation.py
+++ b/addon/rootfs/opt/mindhome/routes/automation.py
@@ -205,6 +205,27 @@ def api_set_phase(room_id, domain_id):
 
 
 
+@automation_bp.route("/api/phases/<int:room_id>/<int:domain_id>/mode", methods=["PUT"])
+def api_set_room_domain_mode(room_id, domain_id):
+    """Set the mode override for a domain in a specific room."""
+    data = request.json or {}
+    mode = data.get("mode", "global")
+    if mode not in ("global", "suggest", "auto", "off"):
+        return jsonify({"error": "Invalid mode. Use: global, suggest, auto, off"}), 400
+
+    session = get_db()
+    try:
+        ds = session.query(RoomDomainState).filter_by(room_id=room_id, domain_id=domain_id).first()
+        if not ds:
+            return jsonify({"error": "Room/Domain combination not found"}), 404
+        ds.mode = mode
+        session.commit()
+        return jsonify({"room_id": room_id, "domain_id": domain_id, "mode": mode})
+    finally:
+        session.close()
+
+
+
 @automation_bp.route("/api/automation/anomalies", methods=["GET"])
 def api_get_anomalies():
     """Get recent anomalies."""

--- a/addon/rootfs/opt/mindhome/routes/rooms.py
+++ b/addon/rootfs/opt/mindhome/routes/rooms.py
@@ -94,7 +94,8 @@ def api_get_rooms():
                     "domain_id": ds.domain_id,
                     "learning_phase": ds.learning_phase.value,
                     "confidence_score": ds.confidence_score,
-                    "is_paused": ds.is_paused
+                    "is_paused": ds.is_paused,
+                    "mode": getattr(ds, 'mode', 'global') or 'global'
                 } for ds in r.domain_states if ds.domain_id in device_domain_ids]
             })
         return jsonify(result)

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,17 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.29"
-BUILD = 30
+VERSION = "0.6.30"
+BUILD = 31
 BUILD_DATE = "2026-02-13"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 
 # Changelog
+# Build 31: v0.6.30 Raum-Domain-Modus (Hierarchie)
+#   - Neues mode-Feld in RoomDomainState (global/suggest/auto/off)
+#   - API: PUT /api/phases/{room}/{domain}/mode
+#   - Frontend: Modus-Dropdown pro Domain auf Raum-Karte
+#   - Hierarchie: Global aus = immer aus, Raum kann verfeinern
 # Build 29: v0.6.28 Domain-Karten Layout verbessert
 #   - Control-Badges und Pattern-Badges als getrennte Gruppen mit Trennlinie
 #   - Domain-Icons: mdi: zu mdi- Konvertierung korrigiert


### PR DESCRIPTION
- DB: mode-Spalte in RoomDomainState (global/suggest/auto/off)
- Migration v8: ALTER TABLE room_domain_states ADD COLUMN mode
- API: PUT /api/phases/{room}/{domain}/mode
- Frontend: Modus-Dropdown (Global/Vorschlagen/Automatisch/Aus) pro Domain auf jeder Raum-Karte
- Domain global aus = immer aus, Raum kann nur verfeinern
- Zeile wird gedimmt wenn Modus "Aus" oder Domain global deaktiviert

v0.6.30 (Build 31)

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp