### PR TITLE
fix: Addon config.yaml Version auf 0.6.51 aktualisiert

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.6.50"
+version: "0.6.51"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"


### PR DESCRIPTION
HA erkennt Updates anhand der Version in config.yaml, nicht version.py.

https://claude.ai/code/session_0144DvZXjcsLiTXnhHDKZnkp