### PR TITLE
feat: 3 neue Domains + fix Domain-Delete FOREIGN KEY Fehler

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.42"
+version: "0.6.43"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/app.py
+++ b/addon/rootfs/opt/mindhome/app.py
@@ -76,6 +76,14 @@ init_database(engine)
 run_migrations(engine)
 init_db(engine)
 
+# Ensure new system domains exist in DB (for upgrades)
+try:
+    from init_db import create_default_domains
+    with get_db_session() as session:
+        create_default_domains(session)
+except Exception as e:
+    logger.warning(f"Domain seed check: {e}")
+
 # Fix: Auto-set is_controllable=False for sensor-type entities
 try:
     with get_db_session() as session:
@@ -154,13 +162,6 @@ DOMAIN_PLUGINS = {
         "pattern_features": ["time_of_day", "presence"],
         "icon": "mdi:lock",
     },
-    "vacuum": {
-        "ha_domain": "vacuum",
-        "attributes": ["battery_level", "status"],
-        "controls": ["start", "stop", "return_to_base"],
-        "pattern_features": ["schedule", "presence"],
-        "icon": "mdi:robot-vacuum",
-    },
     "fan": {
         "ha_domain": "fan",
         "attributes": ["percentage", "preset_mode"],
@@ -205,6 +206,29 @@ DOMAIN_PLUGINS = {
         "controls": [],
         "pattern_features": ["condition_correlation"],
         "icon": "mdi:weather-cloudy",
+    },
+    "bed_occupancy": {
+        "ha_domain": "binary_sensor",
+        "device_class": "occupancy",
+        "attributes": ["device_class"],
+        "controls": [],
+        "pattern_features": ["sleep_start", "sleep_end", "duration"],
+        "icon": "mdi:bed",
+    },
+    "seat_occupancy": {
+        "ha_domain": "binary_sensor",
+        "device_class": "occupancy",
+        "attributes": ["device_class"],
+        "controls": [],
+        "pattern_features": ["occupied_duration", "frequency"],
+        "icon": "mdi:seat",
+    },
+    "vacuum": {
+        "ha_domain": "vacuum",
+        "attributes": ["battery_level", "status"],
+        "controls": ["start", "stop", "return_to_base"],
+        "pattern_features": ["schedule", "presence"],
+        "icon": "mdi:robot-vacuum",
     },
 }
 

--- a/addon/rootfs/opt/mindhome/domains/__init__.py
+++ b/addon/rootfs/opt/mindhome/domains/__init__.py
@@ -21,6 +21,9 @@ from .switch import SwitchDomain
 from .air_quality import AirQualityDomain
 from .ventilation import VentilationDomain
 from .solar import SolarDomain
+from .bed_occupancy import BedOccupancyDomain
+from .seat_occupancy import SeatOccupancyDomain
+from .vacuum import VacuumDomain
 
 logger = logging.getLogger("mindhome.domain_manager")
 
@@ -40,6 +43,9 @@ DOMAIN_REGISTRY: Dict[str, type] = {
     "air_quality": AirQualityDomain,
     "ventilation": VentilationDomain,
     "solar": SolarDomain,
+    "bed_occupancy": BedOccupancyDomain,
+    "seat_occupancy": SeatOccupancyDomain,
+    "vacuum": VacuumDomain,
 }
 
 

--- a/addon/rootfs/opt/mindhome/domains/bed_occupancy.py
+++ b/addon/rootfs/opt/mindhome/domains/bed_occupancy.py
@@ -1,0 +1,40 @@
+"""MindHome - Bed Occupancy Domain Plugin (Phase 3)"""
+from .base import DomainPlugin
+
+
+class BedOccupancyDomain(DomainPlugin):
+    DOMAIN_NAME = "bed_occupancy"
+    HA_DOMAINS = ["binary_sensor"]
+    DEVICE_CLASSES = ["occupancy"]
+    DEFAULT_SETTINGS = {"enabled": "true", "mode": "suggest"}
+
+    def on_start(self):
+        self.logger.info("Bed occupancy domain ready")
+
+    def on_stop(self):
+        pass
+
+    def on_state_change(self, entity_id, old_state, new_state, context=None):
+        if not self.is_entity_tracked(entity_id):
+            return
+        if isinstance(new_state, dict):
+            state = new_state.get("state", "")
+        else:
+            state = new_state
+        self.logger.debug(f"Bed occupancy {entity_id}: -> {state}")
+
+    def get_trackable_features(self):
+        return [
+            {"key": "bed_occupied", "label_de": "Bett belegt", "label_en": "Bed occupied"},
+            {"key": "sleep_duration", "label_de": "Schlafdauer", "label_en": "Sleep duration"},
+        ]
+
+    def get_current_status(self, room_id=None):
+        entities = self.get_entities()
+        relevant = [e for e in entities
+                    if e.get("attributes", {}).get("device_class") in self.DEVICE_CLASSES]
+        occupied = sum(1 for e in relevant if e.get("state") == "on")
+        return {"total": len(relevant), "occupied": occupied, "free": len(relevant) - occupied}
+
+    def evaluate(self, context):
+        return []

