### PR TITLE
fix: defaultdict-Import + Stale-Pattern-Cleanup (v0.7.18, Build 71)

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.18 – Stale-Pattern-Cleanup + defaultdict-Fix
+
+### Fix
+- **defaultdict-Import**: "cannot access local variable 'defaultdict'" — doppelter Import entfernt (war schon global importiert)
+- **Stale-Pattern-Cleanup**: Nach jeder Analyse werden Patterns automatisch geloescht, die in diesem Lauf nicht bestaetigt/aktualisiert wurden. Betrifft nur `status=observed` — vom User bestaetigte/abgelehnte Patterns bleiben erhalten. Loest das Problem: 4.234 alte Korrelationen blieben in der DB obwohl die neuen Filter sie nicht mehr erzeugen
+
 ## 0.7.17 – Korrelations-Filter verschaerft (364 → ~30 Patterns)
 
 ### Fix

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.17"
+  org.opencontainers.image.version: "0.7.18"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.17"
+version: "0.7.18"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,15 +4,20 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.17"
-BUILD = 70
+VERSION = "0.7.18"
+BUILD = 71
 BUILD_DATE = "2026-02-15"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
+# Build 71: v0.7.18 Stale-Pattern-Cleanup + defaultdict-Fix
+#   - FIX: "cannot access local variable 'defaultdict'" — doppelter Import entfernt
+#   - Stale-Pattern-Cleanup: Nach Analyse werden nicht-bestaetigte observed-Patterns geloescht
+#     Loest: 4234 alte Korrelationen blieben in DB obwohl Filter verschaerft
+#
 # Build 70: v0.7.17 Korrelations-Filter verschaerft (364 → ~30 Patterns)
-#   - Baseline verschaerft: 0.85 → 0.75 (mehr "immer gleich" Entities filtern)
-#   - Top-3 pro Trigger-Entity: Nur die 3 staerksten Korrelationen pro Trigger behalten
+#   - Baseline verschaerft: 0.85 → 0.75
+#   - Top-3 pro Trigger-Entity
 #   - Count-Schwellwerte erhoeht: same 6→8, cross 10→14
 #
 # Build 69: v0.7.16 Korrelations-Qualitaetsfilter (4220 → 364 Patterns)


### PR DESCRIPTION
- Fix: doppelter 'from collections import defaultdict' in Funktion kollidierte mit globalem Import → "cannot access local variable" Error
- Stale-Pattern-Cleanup: Nach Analyse werden observed-Patterns die nicht bestaetigt wurden automatisch geloescht (4234 alte Korrelationen aufräumen)
- User-bestaetigte/abgelehnte Patterns bleiben erhalten

https://claude.ai/code/session_01RFnVuJJ7VvtQEECw6bHVTn