### PR TITLE
fix: DB session context manager + Bettbelegung in Schlaf-Erkennung

### DIFF
--- a/addon/rootfs/opt/mindhome/engines/routines.py
+++ b/addon/rootfs/opt/mindhome/engines/routines.py
@@ -46,8 +46,7 @@ class RoutineEngine:
             if not is_feature_enabled("phase4.room_transitions"):
                 return self._cached_routines
 
-            session = self.get_session()
-            try:
+            with self.get_session() as session:
                 # Get accepted/active patterns with time info
                 patterns = session.query(LearnedPattern).filter(
                     LearnedPattern.is_active == True,
@@ -126,8 +125,6 @@ class RoutineEngine:
                 self._last_detect = datetime.now(timezone.utc)
                 logger.info(f"Detected {len(routines)} routines ({', '.join(r['period'] for r in routines)})")
                 return routines
-            finally:
-                session.close()
         except Exception as e:
             logger.error(f"detect_routines error: {e}")
             return self._cached_routines
@@ -175,8 +172,7 @@ class RoutineEngine:
             if not is_feature_enabled("phase4.room_transitions"):
                 return []
 
-            session = self.get_session()
-            try:
+            with self.get_session() as session:
                 cutoff = datetime.now(timezone.utc) - timedelta(days=7)
                 # Get motion events grouped by room
                 motion_events = session.query(StateHistory).filter(
@@ -222,8 +218,6 @@ class RoutineEngine:
                     })
 
                 return results[:20]  # top 20
-            finally:
-                session.close()
         except Exception as e:
             logger.error(f"detect_room_transitions error: {e}")
             return []

--- a/addon/rootfs/opt/mindhome/engines/visit.py
+++ b/addon/rootfs/opt/mindhome/engines/visit.py
@@ -35,8 +35,7 @@ class VisitPreparationManager:
         """Activate a visit preparation by ID — execute all actions."""
         try:
             from models import VisitPreparation
-            session = self.get_session()
-            try:
+            with self.get_session() as session:
                 prep = session.get(VisitPreparation, preparation_id)
                 if not prep:
                     return {"error": "Preparation not found"}
@@ -64,8 +63,6 @@ class VisitPreparationManager:
                 })
                 logger.info(f"Visit preparation '{prep.name}' activated: {executed}/{len(actions)} actions")
                 return {"success": True, "actions_executed": executed, "total_actions": len(actions)}
-            finally:
-                session.close()
         except Exception as e:
             logger.error(f"activate error: {e}")
             return {"error": str(e)}
@@ -74,8 +71,7 @@ class VisitPreparationManager:
         """Return list of configured visit preparations."""
         try:
             from models import VisitPreparation
-            session = self.get_session()
-            try:
+            with self.get_session() as session:
                 preps = session.query(VisitPreparation).order_by(VisitPreparation.name).all()
                 return [{
                     "id": p.id,
@@ -87,8 +83,6 @@ class VisitPreparationManager:
                     "is_active": p.is_active,
                     "created_at": p.created_at.isoformat() if p.created_at else None,
                 } for p in preps]
-            finally:
-                session.close()
         except Exception as e:
             logger.error(f"get_preparations error: {e}")
             return []
@@ -106,8 +100,7 @@ class VisitPreparationManager:
             if not is_feature_enabled("phase4.visit_preparation"):
                 return
 
-            session = self.get_session()
-            try:
+            with self.get_session() as session:
                 auto_preps = session.query(VisitPreparation).filter(
                     VisitPreparation.auto_trigger == True,
                     VisitPreparation.is_active == True
@@ -127,8 +120,6 @@ class VisitPreparationManager:
                                     self.activate(prep.id)
                             except Exception:
                                 pass
-            finally:
-                session.close()
         except Exception as e:
             logger.error(f"check_triggers error: {e}")
 


### PR DESCRIPTION
- Fix: get_db_session ist @contextmanager → mit "with" verwenden statt manuellem .close() (alle 3 Engine-Dateien)
- Schlaf-Erkennung: Bettbelegungssensor (device_class=occupancy) als Prioritaet 1, Fallback auf Motion+Licht-Heuristik
- Weck-Erkennung: Bett verlassen (occupancy off) als Prioritaet 1

https://claude.ai/code/session_01RFnVuJJ7VvtQEECw6bHVTn