### PR TITLE
Fix HA automation detection: per-entity WS query for YAML automations

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Changelog
 
-## 0.7.25 – Fix HA-Automation-Erkennung (korrekter WS-Command)
+## 0.7.26 – Fix HA-Automation-Erkennung (per-Entity WS-Abfrage)
 
 ### Fix
-- **CRITICAL**: WS-Command war `config/automation/config/list` — existiert nicht in HA
-- REST-Endpoint `/api/config/automation/config` gibt 404 via Supervisor-Proxy
-- **Fix**: Korrekter HA Storage Collection Command: `automation/config/list`
-- Liefert alle UI-Automationen mit vollstaendigen Action- und Trigger-Definitionen
-- Matching per `alias` (= `friendly_name`) mit Fallback auf `automation.{id}`
+- **CRITICAL**: `automation/config/list` liefert nur UI-Automationen — bei YAML-basierten Automationen kommt eine leere Liste zurueck
+- **Fix**: WS-Command `automation/config` mit `entity_id` Parameter pro Automation — liest `raw_config` vom Entity und funktioniert fuer ALLE Automationen (UI + YAML)
+- Kein alias/friendly_name Matching mehr noetig (direkte entity_id Zuordnung)
 
+## 0.7.25 – WS automation/config/list (leer bei YAML)
 ## 0.7.24 – REST-API Versuch (404 via Supervisor)
 
 ## 0.7.23 – _extract_actions_flat + action-Key Support

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.25"
+  org.opencontainers.image.version: "0.7.26"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.25"
+version: "0.7.26"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,20 +4,20 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.25"
-BUILD = 78
+VERSION = "0.7.26"
+BUILD = 79
 BUILD_DATE = "2026-02-15"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
-# Build 78: v0.7.25 Fix HA-Automation-Erkennung (korrekter WS-Command)
-#   - CRITICAL FIX: WS-Command war "config/automation/config/list" (existiert nicht)
-#     Korrekter HA-Command: "automation/config/list" (Storage Collection API)
-#     REST-Endpoint /api/config/automation/config gibt 404 via Supervisor-Proxy
-#   - WS "automation/config/list" liefert alle UI-Automationen mit actions+triggers
-#   - Matching per alias (friendly_name) + Fallback auf automation.{id}
-#   - Info-Logging: "Got X automation configs from WebSocket"
+# Build 79: v0.7.26 Fix HA-Automation-Erkennung (per-Entity WS-Abfrage)
+#   - CRITICAL FIX: "automation/config/list" liefert nur UI-Automationen (leer bei YAML)
+#     Fix: WS "automation/config" mit entity_id pro Automation — funktioniert fuer
+#     ALLE Automationen (UI + YAML) weil es raw_config vom Entity liest
+#   - Kein Matching-Problem mehr (direkte entity_id Zuordnung)
+#   - Info-Logging: "Fetched X/Y automation configs via WS"
 #
+# Build 78: v0.7.25 WS automation/config/list (leer bei YAML-Automationen)
 # Build 77: v0.7.24 REST-API Versuch (404 via Supervisor)
 # Build 76: v0.7.23 _extract_actions_flat + action-Key Support
 #   - NEU: Verschachtelte Actions (choose/if/sequence/parallel/repeat)


### PR DESCRIPTION
automation/config/list only returns UI-created automations (empty for YAML-based). Use automation/config with entity_id parameter instead, which reads raw_config from the entity and works for ALL automations.

https://claude.ai/code/session_01CzrJLKhZKV5cRNkxdte73k