### PR TITLE
fix: Raum-Filter fuer Sequence-Patterns + JSX-Fix (v0.7.10)

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.10 – Raum-Filter fuer Sequence-Patterns
+
+### Intelligentere Mustererkennung
+- **Cross-Room-Filter**: Sinnlose Raum-uebergreifende Muster (z.B. "Bewegungsmelder Wohnzimmer → Toiletten-Licht") werden jetzt herausgefiltert
+- Same-Room-Muster: normaler Schwellwert (min 7x in 14 Tagen, Confidence >= 0.45)
+- Cross-Room-Muster: deutlich strengerer Schwellwert (min 20x, Confidence >= 0.65, Timing-Varianz max 40%)
+- Neues `same_room` Flag in pattern_data zur Transparenz
+
+### Fixes
+- JSX-Fehler im EnergyPage Konfiguration-Tab behoben (Adjacent elements Fragment)
+
 ## 0.7.9 – Phase 4 Feature-Konfiguration
 
 ### Umfassende Feature-Einstellungen

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.9"
+version: "0.7.10"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/static/frontend/app.jsx
+++ b/addon/rootfs/opt/mindhome/static/frontend/app.jsx
@@ -6941,7 +6941,7 @@ const EnergyPage = () => {
                 </div>
             )}
 
-            {tab === 'config' && config && (
+            {tab === 'config' && config && (<>
                 <div className="card animate-in">
                     <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--border-color)', fontWeight: 600 }}>{lang === 'de' ? 'Energie-Einstellungen' : 'Energy Settings'}</div>
                     <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -6994,7 +6994,7 @@ const EnergyPage = () => {
                     </h3>
                     <FeatureSettingsPanel category="energy" lang={lang} showToast={showToast} />
                 </div>
-            )}
+            </>)}
 
             {showDiscover && (
                 <Modal title={lang === 'de' ? 'Gefundene Energie-Sensoren' : 'Discovered Energy Sensors'} onClose={() => setShowDiscover(false)}>

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,19 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.9"
-BUILD = 62
+VERSION = "0.7.10"
+BUILD = 63
 BUILD_DATE = "2026-02-14"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
+# Build 63: v0.7.10 Raum-Filter fuer Sequence-Patterns + JSX-Fix
+#   - Fix: Cross-Room-Patterns (z.B. Wohnzimmer-BWM → Toilette-Licht) werden jetzt gefiltert
+#     Same-Room: normaler Schwellwert (min 7 Vorkommen, Confidence 0.45)
+#     Cross-Room: deutlich hoeher (min 20 Vorkommen, Confidence 0.65, strengere Timing-Varianz)
+#   - entity→room_id Lookup vor Analyse, room-aware Thresholds in _detect_sequence_patterns()
+#   - Fix: JSX adjacent-elements Fehler im EnergyPage Config-Tab (Fragment-Wrapper)
+#
 # Build 62: v0.7.9 Phase 4 Feature-Konfiguration pro Seite
 #   - Neu: Umfassende Feature-Einstellungen fuer alle 20 Phase-4 Features
 #   - Konfiguration-Tab auf Klima-, Gesundheits-, Energie- und KI-Seite


### PR DESCRIPTION
Cross-room patterns (z.B. Wohnzimmer-BWM -> Toilette-Licht) werden jetzt mit deutlich strengeren Schwellwerten gefiltert:
- Same-room: min 7x, confidence >= 0.45, timing-varianz 60%
- Cross-room: min 20x, confidence >= 0.65, timing-varianz 40%
- entity->room_id Lookup vor Analyse fuer Performance
- Neues same_room Flag in pattern_data

Fix: JSX adjacent-elements Fehler im EnergyPage Config-Tab

https://claude.ai/code/session_01RFnVuJJ7VvtQEECw6bHVTn