### PR TITLE
feat: Domain System + Bewegungsmelder Steuerung

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.43"
+version: "0.6.44"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/app.py
+++ b/addon/rootfs/opt/mindhome/app.py
@@ -230,6 +230,22 @@ DOMAIN_PLUGINS = {
         "pattern_features": ["schedule", "presence"],
         "icon": "mdi:robot-vacuum",
     },
+    "system": {
+        "ha_domain": "sensor",
+        "device_class": "battery",
+        "attributes": ["device_class", "unit_of_measurement"],
+        "controls": [],
+        "pattern_features": ["battery_trend", "connectivity", "proximity"],
+        "icon": "mdi:cellphone-link",
+    },
+    "motion_control": {
+        "ha_domain": "switch",
+        "device_class": "motion",
+        "attributes": ["device_class"],
+        "controls": ["toggle", "turn_on", "turn_off"],
+        "pattern_features": ["quiet_hours", "presence_based"],
+        "icon": "mdi:motion-sensor-off",
+    },
 }
 
 # Domain Manager (optional)

--- a/addon/rootfs/opt/mindhome/domains/__init__.py
+++ b/addon/rootfs/opt/mindhome/domains/__init__.py
@@ -24,6 +24,8 @@ from .solar import SolarDomain
 from .bed_occupancy import BedOccupancyDomain
 from .seat_occupancy import SeatOccupancyDomain
 from .vacuum import VacuumDomain
+from .system import SystemDomain
+from .motion_control import MotionControlDomain
 
 logger = logging.getLogger("mindhome.domain_manager")
 
@@ -46,6 +48,8 @@ DOMAIN_REGISTRY: Dict[str, type] = {
     "bed_occupancy": BedOccupancyDomain,
     "seat_occupancy": SeatOccupancyDomain,
     "vacuum": VacuumDomain,
+    "system": SystemDomain,
+    "motion_control": MotionControlDomain,
 }
 
 

--- a/addon/rootfs/opt/mindhome/domains/motion_control.py
+++ b/addon/rootfs/opt/mindhome/domains/motion_control.py
@@ -1,0 +1,82 @@
+"""MindHome - Motion Sensor Control Domain Plugin (Phase 3)
+
+Unlike the read-only 'motion' domain, this domain manages
+controllable motion sensors (enable/disable, sensitivity).
+Covers Zigbee/Z-Wave motion sensors exposed as switch or
+binary_sensor with controllable attributes.
+"""
+from .base import DomainPlugin
+
+
+class MotionControlDomain(DomainPlugin):
+    DOMAIN_NAME = "motion_control"
+    HA_DOMAINS = ["switch", "binary_sensor"]
+    DEVICE_CLASSES = ["motion"]
+    DEFAULT_SETTINGS = {
+        "enabled": "true",
+        "mode": "suggest",
+        "disable_when_home": "false",
+        "quiet_hours_off": "true",
+    }
+
+    def on_start(self):
+        self.logger.info("Motion control domain ready")
+
+    def on_stop(self):
+        pass
+
+    def on_state_change(self, entity_id, old_state, new_state, context=None):
+        if not self.is_entity_tracked(entity_id):
+            return
+        if isinstance(new_state, dict):
+            state = new_state.get("state", "")
+        else:
+            state = new_state
+        self.logger.debug(f"Motion control {entity_id}: -> {state}")
+
+    def get_trackable_features(self):
+        return [
+            {"key": "sensor_enabled", "label_de": "Sensor aktiv", "label_en": "Sensor enabled"},
+            {"key": "sensitivity", "label_de": "Empfindlichkeit", "label_en": "Sensitivity"},
+            {"key": "quiet_hours_control", "label_de": "Ruhezeiten-Steuerung", "label_en": "Quiet hours control"},
+        ]
+
+    def get_current_status(self, room_id=None):
+        entities = self.get_entities()
+        relevant = [e for e in entities
+                    if e.get("attributes", {}).get("device_class") in self.DEVICE_CLASSES]
+        enabled = sum(1 for e in relevant if e.get("state") == "on")
+        return {"total": len(relevant), "enabled": enabled, "disabled": len(relevant) - enabled}
+
+    def get_plugin_actions(self):
+        return [
+            {"key": "enable_all", "label_de": "Alle Melder aktivieren", "label_en": "Enable all sensors",
+             "service": "turn_on"},
+            {"key": "disable_all", "label_de": "Alle Melder deaktivieren", "label_en": "Disable all sensors",
+             "service": "turn_off"},
+        ]
+
+    def evaluate(self, context):
+        if not self.is_enabled():
+            return []
+
+        actions = []
+
+        # Quiet hours: disable motion sensors to avoid false triggers
+        if self.get_setting("quiet_hours_off", "true") == "true" and self.is_quiet_time():
+            for entity in self.get_entities():
+                eid = entity.get("entity_id", "")
+                dc = entity.get("attributes", {}).get("device_class", "")
+                state = entity.get("state", "")
+                if dc in self.DEVICE_CLASSES and state == "on" and self.is_entity_tracked(eid):
+                    ha_domain = eid.split(".")[0]
+                    if ha_domain == "switch":
+                        actions.append({
+                            "entity_id": eid,
+                            "service": "turn_off",
+                            "data": {},
+                            "reason_de": "Ruhezeit - Bewegungsmelder deaktivieren",
+                            "reason_en": "Quiet hours - disable motion sensor",
+                        })
+
+        return actions

