### PR TITLE
Fix HA automation detection: correct WS command automation/config/list

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,17 +1,15 @@
 # Changelog
 
-## 0.7.24 – Fix HA-Automation-Erkennung (REST statt WS)
+## 0.7.25 – Fix HA-Automation-Erkennung (korrekter WS-Command)
 
 ### Fix
-- **CRITICAL**: WebSocket-Command `config/automation/config/list` existiert nicht in HA — deshalb wurden **nie** Automation-Configs geladen und immer 0 Entities erkannt
-- **Fix**: Umstellung auf REST API `GET /api/config/automation/config` — liefert alle UI-Automationen mit vollstaendigen Trigger- und Action-Definitionen
+- **CRITICAL**: WS-Command war `config/automation/config/list` — existiert nicht in HA
+- REST-Endpoint `/api/config/automation/config` gibt 404 via Supervisor-Proxy
+- **Fix**: Korrekter HA Storage Collection Command: `automation/config/list`
+- Liefert alle UI-Automationen mit vollstaendigen Action- und Trigger-Definitionen
 - Matching per `alias` (= `friendly_name`) mit Fallback auf `automation.{id}`
 
-### Verbesserungen
-- Info-Logging: "Found X automation entities from REST states API"
-- Info-Logging: "Got X automation configs from REST config API"
-- Info-Logging: "Matched X/Y automation configs to entities"
-- Hinweis wenn REST Config API keine Configs liefert (YAML-basierte Automationen)
+## 0.7.24 – REST-API Versuch (404 via Supervisor)
 
 ## 0.7.23 – _extract_actions_flat + action-Key Support
 

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.24"
+  org.opencontainers.image.version: "0.7.25"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.24"
+version: "0.7.25"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,21 +4,21 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.24"
-BUILD = 77
+VERSION = "0.7.25"
+BUILD = 78
 BUILD_DATE = "2026-02-15"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
-# Build 77: v0.7.24 Fix HA-Automation-Erkennung (REST statt WS)
-#   - CRITICAL FIX: WS-Command "config/automation/config/list" existiert nicht
-#     in HA — deshalb kamen immer 0 Automation-Configs zurueck
-#     Fix: REST API GET /api/config/automation/config statt WebSocket
-#   - REST Config API liefert alle UI-Automationen mit triggers + actions
+# Build 78: v0.7.25 Fix HA-Automation-Erkennung (korrekter WS-Command)
+#   - CRITICAL FIX: WS-Command war "config/automation/config/list" (existiert nicht)
+#     Korrekter HA-Command: "automation/config/list" (Storage Collection API)
+#     REST-Endpoint /api/config/automation/config gibt 404 via Supervisor-Proxy
+#   - WS "automation/config/list" liefert alle UI-Automationen mit actions+triggers
 #   - Matching per alias (friendly_name) + Fallback auf automation.{id}
-#   - Info-Logging: "Found X automation entities" + "Matched X/Y configs"
-#   - Hinweis im Log wenn keine Configs gefunden (YAML-basierte Automationen)
+#   - Info-Logging: "Got X automation configs from WebSocket"
 #
+# Build 77: v0.7.24 REST-API Versuch (404 via Supervisor)
 # Build 76: v0.7.23 _extract_actions_flat + action-Key Support
 #   - NEU: Verschachtelte Actions (choose/if/sequence/parallel/repeat)
 #     werden rekursiv traversiert via _extract_actions_flat()


### PR DESCRIPTION
The previous WS command "config/automation/config/list" does not exist in HA, and the REST endpoint /api/config/automation/config returns 404 through the Supervisor proxy.

The correct HA Storage Collection command is "automation/config/list" which returns all UI-created automations with their action and trigger definitions.

https://claude.ai/code/session_01CzrJLKhZKV5cRNkxdte73k