### PR TITLE
fix: Auto-Sync RoomDomainState für bestehende Räume

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.30"
+version: "0.6.31"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,8 +4,8 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.30"
-BUILD = 31
+VERSION = "0.6.31"
+BUILD = 32
 BUILD_DATE = "2026-02-13"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 


### PR DESCRIPTION
Beim Laden der Räume-Seite werden automatisch fehlende RoomDomainState-Einträge für Räume erstellt, die Geräte haben aber noch keinen domain_state. So erscheinen Lernphasen und Modus-Dropdown auch bei bestehenden (vorher importierten) Räumen.

v0.6.31 (Build 32)

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp