### PR TITLE
fix: Korrelations-Regression behoben (v0.7.12, Build 65)

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.12 – Fix Korrelations-Regression
+
+### Fix
+- **Korrelations-Filter zu aggressiv**: `MAX_STATE_AGE_SECONDS` von 2 Stunden auf 8 Stunden erhoeht — viele Entities (person, Licht, Klima) halten ihren State stundenlang, der 2h-Filter hat praktisch alle Korrelationen herausgefiltert (0 Korrelationsmuster in Produktion)
+- **Debug-Logging**: Zeitmuster-Erkennung protokolliert jetzt Gruppen/Schwellwerte/Ablehnungen fuer bessere Diagnose
+
 ## 0.7.11 – Mustererkennung komplett ueberarbeitet (29 Fixes)
 
 ### Kritische Fixes
@@ -12,7 +18,7 @@
 
 ### Datenqualitaet
 - **Korrelationen Room-Aware**: B3-Korrelationen haben jetzt getrennte Schwellwerte fuer same-room (ratio 0.7, count 4) und cross-room (ratio 0.8, count 10)
-- **State-Bereinigung**: Korrelationen ignorieren Entity-States die aelter als 2 Stunden sind
+- **State-Bereinigung**: Korrelationen ignorieren Entity-States die aelter als 8 Stunden sind
 - **Exclusions sofort wirksam**: Ausschluesse werden direkt an Detektoren und den Executor weitergegeben (nicht erst bei naechster 6h-Analyse)
 - **Bessere Statistik**: Example-Cap von 20 auf 50 erhoeht, Timing-Konsistenz fliesst in Confidence ein, 5s Mindest-Toleranz fuer kurze Delays
 - **Automation-Ketten**: Events die durch bestehende HA-Automationen ausgeloest wurden, werden erkannt und uebersprungen

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.11"
+  org.opencontainers.image.version: "0.7.12"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.11"
+version: "0.7.12"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,17 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.11"
-BUILD = 64
+VERSION = "0.7.12"
+BUILD = 65
 BUILD_DATE = "2026-02-14"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
+# Build 65: v0.7.12 Fix Korrelations-Regression (MAX_STATE_AGE 2h → 8h)
+#   - Fix: 0 Korrelationsmuster durch zu aggressiven Staleness-Filter (2h → 8h)
+#   - Viele Entities (person, Licht, Klima) halten State stundenlang
+#   - Debug-Logging fuer Zeitmuster-Erkennung (Diagnose 0 time patterns)
+#
 # Build 64: v0.7.11 Mustererkennung komplett ueberarbeitet (29 Fixes)
 #   KRITISCHE FIXES:
 #   - Fix: Cross-Room Confidence-Formel (Doppelbestrafung behoben, min_count wirkt korrekt)


### PR DESCRIPTION
MAX_STATE_AGE_SECONDS von 7200 (2h) auf 28800 (8h) erhoeht. Der 2h-Staleness-Filter war zu aggressiv — viele Entities (person, Licht, Klima) halten ihren State stundenlang, was in Produktion zu 0 Korrelationsmustern fuehrte. Debug-Logging fuer Zeitmuster hinzugefuegt.

https://claude.ai/code/session_01RFnVuJJ7VvtQEECw6bHVTn