--- a/addon/rootfs/opt/mindhome/domains/system.py
+++ b/addon/rootfs/opt/mindhome/domains/system.py
@@ -1,0 +1,48 @@
+"""MindHome - System Domain Plugin (Phase 3)"""
+from .base import DomainPlugin
+
+
+class SystemDomain(DomainPlugin):
+    DOMAIN_NAME = "system"
+    HA_DOMAINS = ["sensor", "binary_sensor", "proximity"]
+    DEVICE_CLASSES = [
+        "battery", "connectivity", "plug", "power",
+        "data_size", "data_rate", "frequency",
+        "signal_strength", "timestamp",
+    ]
+    DEFAULT_SETTINGS = {"enabled": "true", "mode": "suggest"}
+
+    def on_start(self):
+        self.logger.info("System domain ready")
+
+    def on_stop(self):
+        pass
+
+    def on_state_change(self, entity_id, old_state, new_state, context=None):
+        if not self.is_entity_tracked(entity_id):
+            return
+        if isinstance(new_state, dict):
+            state = new_state.get("state", "")
+        else:
+            state = new_state
+        self.logger.debug(f"System {entity_id}: -> {state}")
+
+    def get_trackable_features(self):
+        return [
+            {"key": "battery_level", "label_de": "Akkustand", "label_en": "Battery level"},
+            {"key": "connectivity", "label_de": "Verbindungsstatus", "label_en": "Connectivity status"},
+            {"key": "proximity", "label_de": "Entfernung/Proximität", "label_en": "Proximity/Distance"},
+            {"key": "system_load", "label_de": "Systemauslastung", "label_en": "System load"},
+        ]
+
+    def get_current_status(self, room_id=None):
+        entities = self.get_entities()
+        relevant = [e for e in entities
+                    if e.get("attributes", {}).get("device_class") in self.DEVICE_CLASSES
+                    or e.get("entity_id", "").startswith("proximity.")]
+        online = sum(1 for e in relevant
+                     if e.get("state") not in ("unavailable", "unknown", "off"))
+        return {"total": len(relevant), "online": online, "offline": len(relevant) - online}
+
+    def evaluate(self, context):
+        return []

--- a/addon/rootfs/opt/mindhome/init_db.py
+++ b/addon/rootfs/opt/mindhome/init_db.py
@@ -155,6 +155,22 @@ def create_default_domains(session):
             "description_de": "Saugroboter, automatische Reinigung",
             "description_en": "Robot vacuums, automatic cleaning"
         },
+        {
+            "name": "system",
+            "display_name_de": "System",
+            "display_name_en": "System",
+            "icon": "mdi:cellphone-link",
+            "description_de": "Telefone, Proximität, Rechner, Akkus, Netzwerk",
+            "description_en": "Phones, proximity, computers, batteries, network"
+        },
+        {
+            "name": "motion_control",
+            "display_name_de": "Bewegungsmelder Steuerung",
+            "display_name_en": "Motion Sensor Control",
+            "icon": "mdi:motion-sensor-off",
+            "description_de": "Bewegungsmelder ein-/ausschalten, Empfindlichkeit",
+            "description_en": "Toggle motion sensors on/off, sensitivity"
+        },
     ]
 
     created = 0

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,8 +4,8 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.43"
-BUILD = 44
+VERSION = "0.6.44"
+BUILD = 45
 BUILD_DATE = "2026-02-13"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 


### PR DESCRIPTION
Neue Domain-Plugins:
- system: Telefone, Proximität, Rechner, Akkus, Netzwerk (sensor/binary_sensor/proximity mit device_classes battery, connectivity, plug, power, signal_strength etc.)
- motion_control: Bewegungsmelder ein-/ausschalten (switch/binary_sensor mit device_class motion, controls toggle/turn_on/turn_off, evaluate() deaktiviert Melder in Ruhezeiten)

Vollstaendig eingebunden in:
- domains/__init__.py DOMAIN_REGISTRY
- app.py DOMAIN_PLUGINS Config
- init_db.py DB-Seed mit Duplikat-Check

v0.6.44 (Build 45)

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp