### PR TITLE
Fix HA automation config: unwrap {"config": {...}} response wrapper

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 0.7.26 – Fix HA-Automation-Erkennung (per-Entity WS-Abfrage)
+## 0.7.29 – Fix HA-Automation-Erkennung (config-Wrapper unwrapping)
 
 ### Fix
-- **CRITICAL**: `automation/config/list` liefert nur UI-Automationen — bei YAML-basierten Automationen kommt eine leere Liste zurueck
-- **Fix**: WS-Command `automation/config` mit `entity_id` Parameter pro Automation — liest `raw_config` vom Entity und funktioniert fuer ALLE Automationen (UI + YAML)
-- Kein alias/friendly_name Matching mehr noetig (direkte entity_id Zuordnung)
+- **CRITICAL**: WS `automation/config` gibt `{"config": {...}}` zurueck — nicht direkt das Config-Dict
+- Response muss mit `raw.get("config", raw)` unwrapped werden bevor `action`/`trigger` gelesen werden
+- Fix: `with_actions` NameError aus vorherigem Diagnostik-Refactoring
 
+## 0.7.26 – per-Entity WS-Abfrage (UI + YAML)
 ## 0.7.25 – WS automation/config/list (leer bei YAML)
 ## 0.7.24 – REST-API Versuch (404 via Supervisor)
 

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.28"
+  org.opencontainers.image.version: "0.7.29"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.7.28"
+version: "0.7.29"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,16 +4,20 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.7.28"
-BUILD = 81
+VERSION = "0.7.29"
+BUILD = 82
 BUILD_DATE = "2026-02-15"
 CODENAME = "Phase 4 - Smart Health"
 
 # Changelog
-# Build 80: v0.7.27 Diagnostik - Automation Config Content Logging
-#   - Diagnostik: Loggt wie viele Configs actions haben + Sample Action-Keys
-#   - Hilft herauszufinden warum 80/80 fetched aber 0 coverage
+# Build 82: v0.7.29 Fix HA-Automation-Erkennung (config-Wrapper)
+#   - CRITICAL FIX: WS "automation/config" gibt {"config": {...}} zurueck,
+#     nicht direkt das Config-Dict. Fehlte: raw.get("config", raw) Unwrapping
+#   - Fix: with_actions NameError (Variable wurde in Diagnostik entfernt)
+#   - Diagnostik-Logging aufgeraeumt (nur noch with_actions Count)
 #
+# Build 81: v0.7.28 Diagnostik - Raw Response Keys
+# Build 80: v0.7.27 Diagnostik - Automation Config Content Logging
 # Build 79: v0.7.26 per-Entity WS-Abfrage (UI + YAML)
 # Build 78: v0.7.25 WS automation/config/list (leer bei YAML-Automationen)
 # Build 77: v0.7.24 REST-API Versuch (404 via Supervisor)


### PR DESCRIPTION
HA WS "automation/config" returns {"config": {triggers, actions...}}, not the config dict directly. Added raw.get("config", raw) unwrapping. Also fixed with_actions NameError from diagnostic cleanup.

https://claude.ai/code/session_01CzrJLKhZKV5cRNkxdte73k