### PR TITLE
fix: Zeitmuster-Confidence + Korrelations-Schwellwerte (v0.7.14, Buil…

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.7.14 – Fix Zeitmuster-Confidence & Korrelations-Schwellwerte
+
+### Fix
+- **Zeitmuster-Confidence Formel**: Multiplikation von Frequenz und Konsistenz war zu streng (effektiv Quadrierung). Neue Formel: gewichteter Durchschnitt (50% Frequenz + 50% Konsistenz). Beispiel: 6 Events an 6 Tagen — alt: 0.18 (blockiert), neu: 0.51 (erkannt)
+- **expected_days fuer "alle Tage"**: Von 14 auf 10 gesenkt — realistischer, da Nutzer nicht jeden einzelnen Tag aktiv sind
+- **Korrelations-Schwellwerte gelockert**: same-room Ratio 0.7→0.55, cross-room Ratio 0.8→0.7, cross-room Count 10→7 — 22.103 Entity-Paare scheiterten zuvor an den zu strengen Schwellwerten
+
+### Diagnose
+- **Near-Miss-Logging**: Korrelationspaare die knapp am Schwellwert scheitern werden im Debug-Log protokolliert
+
 ## 0.7.13 – Diagnose-Logging & Cross-Room Integration
 
 ### Diagnose

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.13"
+  org.opencontainers.image.version: "0.7.14"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.13"
+version: "0.7.14"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,20 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.13"
-BUILD = 66
-BUILD_DATE = "2026-02-14"
+VERSION = "0.7.14"
+BUILD = 67
+BUILD_DATE = "2026-02-15"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
+# Build 67: v0.7.14 Fix Zeitmuster-Confidence + Korrelations-Schwellwerte
+#   - Fix: Zeitmuster-Confidence Formel: Multiplikation → gewichteter Durchschnitt (0.5*freq + 0.5*consistency)
+#     Alte Formel quadrierte effektiv (6 Events/6 Tage → 0.18), neue Formel: → 0.51
+#   - Fix: expected_days fuer "alle Tage" von 14 auf 10 (realistischer, Leute fehlen mal)
+#   - Fix: Korrelations-Schwellwerte gelockert (same-room: 0.7→0.55, cross-room: 0.8→0.7, count: 10→7)
+#     22.103 Paare scheiterten bei alten Schwellwerten
+#   - Diagnose: Near-Miss-Logging fuer Korrelationen (Paare die knapp scheitern)
+#
 # Build 66: v0.7.13 Diagnose-Logging + Cross-Room Integration
 #   - INFO-Logging: Zeitmuster zeigt actionable Events, Gruppen, Cluster, Confidence-Filter
 #   - INFO-Logging: Korrelationen zeigt Trigger-Paare, Schwellwert-Filter, Confidence-Filter


### PR DESCRIPTION
…d 67)

- Zeitmuster: Confidence-Formel von Multiplikation auf gewichteten Durchschnitt (50% Frequenz + 50% Konsistenz) — 85 Cluster scheiterten an alter Formel
- expected_days "alle Tage": 14 → 10 (realistischer)
- Korrelationen: Schwellwerte gelockert (same-room 0.7→0.55, cross-room 0.8→0.7, count 10→7) — 22.103 Paare scheiterten an alten Werten
- Near-Miss-Logging fuer Korrelationen (Debug)

https://claude.ai/code/session_01RFnVuJJ7VvtQEECw6bHVTn