### PR TITLE
feat: DB Cleanup, Indexes & Maintenance (v0.6.51)

### DIFF
--- a/addon/rootfs/opt/mindhome/app.py
+++ b/addon/rootfs/opt/mindhome/app.py
@@ -665,9 +665,18 @@ def start_app():
     automation_scheduler.start()
     logger.info("  ✅ Automation Engine started")
 
+    # Register cleanup + DB maintenance tasks
+    from routes.system import run_cleanup, run_db_maintenance
+    task_scheduler.register("db_cleanup", run_cleanup,
+                            interval_seconds=24 * 3600,  # daily
+                            run_immediately=False)
+    task_scheduler.register("db_maintenance", run_db_maintenance,
+                            interval_seconds=7 * 24 * 3600,  # weekly
+                            run_immediately=False)
+
     # Start task scheduler
     task_scheduler.start()
-    logger.info("  ✅ Task Scheduler started")
+    logger.info("  ✅ Task Scheduler started (cleanup:24h, maintenance:7d)")
 
     logger.info(f"MindHome {vi['full']} started successfully!")
 

--- a/addon/rootfs/opt/mindhome/models.py
+++ b/addon/rootfs/opt/mindhome/models.py
@@ -1,4 +1,4 @@
-# MindHome Models v0.6.2 (2026-02-10) - models.py
+# MindHome Models v0.6.51 (2026-02-14) - models.py
 """
 MindHome - Database Models
 All persistent data structures for MindHome.
@@ -1362,6 +1362,19 @@ MIGRATIONS = [
         "description": "v0.6.30 - Room-level domain mode override",
         "sql": [
             "ALTER TABLE room_domain_states ADD COLUMN mode VARCHAR(20) DEFAULT 'global'",
+        ]
+    },
+    {
+        "version": 9,
+        "description": "v0.6.51 - DB indexes on learned_patterns + pattern_match_log cleanup index",
+        "sql": [
+            "CREATE INDEX IF NOT EXISTS idx_learned_patterns_status_active ON learned_patterns(status, is_active)",
+            "CREATE INDEX IF NOT EXISTS idx_learned_patterns_type_active ON learned_patterns(pattern_type, is_active)",
+            "CREATE INDEX IF NOT EXISTS idx_learned_patterns_domain ON learned_patterns(domain_id)",
+            "CREATE INDEX IF NOT EXISTS idx_learned_patterns_room ON learned_patterns(room_id)",
+            "CREATE INDEX IF NOT EXISTS idx_learned_patterns_confidence ON learned_patterns(confidence)",
+            "CREATE INDEX IF NOT EXISTS idx_learned_patterns_last_matched ON learned_patterns(last_matched_at)",
+            "CREATE INDEX IF NOT EXISTS idx_pattern_match_log_matched ON pattern_match_log(matched_at)",
         ]
     },
 ]

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,29 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.6.50"
-BUILD = 51
+VERSION = "0.6.51"
+BUILD = 52
 BUILD_DATE = "2026-02-14"
 CODENAME = "Phase 3.5 - Kalender & Presence"
 
 # Changelog
+# Build 52: v0.6.51 DB Cleanup, Indexes & Maintenance
+#   - DB Indexes: 7 neue Indexes auf learned_patterns + pattern_match_log
+#     (status+is_active, pattern_type+is_active, domain_id, room_id, confidence, last_matched_at, matched_at)
+#   - run_cleanup(): Intelligentes Aufraeumen implementiert (war vorher undefiniert/crashte)
+#     - Rejected Patterns nach 30 Tagen loeschen
+#     - Disabled Patterns (confidence < 0.1) nach 14 Tagen loeschen
+#     - StateHistory nach data_retention_days loeschen
+#     - PatternMatchLog nach 90 Tagen loeschen
+#     - ActionLog nach data_retention_days loeschen
+#     - NotificationLog nach 90 Tagen loeschen
+#     - AuditTrail nach 180 Tagen loeschen
+#   - Smart Eviction: Bei > 500 observed Patterns werden die mit niedrigster
+#     Confidence + aeltestem last_matched_at zuerst entfernt
+#   - DB Maintenance: Woechentliches VACUUM + ANALYZE (SQLite Optimierung)
+#   - Scheduler: Cleanup taeglich, Maintenance woechentlich
+#   - Migration v9: Indexes als DB-Migration fuer bestehende Installationen
+#
 # Build 51: v0.6.50 Presence Auto-Detection Fix
 #   - Event-basierte Erkennung: person.*/device_tracker.* loest sofort check aus
 #   - Kein falsches "Abwesend" mehr bei HA-API-Ausfall (502 Gateway)


### PR DESCRIPTION
- Add 7 indexes on learned_patterns + pattern_match_log (Migration v9)
- Implement run_cleanup() with intelligent pruning:
  - Rejected patterns: delete after 30 days
  - Disabled patterns (confidence < 0.1): delete after 14 days
  - StateHistory/ActionLog: enforce data_retention_days
  - PatternMatchLog/NotificationLog: 90 day retention
  - AuditTrail: 180 day retention
- Smart eviction: cap observed patterns at 500, evict lowest confidence
- Weekly VACUUM + ANALYZE for SQLite optimization
- Register cleanup (daily) and maintenance (weekly) in TaskScheduler

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp