### PR TITLE
fix: sequence patterns nur mit steuerbaren Entities als Action

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.41"
+version: "0.6.42"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/pattern_engine.py
+++ b/addon/rootfs/opt/mindhome/pattern_engine.py
@@ -1087,6 +1087,13 @@ class PatternDetector:
     # as automation triggers or actions in sequence patterns
     _SENSOR_ONLY_DOMAINS = frozenset({"sensor", "weather", "number"})
 
+    # HA domains that can actually be controlled (valid as action side of a pattern)
+    _ACTIONABLE_DOMAINS = frozenset({
+        "light", "switch", "cover", "climate", "fan", "media_player",
+        "lock", "vacuum", "humidifier", "water_heater", "valve",
+        "input_boolean", "input_number", "input_select", "scene", "script",
+    })
+
     def _is_same_domain_sensor_pair(self, entity_a, entity_b):
         """Check if both entities are sensor-only domains (no actionable patterns)."""
         domain_a = entity_a.split(".")[0]
@@ -1115,6 +1122,9 @@ class PatternDetector:
                     continue
                 # Skip sensor→sensor pairs (numeric correlations, not actionable)
                 if self._is_same_domain_sensor_pair(ev_a.entity_id, ev_b.entity_id):
+                    continue
+                # Action side must be controllable (sensor as action makes no sense)
+                if ev_b.entity_id.split(".")[0] not in self._ACTIONABLE_DOMAINS:
                     continue
 
                 key = (

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,8 +4,8 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.41"
-BUILD = 42
+VERSION = "0.6.42"
+BUILD = 43
 BUILD_DATE = "2026-02-13"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 


### PR DESCRIPTION
Bisher wurden alle Entity-Paare als Sequence-Pattern erkannt, auch unsinnige wie light→sensor oder switch→binary_sensor. Ein Sensor kann nicht "geschaltet" werden - solche Patterns sind nicht automatisierbar.

Neuer Filter: Action-Seite (B) muss eine steuerbare Domain sein (light, switch, cover, climate, fan, media_player, lock, vacuum, humidifier, water_heater, valve, input_boolean, input_number, input_select, scene, script).

Trigger-Seite (A) bleibt uneingeschränkt - "Tür-Sensor auf → Licht an" ist weiterhin ein valides Pattern.

Erwartung: 321 Patterns drastisch reduziert.

v0.6.42 (Build 43)

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp