### PR TITLE
feat: HA-Automations-Erkennung + Duplikat-Vermeidung (v0.7.21, Build 74)

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.20"
+version: "0.7.21"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/automation_engine.py
+++ b/addon/rootfs/opt/mindhome/automation_engine.py
@@ -334,6 +334,16 @@ class AutomationExecutor:
                     logger.debug(f"Pattern {pattern.id}: excluded pair {trigger_entity} <-> {action_entity}")
                     continue
 
+                # Skip entities already covered by HA automations (avoid duplicates)
+                if self.ha:
+                    target_state = action.get("target_state", "")
+                    if self.ha.is_entity_ha_automated(entity_id, target_state or None):
+                        logger.info(
+                            f"Pattern {pattern.id}: {entity_id} ({target_state}) "
+                            f"already automated by HA, skipping"
+                        )
+                        continue
+
                 # #23 Skip non-essential automations in vacation mode
                 # but #55 allow light toggles if simulation is on
                 if is_vacation and not simulate:

--- a/addon/rootfs/opt/mindhome/pattern_engine.py
+++ b/addon/rootfs/opt/mindhome/pattern_engine.py
@@ -2004,6 +2004,22 @@ class PatternDetector:
             if cond_is_sensor and corr_is_sensor:
                 initial_status = "insight"
 
+        # Check if entity+action is already covered by a HA automation
+        ha_covered = False
+        if self.ha and action_def:
+            try:
+                act_entity = action_def.get("entity_id", "")
+                act_state = action_def.get("target_state", "")
+                if act_entity and self.ha.is_entity_ha_automated(act_entity, act_state or None):
+                    ha_covered = True
+                    pattern_data["ha_covered"] = True
+                    logger.info(
+                        f"Pattern {pattern_type}: {act_entity} ({act_state}) "
+                        f"already covered by HA automation"
+                    )
+            except Exception as e:
+                logger.debug(f"HA coverage check failed: {e}")
+
         pattern = LearnedPattern(
             domain_id=domain_id or 1,
             room_id=room_id,

--- a/addon/rootfs/opt/mindhome/static/frontend/app.jsx
+++ b/addon/rootfs/opt/mindhome/static/frontend/app.jsx
@@ -5199,6 +5199,13 @@ const PatternsPage = () => {
                                         <span className={`badge badge-${statusColors[p.status]}`} style={{ fontSize: 11 }}>
                                             {statusLabels[p.status]}
                                         </span>
+                                        {p.ha_covered && (
+                                            <span className="badge badge-info" style={{ fontSize: 10 }}
+                                                  title={lang === 'de' ? 'Diese Entity wird bereits von einer HA-Automation gesteuert' : 'This entity is already controlled by a HA automation'}>
+                                                <span className="mdi mdi-robot" style={{ marginRight: 3 }} />
+                                                HA-Automation
+                                            </span>
+                                        )}
                                         <span style={{ color: 'var(--text-muted)' }}>
                                             {typeLabels[p.pattern_type]}
                                         </span>

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,28 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.20"
-BUILD = 73
+VERSION = "0.7.21"
+BUILD = 74
 BUILD_DATE = "2026-02-15"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
+# Build 74: v0.7.21 HA-Automations-Erkennung + Duplikat-Vermeidung
+#   - NEU: MindHome erkennt bestehende HA-Automationen und vermeidet Duplikate
+#     ha_connection: get_automation_configs() laedt HA-Automation-Konfigurationen
+#     ha_connection: get_ha_automated_entities() extrahiert (entity_id, target_state) Paare
+#     ha_connection: is_entity_ha_automated() prueft ob Entity von HA gesteuert wird
+#     10-Minuten-Cache fuer HA-Automation-Abfragen (kein DB-Schema-Change)
+#   - NEU: Pattern-Engine annotiert neue Patterns mit ha_covered Flag
+#     _upsert_pattern() prueft bei Erstellung ob HA-Automation existiert
+#     pattern_data.ha_covered = true wenn Entity bereits von HA gesteuert
+#   - NEU: Automation-Executor ueberspringt HA-gesteuerte Entities
+#     check_and_execute() prueft vor Ausfuehrung gegen HA-Automation-Cache
+#     Log: "already automated by HA, skipping"
+#   - NEU: API /api/patterns liefert ha_covered Flag pro Pattern
+#     Frontend zeigt blauen "HA-Automation" Badge auf betroffenen Pattern-Karten
+#     Tooltip erklaert: "Diese Entity wird bereits von einer HA-Automation gesteuert"
+#
 # Build 73: v0.7.20 Fix Device-Loeschung + Muster-Konflikterkennung
 #   - FIX: Device-Loeschung crashte mit FOREIGN KEY constraint (500er)
 #     Root-Cause: 6 Tabellen referenzieren devices.id ohne CASCADE


### PR DESCRIPTION
MindHome erkennt jetzt bestehende Home Assistant Automationen und vermeidet Duplikate: Patterns werden annotiert, der Executor ueberspringt HA-gesteuerte Entities, und das Frontend zeigt einen HA-Automation Badge.

https://claude.ai/code/session_01CzrJLKhZKV5cRNkxdte73k