### PR TITLE
fix: Korrelations-Filter verschaerft — 364 auf ~30 reduzieren (v0.7.1…

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
-## 0.7.16 – Korrelations-Qualitaetsfilter (4220 → ~30 Patterns)
+## 0.7.17 – Korrelations-Filter verschaerft (364 → ~30 Patterns)
 
 ### Fix
-- **Baseline-Filter**: Entities die >85% der Zeit im gleichen State sind werden als triviale Korrelation uebersprungen (z.B. person.home=home 95% → uninformativ)
-- **Bidirektionale Dedup**: A→B und B→A erzeugen nicht mehr zwei Patterns — nur die staerkere Richtung wird behalten
-- **Hoehere Schwellwerte**: Count same-room 4→6, cross-room 7→10; Confidence same 0.3→0.4, cross 0.5→0.55
+- **Baseline verschaerft**: 0.85 → 0.75 — mehr "immer gleich" Entities werden als trivial gefiltert
+- **Top-3 pro Trigger-Entity**: Nur die 3 staerksten Korrelationen pro Trigger-Entity behalten, Rest verworfen
+- **Count erhoeht**: same-room 6→8, cross-room 10→14
+
+## 0.7.16 – Korrelations-Qualitaetsfilter (4220 → 364 Patterns)
+
+### Fix
+- **Baseline-Filter**: Entities >85% im gleichen State = trivial
+- **Bidirektionale Dedup**: A→B und B→A = nur staerkere Richtung
+- **Schwellwerte erhoeht**: Count same 4→6, cross 7→10; Confidence same 0.3→0.4, cross 0.5→0.55
 
 ## 0.7.15 – Fix Korrelations-Ratio Berechnung (kritischer Bug)
 

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.16"
+  org.opencontainers.image.version: "0.7.17"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.16"
+version: "0.7.17"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,15 +4,19 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.16"
-BUILD = 69
+VERSION = "0.7.17"
+BUILD = 70
 BUILD_DATE = "2026-02-15"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
-# Build 69: v0.7.16 Korrelations-Qualitaetsfilter (4220 → ~30 Patterns)
-#   - Baseline-Filter: Entities die >85% der Zeit im gleichen State sind = triviale Korrelation
-#     (z.B. person.home=home 95% → jede Korrelation damit ist uninformativ)
+# Build 70: v0.7.17 Korrelations-Filter verschaerft (364 → ~30 Patterns)
+#   - Baseline verschaerft: 0.85 → 0.75 (mehr "immer gleich" Entities filtern)
+#   - Top-3 pro Trigger-Entity: Nur die 3 staerksten Korrelationen pro Trigger behalten
+#   - Count-Schwellwerte erhoeht: same 6→8, cross 10→14
+#
+# Build 69: v0.7.16 Korrelations-Qualitaetsfilter (4220 → 364 Patterns)
+#   - Baseline-Filter: Entities >85% der Zeit im gleichen State = trivial
 #   - Bidirektionale Dedup: A→B und B→A = nur die staerkere Richtung behalten
 #   - Hoehere Count-Schwellwerte: same-room 4→6, cross-room 7→10
 #   - Hoehere Confidence-Schwellwerte: same-room 0.3→0.4, cross-room 0.5→0.55


### PR DESCRIPTION
…7, Build 70)

- Baseline-Filter: 0.85 → 0.75 (mehr triviale Korrelationen filtern)
- Top-3 pro Trigger-Entity (statt unbegrenzt)
- Count-Schwellwerte: same-room 6→8, cross-room 10→14

https://claude.ai/code/session_01RFnVuJJ7VvtQEECw6bHVTn