--- a/addon/rootfs/opt/mindhome/domains/seat_occupancy.py
+++ b/addon/rootfs/opt/mindhome/domains/seat_occupancy.py
@@ -1,0 +1,39 @@
+"""MindHome - Seat Occupancy Domain Plugin (Phase 3)"""
+from .base import DomainPlugin
+
+
+class SeatOccupancyDomain(DomainPlugin):
+    DOMAIN_NAME = "seat_occupancy"
+    HA_DOMAINS = ["binary_sensor"]
+    DEVICE_CLASSES = ["occupancy"]
+    DEFAULT_SETTINGS = {"enabled": "true", "mode": "suggest"}
+
+    def on_start(self):
+        self.logger.info("Seat occupancy domain ready")
+
+    def on_stop(self):
+        pass
+
+    def on_state_change(self, entity_id, old_state, new_state, context=None):
+        if not self.is_entity_tracked(entity_id):
+            return
+        if isinstance(new_state, dict):
+            state = new_state.get("state", "")
+        else:
+            state = new_state
+        self.logger.debug(f"Seat occupancy {entity_id}: -> {state}")
+
+    def get_trackable_features(self):
+        return [
+            {"key": "seat_occupied", "label_de": "Sitz belegt", "label_en": "Seat occupied"},
+        ]
+
+    def get_current_status(self, room_id=None):
+        entities = self.get_entities()
+        relevant = [e for e in entities
+                    if e.get("attributes", {}).get("device_class") in self.DEVICE_CLASSES]
+        occupied = sum(1 for e in relevant if e.get("state") == "on")
+        return {"total": len(relevant), "occupied": occupied, "free": len(relevant) - occupied}
+
+    def evaluate(self, context):
+        return []

--- a/addon/rootfs/opt/mindhome/domains/vacuum.py
+++ b/addon/rootfs/opt/mindhome/domains/vacuum.py
@@ -1,0 +1,69 @@
+"""MindHome - Vacuum/Robot Vacuum Domain Plugin (Phase 3)"""
+from .base import DomainPlugin
+
+
+class VacuumDomain(DomainPlugin):
+    DOMAIN_NAME = "vacuum"
+    HA_DOMAINS = ["vacuum"]
+    DEVICE_CLASSES = []
+    DEFAULT_SETTINGS = {
+        "enabled": "true",
+        "mode": "suggest",
+        "clean_when_away": "true",
+    }
+
+    def on_start(self):
+        self.logger.info("Vacuum domain ready")
+
+    def on_stop(self):
+        pass
+
+    def on_state_change(self, entity_id, old_state, new_state, context=None):
+        if not self.is_entity_tracked(entity_id):
+            return
+        if isinstance(new_state, dict):
+            state = new_state.get("state", "")
+            battery = new_state.get("attributes", {}).get("battery_level")
+        else:
+            state = new_state
+            battery = None
+        self.logger.debug(f"Vacuum {entity_id}: -> {state} (battery={battery})")
+
+    def get_trackable_features(self):
+        return [
+            {"key": "cleaning_active", "label_de": "Reinigung aktiv", "label_en": "Cleaning active"},
+            {"key": "battery_level", "label_de": "Akkustand", "label_en": "Battery level"},
+            {"key": "clean_when_away", "label_de": "Reinigung bei Abwesenheit", "label_en": "Clean when away"},
+        ]
+
+    def get_current_status(self, room_id=None):
+        entities = self.get_entities()
+        cleaning = sum(1 for e in entities if e.get("state") == "cleaning")
+        docked = sum(1 for e in entities if e.get("state") == "docked")
+        returning = sum(1 for e in entities if e.get("state") == "returning")
+        return {
+            "total": len(entities),
+            "cleaning": cleaning,
+            "docked": docked,
+            "returning": returning,
+        }
+
+    def evaluate(self, context):
+        if not self.is_enabled() or not self.get_setting("clean_when_away", "true") == "true":
+            return []
+        if context.get("anyone_home", True):
+            return []
+
+        actions = []
+        for entity in self.get_entities():
+            eid = entity.get("entity_id", "")
+            state = entity.get("state", "")
+            if state == "docked" and self.is_entity_tracked(eid):
+                actions.append({
+                    "entity_id": eid,
+                    "service": "start",
+                    "data": {},
+                    "reason_de": "Niemand zuhause - Saugroboter starten",
+                    "reason_en": "Nobody home - start robot vacuum",
+                })
+        return actions

