### PR TITLE
fix: Abgelehnte Muster + Domain-Ausschluss in Mustererkennung (v0.7.8)

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.8 – Bugfix: Muster-Ablehnung & Domain-Ausschluss
+
+### Muster-Ablehnung Fix
+- Abgelehnte Muster tauchen nach "Jetzt synchronisieren" nicht mehr wieder auf
+- `_upsert_pattern()` prüft jetzt auch rejected/disabled Muster bei Duplikat-Erkennung
+- Betrifft alle 3 Mustertypen: time_based, event_chain, correlation
+
+### Domain-Ausschluss Fix
+- Deaktivierte Domains (z.B. Klima, Licht) werden jetzt bei Mustererkennung respektiert
+- Events von Geräten deaktivierter Domains werden vor der Analyse herausgefiltert
+- Kein erneutes Auftauchen von Mustern für ausgeschlossene Domains mehr
+
 ## 0.7.7 – UI Polish: Klima & KI Seiten
 
 ### ClimatePage Redesign

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.7"
+version: "0.7.8"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,20 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.7"
-BUILD = 60
+VERSION = "0.7.8"
+BUILD = 61
 BUILD_DATE = "2026-02-14"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
+# Build 61: v0.7.8 Bugfix - Muster-Ablehnung & Domain-Ausschluss
+#   - Fix: Abgelehnte Muster tauchten nach "Jetzt synchronisieren" wieder auf
+#     Root-Cause: _upsert_pattern() pruefte nur is_active=True, rejected/disabled Muster unsichtbar
+#     Fix: Query findet jetzt auch rejected/disabled Muster und ueberspringt sie
+#   - Fix: Deaktivierte Domains (z.B. Klima, Licht) wurden bei Mustererkennung nicht beachtet
+#     Root-Cause: run_full_analysis() filterte Events nicht nach Domain-Status
+#     Fix: Events von deaktivierten Domains werden vor Analyse herausgefiltert
+#
 # Build 60: v0.7.7 UI Polish - Klima & KI Seiten
 #   - ClimatePage: Hardcoded Hex-Farben ersetzt durch CSS-Variablen (--success, --warning, --danger, --info)
 #   - ClimatePage: Tab-Bar auf btn btn-sm btn-primary/btn-ghost Klassen umgestellt


### PR DESCRIPTION
Rejected patterns reappeared after "Jetzt synchronisieren" because _upsert_pattern() only checked is_active=True, making rejected/disabled patterns invisible to duplicate detection. Also, disabled domains (e.g. Klima, Licht) were not filtered during pattern analysis.

https://claude.ai/code/session_01RFnVuJJ7VvtQEECw6bHVTn