### PR TITLE
fix: Presence Auto-Detection - Event-basiert statt nur Polling

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.49"
+version: "0.6.50"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/routes/presence.py
+++ b/addon/rootfs/opt/mindhome/routes/presence.py
@@ -376,6 +376,18 @@ def api_presence_manual_override():
                 description_de="Manuelle Anwesenheits-Steuerung aktiv",
                 description_en="Manual presence control active",
             ))
+        # Store timestamp for auto-reset (4h)
+        ts_setting = session.query(SystemSetting).filter_by(key="presence_manual_override_ts").first()
+        ts_val = datetime.now(timezone.utc).isoformat() if enabled else ""
+        if ts_setting:
+            ts_setting.value = ts_val
+        else:
+            session.add(SystemSetting(
+                key="presence_manual_override_ts",
+                value=ts_val,
+                description_de="Zeitpunkt der manuellen Übersteuerung",
+                description_en="Manual override timestamp",
+            ))
         session.commit()
         return jsonify({"success": True, "manual_override": enabled})
     finally:

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,20 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.49"
-BUILD = 50
+VERSION = "0.6.50"
+BUILD = 51
 BUILD_DATE = "2026-02-14"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 
 # Changelog
+# Build 51: v0.6.50 Presence Auto-Detection Fix
+#   - Event-basierte Erkennung: person.*/device_tracker.* loest sofort check aus
+#   - Kein falsches "Abwesend" mehr bei HA-API-Ausfall (502 Gateway)
+#   - Manual Override wird in check_auto_transitions geprueft
+#   - Manual Override auto-reset nach 4 Stunden
+#   - Debounce reduziert: 60s -> 30s
+#   - Polling-Fallback: 120s -> 60s
+#
 # Build 50: v0.6.49 TTS Speaker-Toggle rechts + UI Polish
 #   - Speaker Ein/Aus-Toggle nach ganz rechts verschoben
 #   - Layout: Name | Raum-Dropdown | Test | Toggle


### PR DESCRIPTION
- person.*/device_tracker.* State-Changes triggern sofort check_auto_transitions()
- Kein falsches "Abwesend" bei HA-API-Ausfall (502 Bad Gateway Schutz)
- Manual Override wird jetzt auch im PresenceModeManager geprueft
- Manual Override auto-reset nach 4 Stunden
- Debounce: 60s -> 30s, Polling-Fallback: 120s -> 60s

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp