### PR TITLE
debug: Calendar 400 - Response-Body Logging hinzugefügt

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.33"
+version: "0.6.34"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/ha_connection.py
+++ b/addon/rootfs/opt/mindhome/ha_connection.py
@@ -79,7 +79,12 @@ class HAConnection:
                 status_code = e.response.status_code if e.response is not None else 0
                 # Don't retry client errors (4xx) — the request is wrong, retrying won't help
                 if 400 <= status_code < 500:
-                    logger.error(f"HA API client error for {endpoint}: {e}")
+                    body = ""
+                    try:
+                        body = e.response.text[:500] if e.response is not None else ""
+                    except Exception:
+                        pass
+                    logger.error(f"HA API client error for {endpoint}: {e} | payload={data} | response={body}")
                     self._is_online = True
                     return None
                 if attempt < attempts - 1:
@@ -211,6 +216,7 @@ class HAConnection:
         data = {"summary": summary}
         # Support both all-day (date) and timed (dateTime) events
         if "T" in start:
+            # HA expects in_type: "datetime" with proper key names
             data["start_date_time"] = start
             data["end_date_time"] = end
         else:
@@ -220,7 +226,9 @@ class HAConnection:
             data["description"] = description
         if location:
             data["location"] = location
+        logger.debug(f"Calendar create_event: entity={entity_id} data={data}")
         return self.call_service("calendar", "create_event", data, entity_id=entity_id)
+
 
     def delete_calendar_event(self, entity_id, uid):
         """Delete event from a HA calendar entity via calendar.delete_event service."""

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,8 +4,8 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.33"
-BUILD = 34
+VERSION = "0.6.34"
+BUILD = 35
 BUILD_DATE = "2026-02-13"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 


### PR DESCRIPTION
- _api_request loggt jetzt bei 4xx Fehlern das gesendete Payload UND den Response-Body von HA (max 500 Zeichen)
- Damit sehen wir genau was HA bei calendar/create_event und calendar/delete_event ablehnt (Schema-Fehler, Format, etc.)

v0.6.34 (Build 35)

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp