### PR TITLE
fix: Korrelations-Qualitaetsfilter — 4220 auf ~30 Patterns reduzieren…

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.16 – Korrelations-Qualitaetsfilter (4220 → ~30 Patterns)
+
+### Fix
+- **Baseline-Filter**: Entities die >85% der Zeit im gleichen State sind werden als triviale Korrelation uebersprungen (z.B. person.home=home 95% → uninformativ)
+- **Bidirektionale Dedup**: A→B und B→A erzeugen nicht mehr zwei Patterns — nur die staerkere Richtung wird behalten
+- **Hoehere Schwellwerte**: Count same-room 4→6, cross-room 7→10; Confidence same 0.3→0.4, cross 0.5→0.55
+
 ## 0.7.15 – Fix Korrelations-Ratio Berechnung (kritischer Bug)
 
 ### Fix

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.15"
+  org.opencontainers.image.version: "0.7.16"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.15"
+version: "0.7.16"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,16 +4,21 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.15"
-BUILD = 68
+VERSION = "0.7.16"
+BUILD = 69
 BUILD_DATE = "2026-02-15"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
+# Build 69: v0.7.16 Korrelations-Qualitaetsfilter (4220 → ~30 Patterns)
+#   - Baseline-Filter: Entities die >85% der Zeit im gleichen State sind = triviale Korrelation
+#     (z.B. person.home=home 95% → jede Korrelation damit ist uninformativ)
+#   - Bidirektionale Dedup: A→B und B→A = nur die staerkere Richtung behalten
+#   - Hoehere Count-Schwellwerte: same-room 4→6, cross-room 7→10
+#   - Hoehere Confidence-Schwellwerte: same-room 0.3→0.4, cross-room 0.5→0.55
+#
 # Build 68: v0.7.15 Fix Korrelations-Ratio Berechnung (kritischer Bug)
 #   - CRITICAL FIX: ratio = count / total war falsch — total summierte ALLE Entity/State-Paare
-#     Bei 50 Entities wurde ratio um Faktor ~50 verduennt (0.75 → 0.015)
-#     Jetzt: ratio pro Target-Entity berechnet (korrekt: "75% wenn Kueche an, ist Wohnzimmer auch an")
 #   - Schwellwerte zurueck auf Originalwerte (0.7/0.8) da Ratios jetzt korrekt berechnet werden
 #
 # Build 67: v0.7.14 Fix Zeitmuster-Confidence + Korrelations-Schwellwerte


### PR DESCRIPTION
… (v0.7.16, Build 69)

3 neue Filter gegen die Flut an trivialen Korrelationen:
- Baseline-Filter: Entities >85% im gleichen State = trivial (person.home=home)
- Bidirektionale Dedup: A→B und B→A = nur staerkere Richtung behalten
- Hoehere Schwellwerte: Count 6/10, Confidence 0.4/0.55

https://claude.ai/code/session_01RFnVuJJ7VvtQEECw6bHVTn