--- a/addon/rootfs/opt/mindhome/init_db.py
+++ b/addon/rootfs/opt/mindhome/init_db.py
@@ -131,14 +131,43 @@ def create_default_domains(session):
             "description_de": "Photovoltaik, Erzeugung, Eigenverbrauch, Einspeisung",
             "description_en": "Photovoltaics, generation, self-consumption, feed-in"
         },
+        {
+            "name": "bed_occupancy",
+            "display_name_de": "Bettbelegung",
+            "display_name_en": "Bed Occupancy",
+            "icon": "mdi:bed",
+            "description_de": "Bettbelegungssensoren, Schlaftracking",
+            "description_en": "Bed occupancy sensors, sleep tracking"
+        },
+        {
+            "name": "seat_occupancy",
+            "display_name_de": "Sitzbelegung",
+            "display_name_en": "Seat Occupancy",
+            "icon": "mdi:seat",
+            "description_de": "Sitzbelegungssensoren fuer Sofa, Stuhl, etc.",
+            "description_en": "Seat occupancy sensors for sofa, chair, etc."
+        },
+        {
+            "name": "vacuum",
+            "display_name_de": "Saugroboter",
+            "display_name_en": "Robot Vacuum",
+            "icon": "mdi:robot-vacuum",
+            "description_de": "Saugroboter, automatische Reinigung",
+            "description_en": "Robot vacuums, automatic cleaning"
+        },
     ]
 
+    created = 0
     for domain_data in domains:
+        existing = session.query(Domain).filter_by(name=domain_data["name"]).first()
+        if existing:
+            continue
         domain = Domain(**domain_data)
         session.add(domain)
+        created += 1
 
     session.commit()
-    print(f"Created {len(domains)} domains.")
+    print(f"Created {created} domains ({len(domains) - created} already existed).")
 
 
 def create_default_quick_actions(session):

--- a/addon/rootfs/opt/mindhome/routes/domains.py
+++ b/addon/rootfs/opt/mindhome/routes/domains.py
@@ -179,8 +179,12 @@ def api_delete_domain(domain_id):
         for d in devices:
             d.domain_id = default_domain.id if default_domain else 1
 
-        # Remove room domain states
+        # Remove all FK references to this domain
         session.query(RoomDomainState).filter_by(domain_id=domain_id).delete()
+        session.query(LearnedPattern).filter_by(domain_id=domain_id).delete()
+        session.query(ActionLog).filter_by(domain_id=domain_id).delete()
+        session.query(AnomalySetting).filter_by(domain_id=domain_id).delete()
+        session.query(DataCollection).filter_by(domain_id=domain_id).delete()
 
         session.delete(domain)
         session.commit()

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,8 +4,8 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.42"
-BUILD = 43
+VERSION = "0.6.43"
+BUILD = 44
 BUILD_DATE = "2026-02-13"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 


### PR DESCRIPTION
Neue Domain-Plugins:
- bed_occupancy: Bettbelegungssensoren (binary_sensor/occupancy)
- seat_occupancy: Sitzbelegungssensoren (binary_sensor/occupancy)
- vacuum: Saugroboter mit evaluate() (start bei Abwesenheit)

Vollstaendig eingebunden:
- Domain-Plugin-Klassen in domains/
- DOMAIN_REGISTRY in domains/__init__.py
- DOMAIN_PLUGINS Config in app.py
- DB-Seed in init_db.py (mit Duplikat-Check)
- Auto-Seed beim Start fuer bestehende DBs (app.py)

Bugfix: Domain loeschen schlug mit FOREIGN KEY constraint fehl weil nur Device + RoomDomainState bereinigt wurden. Jetzt werden auch LearnedPattern, ActionLog, AnomalySetting und DataCollection vor dem Delete entfernt.

v0.6.43 (Build 44)

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp