### PR TITLE
feat: integrate mindhome-assistant into monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 __pycache__/
 *.pyc
 *.pyo
+
+# MindHome Assistant
+assistant/.env
+assistant/data/
+assistant/data/**
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -72,12 +72,61 @@ MindHome ist ein KI-basiertes Home Assistant Add-on, das deine Gewohnheiten lern
 - Infrastruktur-Module (db.py, event_bus.py, task_scheduler.py, helpers.py, version.py)
 - Systematische Bug-Fixes & Code-Qualität
 
+## MindHome Assistant (KI-Sprachassistent)
+
+MindHome Assistant ist ein separater, lokaler KI-Sprachassistent der auf einem zweiten PC laeuft und MindHome eine Stimme gibt.
+
+| Komponente | PC | Technologie | Port |
+|---|---|---|---|
+| **MindHome Add-on** | PC 1 (HAOS) | Flask, SQLite | 8099 |
+| **MindHome Assistant** | PC 2 (Ubuntu) | FastAPI, Ollama, ChromaDB, Redis | 8200 |
+
+### Features
+- Lokale LLM-Inference (Qwen 2.5 via Ollama)
+- Function Calling (Licht, Klima, Szenen, Alarme, Schloesser)
+- 3-Schichten-Gedaechtnis (Working + Episodic + Semantic)
+- Proaktive Meldungen (Morgen-Briefing, Ankunft, Warnungen)
+- Stimmungserkennung & adaptives Verhalten
+- Butler-Persoenlichkeit mit Tageszeit-Anpassung
+- Autonomie-Level 1-5 (Assistent bis Autopilot)
+
+### Installation (Assistant-PC)
+```bash
+cd assistant/
+chmod +x install.sh
+./install.sh
+```
+
+Siehe [docs/PROJECT_MINDHOME_ASSISTANT.md](docs/PROJECT_MINDHOME_ASSISTANT.md) fuer die vollstaendige Dokumentation.
+
+---
+
 ## Architektur
 
 ```
 mindhome/
 ├── repository.yaml              # HA Add-on Store
 ├── README.md
+├── shared/                      # Gemeinsame Schemas & Konstanten
+│   ├── constants.py
+│   └── schemas/
+│       ├── chat_request.py
+│       ├── chat_response.py
+│       └── events.py
+├── assistant/                   # MindHome Assistant (PC 2)
+│   ├── Dockerfile
+│   ├── docker-compose.yml
+│   ├── requirements.txt
+│   ├── install.sh
+│   ├── .env.example
+│   ├── config/settings.yaml
+│   └── assistant/               # Python-Package (22 Module)
+│       ├── main.py              # FastAPI Server
+│       ├── brain.py             # Orchestrator
+│       ├── personality.py       # Persoenlichkeits-Engine
+│       ├── function_calling.py  # 10 HA-Tools
+│       ├── memory.py            # 3-Schichten-Gedaechtnis
+│       └── ...                  # 17 weitere Module
 ├── addon/
 │   ├── config.yaml              # Add-on Konfiguration
 │   ├── build.yaml               # Docker Build
@@ -229,6 +278,26 @@ MindHome is an AI-powered Home Assistant add-on that learns your habits and inte
 - Modular Blueprint architecture (13 route modules)
 - Infrastructure modules (db.py, event_bus.py, task_scheduler.py, helpers.py, version.py)
 - Systematic bug fixes & code quality
+
+## MindHome Assistant (AI Voice Assistant)
+
+MindHome Assistant is a separate, local AI voice assistant running on a second PC that gives MindHome a voice.
+
+| Component | PC | Technology | Port |
+|---|---|---|---|
+| **MindHome Add-on** | PC 1 (HAOS) | Flask, SQLite | 8099 |
+| **MindHome Assistant** | PC 2 (Ubuntu) | FastAPI, Ollama, ChromaDB, Redis | 8200 |
+
+### Installation (Assistant PC)
+```bash
+cd assistant/
+chmod +x install.sh
+./install.sh
+```
+
+See [docs/PROJECT_MINDHOME_ASSISTANT.md](docs/PROJECT_MINDHOME_ASSISTANT.md) for full documentation.
+
+---
 
 ## Installation
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -4,43 +4,77 @@ MindHome - Projektstruktur / Project Structure
 mindhome/
 ├── repository.yaml                         # HA Add-on Store Konfiguration
 ├── README.md                               # Dokumentation DE + EN
+├── STRUCTURE.md                            # Diese Datei
 │
-├── addon/                                  # Das Add-on
+├── shared/                                 # Gemeinsame Schemas & Konstanten
+│   ├── __init__.py
+│   ├── constants.py                        # Ports, Events, Moods, Autonomy Levels
+│   └── schemas/                            # Pydantic-Schemas
+│       ├── __init__.py
+│       ├── chat_request.py                 # ChatRequest Schema
+│       ├── chat_response.py                # ChatResponse Schema
+│       └── events.py                       # MindHomeEvent Schema
+│
+├── assistant/                              # MindHome Assistant (KI-Backend, PC 2)
+│   ├── Dockerfile                          # Python 3.12-slim Container
+│   ├── docker-compose.yml                  # Assistant + ChromaDB + Redis
+│   ├── requirements.txt                    # Python-Abhaengigkeiten
+│   ├── install.sh                          # Ein-Klick-Installation
+│   ├── .env.example                        # Konfigurations-Vorlage
+│   ├── config/
+│   │   └── settings.yaml                   # Hauptkonfiguration
+│   └── assistant/                          # Python-Package (22 Module)
+│       ├── __init__.py
+│       ├── main.py                         # FastAPI Server (:8200)
+│       ├── brain.py                        # Orchestrator (verbindet alles)
+│       ├── config.py                       # Settings-Loader (.env + YAML)
+│       ├── context_builder.py              # Kontext-Sammlung (HA + Memory)
+│       ├── model_router.py                 # Modell-Auswahl (fast vs. smart)
+│       ├── ollama_client.py                # Ollama REST API Client
+│       ├── ha_client.py                    # Home Assistant REST API Client
+│       ├── personality.py                  # Persoenlichkeits-Engine
+│       ├── mood_detector.py                # Stimmungserkennung
+│       ├── memory.py                       # 3-Schichten-Gedaechtnis
+│       ├── semantic_memory.py              # Fakten-Speicher (ChromaDB + Redis)
+│       ├── memory_extractor.py             # LLM-basierte Fakten-Extraktion
+│       ├── function_calling.py             # 10 Tool-Funktionen
+│       ├── function_validator.py           # Sicherheits-Checks
+│       ├── action_planner.py               # Multi-Step Aktionsplanung
+│       ├── proactive.py                    # Proaktive Meldungen
+│       ├── feedback.py                     # Adaptives Feedback-Lernen
+│       ├── autonomy.py                     # Autonomie-Level 1-5
+│       ├── activity.py                     # Aktivitaetserkennung
+│       ├── summarizer.py                   # Tages-/Wochen-/Monats-Summaries
+│       └── websocket.py                    # WebSocket-Verbindungsmanager
+│
+├── addon/                                  # MindHome Add-on (HA, PC 1)
 │   ├── config.yaml                         # Add-on Konfiguration (Ingress, Permissions)
 │   ├── Dockerfile                          # Container-Build
-│   │
 │   └── rootfs/opt/mindhome/               # Anwendungscode
 │       ├── run.sh                          # Startskript
-│       ├── requirements.txt                # Python-Abhängigkeiten
+│       ├── requirements.txt                # Python-Abhaengigkeiten
 │       ├── app.py                          # Flask Backend + API Routen
 │       ├── models.py                       # Datenbank-Modelle (SQLAlchemy)
 │       ├── init_db.py                      # Datenbank-Initialisierung
 │       ├── ha_connection.py                # HA WebSocket + REST API Verbindung
-│       │
-│       ├── translations/                   # Übersetzungen
-│       │   ├── de.json                     # Deutsch
-│       │   └── en.json                     # Englisch
-│       │
-│       ├── domains/                        # [Teil C] Domain Plugin-System
-│       │   └── .gitkeep                    # (wird in Teil C gefüllt)
-│       │
-│       ├── ml/                             # [Phase 2] Machine Learning Engine
-│       │   └── .gitkeep                    # (wird in Phase 2 gefüllt)
-│       │
-│       ├── utils/                          # Hilfsfunktionen
-│       │   └── .gitkeep                    # (wird nach Bedarf gefüllt)
-│       │
-│       └── static/frontend/               # [Teil B] React Frontend
-│           └── .gitkeep                    # (wird in Teil B gefüllt)
+│       ├── routes/                         # API-Routen (15 Blueprints)
+│       ├── engines/                        # 14 Intelligenz-Engines
+│       ├── domains/                        # 23 Domain-Plugins
+│       ├── translations/                   # Uebersetzungen (DE + EN)
+│       └── static/frontend/               # React Frontend
 │
-└── docs/                                   # [Teil E] Dokumentation + Logo
-    └── .gitkeep                            # (wird in Teil E gefüllt)
+└── docs/                                   # Dokumentation
+    ├── UPGRADE_v0.6.0.md                   # Phase 3.5 Upgrade Notes
+    └── PROJECT_MINDHOME_ASSISTANT.md       # Assistant Projekt-Dokumentation
 
 
-Status:
-=======
-[✅] Teil A - Backend Grundgerüst          (fertig)
-[⏳] Teil B - Frontend (React)             (als nächstes)
-[⏳] Teil C - Domain Plugin-System         (danach)
-[⏳] Teil D - Onboarding + Personen-Mgr    (danach)
-[⏳] Teil E - Logo + Feinschliff + README  (zuletzt)
+Architektur:
+============
+
+PC 1: HAOS (Intel NUC)              PC 2: Assistant Server (Ubuntu)
+┌─────────────────────────┐          ┌─────────────────────────────┐
+│  Home Assistant          │          │  Ollama (Qwen 2.5 LLM)     │
+│  MindHome Add-on (:8099) │◄── LAN──►│  MindHome Assistant (:8200) │
+│  Whisper (STT)           │          │  ChromaDB (:8100) Memory    │
+│  Piper (TTS)             │          │  Redis (:6379) Cache        │
+└─────────────────────────┘          └─────────────────────────────┘

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -1,0 +1,17 @@
+# Home Assistant Verbindung
+HA_URL=http://192.168.1.100:8123
+HA_TOKEN=dein_long_lived_access_token_hier
+
+# Ollama (laeuft nativ auf dem Host)
+OLLAMA_URL=http://host.docker.internal:11434
+
+# Datenbanken (Docker-intern)
+REDIS_URL=redis://redis:6379
+CHROMA_URL=http://chromadb:8000
+
+# Benutzer
+USER_NAME=Max
+
+# Server
+ASSISTANT_HOST=0.0.0.0
+ASSISTANT_PORT=8200

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# System-Dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python-Dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# MindHome Assistant Code
+COPY assistant/ ./assistant/
+COPY config/ ./config/
+
+# Port
+EXPOSE 8200
+
+# Health Check
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD curl -f http://localhost:8200/api/assistant/health || exit 1
+
+# Start
+CMD ["python", "-m", "assistant.main"]

--- a/assistant/assistant/__init__.py
+++ b/assistant/assistant/__init__.py
@@ -1,0 +1,1 @@
+"""MindHome Assistant - Lokaler KI-Sprachassistent fuer Home Assistant."""

--- a/assistant/assistant/action_planner.py
+++ b/assistant/assistant/action_planner.py
@@ -1,0 +1,278 @@
+"""
+Action Planner (Phase 4) - Plant und fuehrt komplexe Multi-Step Aktionen aus.
+
+Erkennt komplexe Anfragen die mehrere Schritte brauchen und fuehrt sie
+iterativ aus: LLM plant -> Aktionen ausfuehren -> Ergebnisse zurueck an LLM
+-> weiter planen -> bis fertig.
+
+Beispiele:
+  "Mach alles fertig fuer morgen frueh"
+  -> Kalender checken, Wecker stellen, Klima Nachtmodus, Kaffee-Timer
+
+  "Ich gehe fuer 3 Tage weg"
+  -> Away-Modus, Heizung runter, Rolllaeden zu, Alarm scharf
+"""
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .function_calling import ASSISTANT_TOOLS, FunctionExecutor
+from .function_validator import FunctionValidator
+from .ollama_client import OllamaClient
+from .websocket import emit_action
+
+logger = logging.getLogger(__name__)
+
+# Maximale Iterationen (LLM-Runden) um Endlosschleifen zu verhindern
+MAX_ITERATIONS = 5
+
+# Keywords die auf komplexe Anfragen hindeuten
+COMPLEX_KEYWORDS = [
+    "alles", "fertig machen", "vorbereiten",
+    "gehe weg", "fahre weg", "verreise", "urlaub",
+    "routine", "morgenroutine", "abendroutine",
+    "wenn ich", "falls ich", "bevor ich",
+    "zuerst", "danach", "und dann", "ausserdem",
+    "komplett", "ueberall", "in allen",
+    "party", "besuch kommt", "gaeste",
+]
+
+# Prompt fuer den Action Planner
+PLANNER_SYSTEM_PROMPT = """Du bist der MindHome Action Planner.
+Deine Aufgabe: Komplexe Anfragen in konkrete Aktionen umsetzen.
+
+REGELN:
+- Nutze die verfuegbaren Tools um Aktionen auszufuehren.
+- Fuehre ALLE noetige Schritte aus, nicht nur den ersten.
+- Wenn du Informationen brauchst (z.B. Kalender), frage sie zuerst ab.
+- Ergebnisse vorheriger Schritte nutzen um naechste Schritte zu planen.
+- Am Ende: Kurze Zusammenfassung auf Deutsch (max 2-3 Saetze).
+- Antworte IMMER auf Deutsch.
+- Sei knapp. Butler-Stil. Kein Geschwafel."""
+
+
+@dataclass
+class PlanStep:
+    """Ein einzelner Schritt im Plan."""
+    function: str
+    args: dict
+    result: Optional[dict] = None
+    status: str = "pending"  # pending, running, done, failed, blocked
+
+
+@dataclass
+class ActionPlan:
+    """Ein kompletter Aktionsplan."""
+    request: str
+    steps: list[PlanStep] = field(default_factory=list)
+    summary: str = ""
+    iterations: int = 0
+    needs_confirmation: bool = False
+    confirmation_reasons: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "request": self.request,
+            "steps": [
+                {
+                    "function": s.function,
+                    "args": s.args,
+                    "result": s.result,
+                    "status": s.status,
+                }
+                for s in self.steps
+            ],
+            "summary": self.summary,
+            "iterations": self.iterations,
+            "needs_confirmation": self.needs_confirmation,
+            "confirmation_reasons": self.confirmation_reasons,
+        }
+
+
+class ActionPlanner:
+    """Plant und fuehrt komplexe Multi-Step Aktionen aus."""
+
+    def __init__(
+        self,
+        ollama: OllamaClient,
+        executor: FunctionExecutor,
+        validator: FunctionValidator,
+    ):
+        self.ollama = ollama
+        self.executor = executor
+        self.validator = validator
+        self._last_plan: Optional[ActionPlan] = None
+
+    def is_complex_request(self, text: str) -> bool:
+        """
+        Erkennt ob eine Anfrage komplex ist und den Planner braucht.
+
+        Heuristik:
+        - Enthaelt Keywords fuer komplexe Aktionen
+        - Enthaelt mehrere Befehle (und/dann/ausserdem)
+        """
+        text_lower = text.lower()
+        return any(kw in text_lower for kw in COMPLEX_KEYWORDS)
+
+    async def plan_and_execute(
+        self,
+        text: str,
+        system_prompt: str,
+        context: dict,
+        messages: list[dict],
+    ) -> dict:
+        """
+        Plant und fuehrt eine komplexe Anfrage aus.
+
+        Args:
+            text: User-Anfrage
+            system_prompt: Basis-System-Prompt (inkl. Persoenlichkeit + Memory)
+            context: Aktueller Kontext
+            messages: Bisherige Nachrichten (History)
+
+        Returns:
+            Dict mit response, actions, plan
+        """
+        plan = ActionPlan(request=text)
+
+        # System Prompt fuer Planner erweitern
+        planner_prompt = system_prompt + "\n\n" + PLANNER_SYSTEM_PROMPT
+
+        # Nachrichten fuer den Planner aufbauen
+        planner_messages = [{"role": "system", "content": planner_prompt}]
+        # History uebernehmen (ohne System Prompt)
+        for msg in messages:
+            if msg["role"] != "system":
+                planner_messages.append(msg)
+
+        all_actions = []
+
+        # Iterative Ausfuehrung: LLM -> Tools -> Ergebnisse -> LLM -> ...
+        for iteration in range(MAX_ITERATIONS):
+            plan.iterations = iteration + 1
+
+            logger.info("Action Planner: Iteration %d", iteration + 1)
+
+            # LLM aufrufen (mit Tools + Kontext der bisherigen Ergebnisse)
+            response = await self.ollama.chat(
+                messages=planner_messages,
+                model="qwen2.5:14b",  # Immer smart model fuer Planung
+                tools=ASSISTANT_TOOLS,
+                max_tokens=512,
+            )
+
+            if "error" in response:
+                logger.error("Planner LLM Fehler: %s", response["error"])
+                plan.summary = "Fehler bei der Planung."
+                break
+
+            message = response.get("message", {})
+            response_text = message.get("content", "")
+            tool_calls = message.get("tool_calls", [])
+
+            # Keine weiteren Tool Calls -> LLM ist fertig
+            if not tool_calls:
+                plan.summary = response_text
+                logger.info("Action Planner fertig nach %d Iterationen", iteration + 1)
+                break
+
+            # Tool Calls ausfuehren
+            tool_results = []
+            for tool_call in tool_calls:
+                func = tool_call.get("function", {})
+                func_name = func.get("name", "")
+                func_args = func.get("arguments", {})
+
+                step = PlanStep(function=func_name, args=func_args)
+
+                # Validierung
+                validation = self.validator.validate(func_name, func_args)
+                if not validation.ok:
+                    if validation.needs_confirmation:
+                        step.status = "blocked"
+                        step.result = {"needs_confirmation": True, "reason": validation.reason}
+                        plan.needs_confirmation = True
+                        plan.confirmation_reasons.append(validation.reason)
+                        tool_results.append(
+                            f"BLOCKIERT: {func_name} braucht Bestaetigung - {validation.reason}"
+                        )
+                    else:
+                        step.status = "failed"
+                        step.result = {"success": False, "message": validation.reason}
+                        tool_results.append(
+                            f"FEHLER: {func_name} - {validation.reason}"
+                        )
+                    plan.steps.append(step)
+                    all_actions.append({
+                        "function": func_name,
+                        "args": func_args,
+                        "result": step.result,
+                    })
+                    continue
+
+                # Ausfuehren
+                step.status = "running"
+                result = await self.executor.execute(func_name, func_args)
+                step.result = result
+                step.status = "done" if result.get("success", False) else "failed"
+
+                plan.steps.append(step)
+                all_actions.append({
+                    "function": func_name,
+                    "args": func_args,
+                    "result": result,
+                })
+
+                # WebSocket: Aktion melden
+                await emit_action(func_name, func_args, result)
+
+                tool_results.append(
+                    f"{func_name}: {result.get('message', 'OK')}"
+                )
+
+                logger.info(
+                    "Planner Step: %s(%s) -> %s",
+                    func_name, func_args, result.get("message", ""),
+                )
+
+            # Ergebnisse zurueck an LLM fuer naechste Iteration
+            # Aktuelle Antwort des LLM als assistant message hinzufuegen
+            planner_messages.append({
+                "role": "assistant",
+                "content": response_text or "",
+                "tool_calls": tool_calls,
+            })
+            # Tool-Ergebnisse als tool response
+            planner_messages.append({
+                "role": "tool",
+                "content": "\n".join(tool_results),
+            })
+
+        else:
+            # Max Iterations erreicht
+            logger.warning("Action Planner: Max Iterations erreicht")
+            if not plan.summary:
+                plan.summary = "Plan ausgefuehrt."
+
+        # Fallback-Summary wenn keins vorhanden
+        if not plan.summary and plan.steps:
+            successful = sum(1 for s in plan.steps if s.status == "done")
+            total = len(plan.steps)
+            plan.summary = f"{successful} von {total} Aktionen ausgefuehrt."
+
+        self._last_plan = plan
+
+        return {
+            "response": plan.summary,
+            "actions": all_actions,
+            "plan": plan.to_dict(),
+        }
+
+    def get_last_plan(self) -> Optional[dict]:
+        """Gibt den letzten ausgefuehrten Plan zurueck."""
+        if self._last_plan:
+            return self._last_plan.to_dict()
+        return None

--- a/assistant/assistant/activity.py
+++ b/assistant/assistant/activity.py
@@ -1,0 +1,334 @@
+"""
+Activity Engine + Silence Matrix - Phase 6: Perfektes Timing, nie stoeren.
+
+Erkennt die aktuelle Aktivitaet des Benutzers anhand von HA-Sensoren
+und entscheidet WIE eine Meldung zugestellt werden soll.
+
+Aktivitaeten:
+  sleeping    - Schlaeft (Nacht + Bett belegt + Lichter aus)
+  in_call     - In einem Anruf/Zoom (Mikrofon aktiv)
+  watching    - Schaut Film/TV (Media Player aktiv)
+  focused     - Arbeitet konzentriert (PC aktiv, wenig Bewegung)
+  guests      - Gaeste anwesend (mehrere Personen zu Hause)
+  relaxing    - Entspannt (Standard-Aktivitaet)
+  away        - Nicht zu Hause
+
+Zustellmethoden:
+  tts_loud    - Volle Lautstaerke
+  tts_quiet   - Leise TTS
+  led_blink   - Nur LED-Signal (kein Ton)
+  suppress    - Gar nicht zustellen
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from .config import yaml_config
+from .ha_client import HomeAssistantClient
+
+logger = logging.getLogger(__name__)
+
+
+# Erkannte Aktivitaeten
+SLEEPING = "sleeping"
+IN_CALL = "in_call"
+WATCHING = "watching"
+FOCUSED = "focused"
+GUESTS = "guests"
+RELAXING = "relaxing"
+AWAY = "away"
+
+# Zustellmethoden
+TTS_LOUD = "tts_loud"
+TTS_QUIET = "tts_quiet"
+LED_BLINK = "led_blink"
+SUPPRESS = "suppress"
+
+# Stille-Matrix: Aktivitaet x Urgency -> Zustellmethode
+# Format: {activity: {urgency: delivery_method}}
+SILENCE_MATRIX = {
+    SLEEPING: {
+        "critical": TTS_LOUD,
+        "high": LED_BLINK,
+        "medium": SUPPRESS,
+        "low": SUPPRESS,
+    },
+    IN_CALL: {
+        "critical": LED_BLINK,
+        "high": LED_BLINK,
+        "medium": SUPPRESS,
+        "low": SUPPRESS,
+    },
+    WATCHING: {
+        "critical": TTS_LOUD,
+        "high": LED_BLINK,
+        "medium": SUPPRESS,
+        "low": SUPPRESS,
+    },
+    FOCUSED: {
+        "critical": TTS_LOUD,
+        "high": TTS_QUIET,
+        "medium": TTS_QUIET,
+        "low": SUPPRESS,
+    },
+    GUESTS: {
+        "critical": TTS_LOUD,
+        "high": TTS_QUIET,
+        "medium": TTS_QUIET,
+        "low": SUPPRESS,
+    },
+    RELAXING: {
+        "critical": TTS_LOUD,
+        "high": TTS_LOUD,
+        "medium": TTS_LOUD,
+        "low": TTS_QUIET,
+    },
+    AWAY: {
+        "critical": TTS_LOUD,  # Wird an Handy weitergeleitet (spaeter)
+        "high": SUPPRESS,
+        "medium": SUPPRESS,
+        "low": SUPPRESS,
+    },
+}
+
+
+class ActivityEngine:
+    """Erkennt die aktuelle Aktivitaet des Benutzers."""
+
+    def __init__(self, ha_client: HomeAssistantClient):
+        self.ha = ha_client
+
+        # Konfiguration aus YAML
+        activity_cfg = yaml_config.get("activity", {})
+
+        # Entity-IDs (konfigurierbar pro Installation)
+        entities = activity_cfg.get("entities", {})
+        self.media_players = entities.get("media_players", [
+            "media_player.wohnzimmer",
+            "media_player.fernseher",
+            "media_player.tv",
+        ])
+        self.mic_sensors = entities.get("mic_sensors", [
+            "binary_sensor.mic_active",
+            "binary_sensor.microphone",
+        ])
+        self.bed_sensors = entities.get("bed_sensors", [
+            "binary_sensor.bed_occupancy",
+            "binary_sensor.bett",
+        ])
+        self.pc_sensors = entities.get("pc_sensors", [
+            "binary_sensor.pc_active",
+            "binary_sensor.computer",
+            "switch.pc",
+        ])
+
+        # Schwellwerte
+        thresholds = activity_cfg.get("thresholds", {})
+        self.night_start = thresholds.get("night_start", 22)
+        self.night_end = thresholds.get("night_end", 7)
+        self.guest_person_count = thresholds.get("guest_person_count", 2)
+        self.focus_min_minutes = thresholds.get("focus_min_minutes", 30)
+
+        # Cache: letzte erkannte Aktivitaet
+        self._last_activity = RELAXING
+        self._last_detection = None
+
+    async def detect_activity(self) -> dict:
+        """
+        Erkennt die aktuelle Aktivitaet.
+
+        Returns:
+            Dict mit:
+                activity: str - Erkannte Aktivitaet
+                confidence: float - Wie sicher (0.0-1.0)
+                signals: dict - Erkannte Signale
+                delivery: str - Nicht gesetzt (wird von SilenceMatrix bestimmt)
+        """
+        signals = {}
+        states = await self.ha.get_states()
+
+        if not states:
+            return {
+                "activity": self._last_activity,
+                "confidence": 0.3,
+                "signals": {"ha_unavailable": True},
+            }
+
+        # Signale sammeln
+        signals["away"] = self._check_away(states)
+        signals["media_playing"] = self._check_media_playing(states)
+        signals["in_call"] = self._check_in_call(states)
+        signals["sleeping"] = self._check_sleeping(states)
+        signals["pc_active"] = self._check_pc_active(states)
+        signals["guests"] = self._check_guests(states)
+        signals["lights_off"] = self._check_lights_off(states)
+
+        # Aktivitaet klassifizieren (Prioritaet: hoehere ueberschreiben niedrigere)
+        activity, confidence = self._classify(signals)
+
+        self._last_activity = activity
+        self._last_detection = datetime.now()
+
+        logger.debug(
+            "Aktivitaet erkannt: %s (confidence: %.2f, signals: %s)",
+            activity, confidence, signals,
+        )
+
+        return {
+            "activity": activity,
+            "confidence": confidence,
+            "signals": signals,
+        }
+
+    def get_delivery_method(self, activity: str, urgency: str) -> str:
+        """
+        Bestimmt die Zustellmethode anhand der Stille-Matrix.
+
+        Args:
+            activity: Erkannte Aktivitaet
+            urgency: Dringlichkeit (critical, high, medium, low)
+
+        Returns:
+            Zustellmethode (tts_loud, tts_quiet, led_blink, suppress)
+        """
+        activity_row = SILENCE_MATRIX.get(activity, SILENCE_MATRIX[RELAXING])
+        return activity_row.get(urgency, TTS_LOUD)
+
+    async def should_deliver(self, urgency: str) -> dict:
+        """
+        Kombinierte Methode: Erkennt Aktivitaet und bestimmt Zustellmethode.
+
+        Returns:
+            Dict mit:
+                activity: str - Erkannte Aktivitaet
+                delivery: str - Zustellmethode
+                suppress: bool - Soll die Meldung unterdrueckt werden?
+                confidence: float - Sicherheit der Erkennung
+        """
+        detection = await self.detect_activity()
+        activity = detection["activity"]
+        delivery = self.get_delivery_method(activity, urgency)
+
+        return {
+            "activity": activity,
+            "delivery": delivery,
+            "suppress": delivery == SUPPRESS,
+            "confidence": detection["confidence"],
+            "signals": detection["signals"],
+        }
+
+    # ----- Signal-Erkennung -----
+
+    def _check_away(self, states: list[dict]) -> bool:
+        """Prueft ob niemand zu Hause ist."""
+        for state in states:
+            if state.get("entity_id", "").startswith("person."):
+                if state.get("state") == "home":
+                    return False
+        return True
+
+    def _check_media_playing(self, states: list[dict]) -> bool:
+        """Prueft ob ein Media Player aktiv ist (TV, Film)."""
+        for state in states:
+            entity_id = state.get("entity_id", "")
+            if entity_id.startswith("media_player."):
+                if state.get("state") == "playing":
+                    return True
+        return False
+
+    def _check_in_call(self, states: list[dict]) -> bool:
+        """Prueft ob ein Mikrofon aktiv ist (Call/Zoom)."""
+        for state in states:
+            entity_id = state.get("entity_id", "")
+            if entity_id in self.mic_sensors:
+                if state.get("state") == "on":
+                    return True
+        return False
+
+    def _check_sleeping(self, states: list[dict]) -> bool:
+        """Prueft ob der Benutzer schlaeft (Nacht + Bett + Lichter aus)."""
+        now = datetime.now()
+        is_night = now.hour >= self.night_start or now.hour < self.night_end
+
+        if not is_night:
+            return False
+
+        # Bett belegt?
+        bed_occupied = False
+        for state in states:
+            if state.get("entity_id", "") in self.bed_sensors:
+                if state.get("state") == "on":
+                    bed_occupied = True
+                    break
+
+        # Lichter aus?
+        lights_off = self._check_lights_off(states)
+
+        # Schlaf: Nacht + (Bett belegt ODER alle Lichter aus)
+        return bed_occupied or lights_off
+
+    def _check_pc_active(self, states: list[dict]) -> bool:
+        """Prueft ob der PC aktiv ist (Arbeit/Fokus)."""
+        for state in states:
+            entity_id = state.get("entity_id", "")
+            if entity_id in self.pc_sensors:
+                if state.get("state") in ("on", "active"):
+                    return True
+        return False
+
+    def _check_guests(self, states: list[dict]) -> bool:
+        """Prueft ob Gaeste anwesend sind (mehrere Personen zu Hause)."""
+        persons_home = 0
+        for state in states:
+            if state.get("entity_id", "").startswith("person."):
+                if state.get("state") == "home":
+                    persons_home += 1
+        return persons_home >= self.guest_person_count
+
+    def _check_lights_off(self, states: list[dict]) -> bool:
+        """Prueft ob alle Lichter aus sind."""
+        any_light = False
+        for state in states:
+            entity_id = state.get("entity_id", "")
+            if entity_id.startswith("light."):
+                any_light = True
+                if state.get("state") == "on":
+                    return False
+        # Nur True wenn es ueberhaupt Lichter gibt
+        return any_light
+
+    # ----- Klassifikation -----
+
+    def _classify(self, signals: dict) -> tuple[str, float]:
+        """
+        Klassifiziert die Aktivitaet basierend auf gesammelten Signalen.
+        Prioritaet: away > sleeping > in_call > watching > guests > focused > relaxing
+        """
+        # Niemand zu Hause
+        if signals.get("away"):
+            return AWAY, 0.95
+
+        # Schlaf hat hoechste Prioritaet (nach away)
+        if signals.get("sleeping"):
+            confidence = 0.90 if signals.get("lights_off") else 0.70
+            return SLEEPING, confidence
+
+        # Anruf hat hohe Prioritaet (darf nicht gestoert werden)
+        if signals.get("in_call"):
+            return IN_CALL, 0.95
+
+        # TV/Film schauen
+        if signals.get("media_playing"):
+            return WATCHING, 0.85
+
+        # Gaeste anwesend
+        if signals.get("guests"):
+            return GUESTS, 0.80
+
+        # PC aktiv = Arbeitsmodus
+        if signals.get("pc_active"):
+            return FOCUSED, 0.70
+
+        # Standard: Entspannt
+        return RELAXING, 0.60

--- a/assistant/assistant/autonomy.py
+++ b/assistant/assistant/autonomy.py
@@ -1,0 +1,99 @@
+"""
+Autonomy Manager - Bestimmt was der Assistent selbststaendig tun darf.
+Level 1 (Assistent) bis Level 5 (Autopilot).
+"""
+
+import logging
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+
+# Welches Level fuer welche Aktion noetig ist
+ACTION_PERMISSIONS = {
+    # Level 1: Assistent - nur auf Befehle reagieren
+    "respond_to_command": 1,
+    "execute_function_call": 1,
+
+    # Level 2: Butler - proaktive Infos
+    "proactive_info": 2,
+    "morning_briefing": 2,
+    "arrival_greeting": 2,
+    "security_alert": 1,  # Immer, auch bei Level 1
+
+    # Level 3: Mitbewohner - kleine Aenderungen
+    "adjust_temperature_small": 3,  # +/- 1 Grad
+    "adjust_light_auto": 3,
+    "pause_reminder": 3,
+
+    # Level 4: Vertrauter - Routinen anpassen
+    "modify_routine": 4,
+    "suggest_scene": 4,
+    "learn_preferences": 4,
+
+    # Level 5: Autopilot - Automationen erstellen
+    "create_automation": 5,
+    "modify_schedule": 5,
+}
+
+
+class AutonomyManager:
+    """Verwaltet das Autonomie-Level des Assistenten."""
+
+    def __init__(self):
+        self.level = settings.autonomy_level
+
+    def can_act(self, action_type: str) -> bool:
+        """
+        Prueft ob der Assistent diese Aktion ausfuehren darf.
+
+        Args:
+            action_type: Art der Aktion (z.B. "proactive_info")
+
+        Returns:
+            True wenn erlaubt
+        """
+        required_level = ACTION_PERMISSIONS.get(action_type, 5)
+        allowed = self.level >= required_level
+        if not allowed:
+            logger.debug(
+                "Aktion '%s' braucht Level %d, aktuell: %d",
+                action_type, required_level, self.level,
+            )
+        return allowed
+
+    def set_level(self, level: int) -> bool:
+        """Setzt ein neues Autonomie-Level (1-5)."""
+        if 1 <= level <= 5:
+            old = self.level
+            self.level = level
+            logger.info("Autonomie-Level: %d -> %d", old, level)
+            return True
+        return False
+
+    def get_level_info(self) -> dict:
+        """Gibt Info ueber das aktuelle Level zurueck."""
+        names = {
+            1: "Assistent",
+            2: "Butler",
+            3: "Mitbewohner",
+            4: "Vertrauter",
+            5: "Autopilot",
+        }
+        descriptions = {
+            1: "Reagiert nur auf direkte Befehle",
+            2: "Proaktive Infos (Briefing, Warnungen)",
+            3: "Darf kleine Aenderungen selbst machen (Licht, Temp +/-1)",
+            4: "Darf Routinen anpassen, Szenen vorschlagen",
+            5: "Darf neue Automationen erstellen (mit Bestaetigung)",
+        }
+        return {
+            "level": self.level,
+            "name": names.get(self.level, "Unbekannt"),
+            "description": descriptions.get(self.level, ""),
+            "allowed_actions": [
+                action for action, req in ACTION_PERMISSIONS.items()
+                if self.level >= req
+            ],
+        }

--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -1,0 +1,371 @@
+"""
+MindHome Assistant Brain - Das zentrale Gehirn.
+Verbindet alle Komponenten: Context Builder, Model Router, Personality,
+Function Calling, Memory, Autonomy, Memory Extractor und Action Planner.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+from .action_planner import ActionPlanner
+from .activity import ActivityEngine
+from .autonomy import AutonomyManager
+from .config import settings
+from .context_builder import ContextBuilder
+from .feedback import FeedbackTracker
+from .function_calling import ASSISTANT_TOOLS, FunctionExecutor
+from .function_validator import FunctionValidator
+from .ha_client import HomeAssistantClient
+from .memory import MemoryManager
+from .memory_extractor import MemoryExtractor
+from .model_router import ModelRouter
+from .mood_detector import MoodDetector
+from .ollama_client import OllamaClient
+from .personality import PersonalityEngine
+from .proactive import ProactiveManager
+from .summarizer import DailySummarizer
+from .websocket import emit_thinking, emit_speaking, emit_action
+
+logger = logging.getLogger(__name__)
+
+
+class AssistantBrain:
+    """Das zentrale Gehirn von MindHome Assistant."""
+
+    def __init__(self):
+        # Clients
+        self.ha = HomeAssistantClient()
+        self.ollama = OllamaClient()
+
+        # Komponenten
+        self.context_builder = ContextBuilder(self.ha)
+        self.model_router = ModelRouter()
+        self.personality = PersonalityEngine()
+        self.executor = FunctionExecutor(self.ha)
+        self.validator = FunctionValidator()
+        self.memory = MemoryManager()
+        self.autonomy = AutonomyManager()
+        self.feedback = FeedbackTracker()
+        self.activity = ActivityEngine(self.ha)
+        self.proactive = ProactiveManager(self)
+        self.summarizer = DailySummarizer(self.ollama)
+        self.memory_extractor: Optional[MemoryExtractor] = None
+        self.mood = MoodDetector()
+        self.action_planner = ActionPlanner(self.ollama, self.executor, self.validator)
+
+    async def initialize(self):
+        """Initialisiert alle Komponenten."""
+        await self.memory.initialize()
+
+        # Semantic Memory mit Context Builder verbinden
+        self.context_builder.set_semantic_memory(self.memory.semantic)
+
+        # Activity Engine mit Context Builder verbinden (Phase 6)
+        self.context_builder.set_activity_engine(self.activity)
+
+        # Mood Detector initialisieren (Phase 3)
+        await self.mood.initialize(redis_client=self.memory.redis)
+        self.personality.set_mood_detector(self.mood)
+
+        # Memory Extractor initialisieren
+        self.memory_extractor = MemoryExtractor(self.ollama, self.memory.semantic)
+
+        # Feedback Tracker initialisieren (Phase 5)
+        await self.feedback.initialize(redis_client=self.memory.redis)
+
+        # Daily Summarizer initialisieren (Phase 7)
+        self.summarizer.memory = self.memory
+        await self.summarizer.initialize(
+            redis_client=self.memory.redis,
+            chroma_collection=self.memory.chroma_collection,
+        )
+
+        await self.proactive.start()
+        logger.info("Jarvis initialisiert (alle Systeme aktiv)")
+
+    async def process(self, text: str, person: Optional[str] = None) -> dict:
+        """
+        Verarbeitet eine User-Eingabe.
+
+        Args:
+            text: User-Text (z.B. "Mach das Licht aus")
+            person: Name der Person (optional)
+
+        Returns:
+            Dict mit response, actions, model_used
+        """
+        logger.info("Input: '%s' (Person: %s)", text, person or "unbekannt")
+
+        # WebSocket: Denk-Status senden
+        await emit_thinking()
+
+        # 1. Kontext sammeln (inkl. semantischer Erinnerungen)
+        context = await self.context_builder.build(
+            trigger="voice", user_text=text, person=person or ""
+        )
+        if person:
+            context.setdefault("person", {})["name"] = person
+
+        # 2. Stimmungsanalyse (Phase 3)
+        mood_result = await self.mood.analyze(text, person or "")
+        context["mood"] = mood_result
+
+        # 3. Modell waehlen
+        model = self.model_router.select_model(text)
+
+        # 4. System Prompt bauen (mit semantischen Erinnerungen + Stimmung)
+        system_prompt = self.personality.build_system_prompt(context)
+
+        # Semantische Erinnerungen zum System Prompt hinzufuegen
+        memories = context.get("memories", {})
+        memory_context = self._build_memory_context(memories)
+        if memory_context:
+            system_prompt += memory_context
+
+        # Langzeit-Summaries bei Fragen ueber die Vergangenheit (Phase 7)
+        summary_context = await self._get_summary_context(text)
+        if summary_context:
+            system_prompt += summary_context
+
+        # 5. Letzte Gespraeche laden (Working Memory)
+        recent = await self.memory.get_recent_conversations(limit=5)
+        messages = [{"role": "system", "content": system_prompt}]
+        for conv in recent:
+            messages.append({"role": conv["role"], "content": conv["content"]})
+        messages.append({"role": "user", "content": text})
+
+        # 6. Komplexe Anfragen ueber Action Planner routen
+        if self.action_planner.is_complex_request(text):
+            logger.info("Komplexe Anfrage erkannt -> Action Planner")
+            planner_result = await self.action_planner.plan_and_execute(
+                text=text,
+                system_prompt=system_prompt,
+                context=context,
+                messages=messages,
+            )
+            response_text = planner_result.get("response", "")
+            executed_actions = planner_result.get("actions", [])
+            model = "qwen2.5:14b"  # Planner nutzt immer smart model
+        else:
+            # 6b. Einfache Anfragen: Direkt LLM aufrufen
+            response = await self.ollama.chat(
+                messages=messages,
+                model=model,
+                tools=ASSISTANT_TOOLS,
+            )
+
+            if "error" in response:
+                logger.error("LLM Fehler: %s", response["error"])
+                return {
+                    "response": "Da stimmt etwas nicht. Ich kann gerade nicht denken.",
+                    "actions": [],
+                    "model_used": model,
+                    "error": response["error"],
+                }
+
+            # 7. Antwort verarbeiten
+            message = response.get("message", {})
+            response_text = message.get("content", "")
+            tool_calls = message.get("tool_calls", [])
+            executed_actions = []
+
+            # 8. Function Calls ausfuehren
+            if tool_calls:
+                for tool_call in tool_calls:
+                    func = tool_call.get("function", {})
+                    func_name = func.get("name", "")
+                    func_args = func.get("arguments", {})
+
+                    logger.info("Function Call: %s(%s)", func_name, func_args)
+
+                    # Validierung
+                    validation = self.validator.validate(func_name, func_args)
+                    if not validation.ok:
+                        if validation.needs_confirmation:
+                            response_text = f"Sicherheitsbestaetigung noetig: {validation.reason}"
+                            executed_actions.append({
+                                "function": func_name,
+                                "args": func_args,
+                                "result": "needs_confirmation",
+                            })
+                            continue
+                        else:
+                            logger.warning("Validation failed: %s", validation.reason)
+                            executed_actions.append({
+                                "function": func_name,
+                                "args": func_args,
+                                "result": f"blocked: {validation.reason}",
+                            })
+                            continue
+
+                    # Ausfuehren
+                    result = await self.executor.execute(func_name, func_args)
+                    executed_actions.append({
+                        "function": func_name,
+                        "args": func_args,
+                        "result": result,
+                    })
+
+                    # WebSocket: Aktion melden
+                    await emit_action(func_name, func_args, result)
+
+            # Wenn Aktionen, aber keine Text-Antwort: Standard-Bestaetigung
+            if executed_actions and not response_text:
+                if all(a["result"].get("success", False) for a in executed_actions if isinstance(a["result"], dict)):
+                    response_text = "Erledigt."
+                else:
+                    failed = [
+                        a["result"].get("message", "")
+                        for a in executed_actions
+                        if isinstance(a["result"], dict) and not a["result"].get("success", False)
+                    ]
+                    response_text = f"Problem: {', '.join(failed)}" if failed else "Teilweise erledigt."
+
+        # 8. Im Gedaechtnis speichern
+        await self.memory.add_conversation("user", text)
+        await self.memory.add_conversation("assistant", response_text)
+
+        # 9. Episode speichern (Langzeitgedaechtnis)
+        if len(text.split()) > 3:  # Nur bei substantiellen Gespraechen
+            episode = f"User: {text}\nAssistant: {response_text}"
+            await self.memory.store_episode(episode, {
+                "person": person or "unknown",
+                "room": context.get("room", "unknown"),
+                "actions": json.dumps([a["function"] for a in executed_actions]),
+            })
+
+        # 10. Fakten extrahieren (async im Hintergrund - blockiert nicht)
+        if self.memory_extractor and len(text.split()) > 3:
+            asyncio.create_task(
+                self._extract_facts_background(
+                    text, response_text, person or "unknown", context
+                )
+            )
+
+        result = {
+            "response": response_text,
+            "actions": executed_actions,
+            "model_used": model,
+            "context_room": context.get("room", "unbekannt"),
+        }
+        # WebSocket: Antwort senden
+        await emit_speaking(response_text)
+
+        logger.info("Output: '%s' (Aktionen: %d)", response_text, len(executed_actions))
+        return result
+
+    async def health_check(self) -> dict:
+        """Prueft den Zustand aller Komponenten."""
+        ollama_ok = await self.ollama.is_available()
+        ha_ok = await self.ha.is_available()
+
+        models = await self.ollama.list_models() if ollama_ok else []
+
+        return {
+            "status": "ok" if (ollama_ok and ha_ok) else "degraded",
+            "components": {
+                "ollama": "connected" if ollama_ok else "disconnected",
+                "home_assistant": "connected" if ha_ok else "disconnected",
+                "redis": "connected" if self.memory.redis else "disconnected",
+                "chromadb": "connected" if self.memory.chroma_collection else "disconnected",
+                "semantic_memory": "connected" if self.memory.semantic.chroma_collection else "disconnected",
+                "memory_extractor": "active" if self.memory_extractor else "inactive",
+                "mood_detector": f"active (mood: {self.mood.get_current_mood()['mood']})",
+                "action_planner": "active",
+                "feedback_tracker": "running" if self.feedback._running else "stopped",
+                "activity_engine": "active",
+                "summarizer": "running" if self.summarizer._running else "stopped",
+                "proactive": "running" if self.proactive._running else "stopped",
+            },
+            "models_available": models,
+            "autonomy": self.autonomy.get_level_info(),
+        }
+
+    def _build_memory_context(self, memories: dict) -> str:
+        """Baut den Gedaechtnis-Abschnitt fuer den System Prompt."""
+        parts = []
+
+        relevant = memories.get("relevant_facts", [])
+        person_facts = memories.get("person_facts", [])
+
+        if relevant:
+            parts.append("\nRELEVANTE ERINNERUNGEN:")
+            for fact in relevant:
+                parts.append(f"- {fact}")
+
+        if person_facts:
+            parts.append("\nBEKANNTE FAKTEN UEBER DEN USER:")
+            for fact in person_facts:
+                parts.append(f"- {fact}")
+
+        if parts:
+            parts.insert(0, "\n\nGEDAECHTNIS (nutze diese Infos wenn relevant):")
+            return "\n".join(parts)
+
+        return ""
+
+    async def _get_summary_context(self, text: str) -> str:
+        """Holt relevante Langzeit-Summaries wenn die Frage die Vergangenheit betrifft."""
+        # Keywords die auf Vergangenheits-Fragen hindeuten
+        past_keywords = [
+            "gestern", "letzte woche", "letzten monat", "letztes jahr",
+            "vor ", "frueher", "damals", "wann war", "wie war",
+            "erinnerst du", "weisst du noch", "war der", "war die",
+            "im januar", "im februar", "im maerz", "im april", "im mai",
+            "im juni", "im juli", "im august", "im september",
+            "im oktober", "im november", "im dezember",
+            "letzte", "letzten", "letzter", "vorige", "vergangene",
+        ]
+
+        text_lower = text.lower()
+        if not any(kw in text_lower for kw in past_keywords):
+            return ""
+
+        try:
+            summaries = await self.summarizer.search_summaries(text, limit=3)
+            if not summaries:
+                return ""
+
+            parts = ["\n\nLANGZEIT-ERINNERUNGEN (vergangene Tage/Wochen):"]
+            for s in summaries:
+                date = s.get("date", "")
+                stype = s.get("summary_type", "")
+                content = s.get("content", "")
+                parts.append(f"[{stype} {date}]: {content}")
+
+            return "\n".join(parts)
+        except Exception as e:
+            logger.debug("Fehler bei Summary-Kontext: %s", e)
+            return ""
+
+    async def _extract_facts_background(
+        self,
+        user_text: str,
+        assistant_response: str,
+        person: str,
+        context: dict,
+    ):
+        """Extrahiert Fakten im Hintergrund (non-blocking)."""
+        try:
+            facts = await self.memory_extractor.extract_and_store(
+                user_text=user_text,
+                assistant_response=assistant_response,
+                person=person,
+                context=context,
+            )
+            if facts:
+                logger.info(
+                    "Hintergrund-Extraktion: %d Fakt(en) gespeichert", len(facts)
+                )
+        except Exception as e:
+            logger.error("Fehler bei Hintergrund-Fakten-Extraktion: %s", e)
+
+    async def shutdown(self):
+        """Faehrt MindHome Assistant herunter."""
+        await self.proactive.stop()
+        await self.summarizer.stop()
+        await self.feedback.stop()
+        await self.memory.close()
+        logger.info("MindHome Assistant heruntergefahren")

--- a/assistant/assistant/config.py
+++ b/assistant/assistant/config.py
@@ -1,0 +1,57 @@
+"""
+Zentrale Konfiguration - liest .env und settings.yaml
+"""
+
+import os
+from pathlib import Path
+
+import yaml
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Umgebungsvariablen aus .env"""
+
+    # Home Assistant
+    ha_url: str = "http://192.168.1.100:8123"
+    ha_token: str = ""
+
+    # MindHome
+    mindhome_url: str = "http://192.168.1.100:8099"
+
+    # Ollama
+    ollama_url: str = "http://localhost:11434"
+    model_fast: str = "qwen2.5:3b"
+    model_smart: str = "qwen2.5:14b"
+
+    # MindHome Assistant Server
+    assistant_host: str = "0.0.0.0"
+    assistant_port: int = 8200
+
+    # Redis + ChromaDB
+    redis_url: str = "redis://localhost:6379"
+    chroma_url: str = "http://localhost:8100"
+
+    # User
+    user_name: str = "Max"
+    autonomy_level: int = 2
+    language: str = "de"
+
+    # Assistent-Identitaet
+    assistant_name: str = "MindHome Assistant"
+
+    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+
+
+def load_yaml_config() -> dict:
+    """Laedt settings.yaml"""
+    config_path = Path(__file__).parent.parent / "config" / "settings.yaml"
+    if config_path.exists():
+        with open(config_path) as f:
+            return yaml.safe_load(f)
+    return {}
+
+
+# Globale Instanzen
+settings = Settings()
+yaml_config = load_yaml_config()

--- a/assistant/assistant/context_builder.py
+++ b/assistant/assistant/context_builder.py
@@ -1,0 +1,285 @@
+"""
+Context Builder - Sammelt alle relevanten Daten fuer den LLM-Prompt.
+Holt Daten von Home Assistant, MindHome und Semantic Memory via REST API.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from .ha_client import HomeAssistantClient
+from .semantic_memory import SemanticMemory
+
+logger = logging.getLogger(__name__)
+
+# Relevante Entity-Typen fuer den Kontext
+RELEVANT_DOMAINS = [
+    "light", "climate", "cover", "scene", "person",
+    "weather", "sensor", "binary_sensor", "media_player",
+    "lock", "alarm_control_panel",
+]
+
+
+class ContextBuilder:
+    """Baut den vollstaendigen Kontext fuer das LLM zusammen."""
+
+    def __init__(self, ha_client: HomeAssistantClient):
+        self.ha = ha_client
+        self.semantic: Optional[SemanticMemory] = None
+        self._activity_engine = None
+
+    def set_semantic_memory(self, semantic: SemanticMemory):
+        """Setzt die Referenz zum Semantic Memory."""
+        self.semantic = semantic
+
+    def set_activity_engine(self, activity_engine):
+        """Setzt die Referenz zur Activity Engine (Phase 6)."""
+        self._activity_engine = activity_engine
+
+    async def build(
+        self, trigger: str = "voice", user_text: str = "", person: str = ""
+    ) -> dict:
+        """
+        Sammelt den kompletten Kontext.
+
+        Args:
+            trigger: Was den Kontext ausloest ("voice", "proactive", "api")
+            user_text: User-Eingabe fuer semantische Suche
+            person: Name der Person
+
+        Returns:
+            Strukturierter Kontext als Dict
+        """
+        context = {}
+
+        # Zeitkontext
+        now = datetime.now()
+        context["time"] = {
+            "datetime": now.strftime("%Y-%m-%d %H:%M"),
+            "weekday": self._weekday_german(now.weekday()),
+            "time_of_day": self._get_time_of_day(now.hour),
+        }
+
+        # Haus-Status von HA
+        states = await self.ha.get_states()
+        if states:
+            context["house"] = self._extract_house_status(states)
+            context["person"] = self._extract_person(states)
+            context["room"] = self._guess_current_room(states)
+
+        # MindHome-Daten (optional, falls MindHome installiert)
+        mindhome_data = await self._get_mindhome_data()
+        if mindhome_data:
+            context["mindhome"] = mindhome_data
+
+        # Aktivitaets-Erkennung (Phase 6)
+        if self._activity_engine:
+            try:
+                detection = await self._activity_engine.detect_activity()
+                context["activity"] = {
+                    "current": detection["activity"],
+                    "confidence": detection["confidence"],
+                }
+            except Exception as e:
+                logger.debug("Activity Engine Fehler: %s", e)
+
+        # Warnungen
+        context["alerts"] = self._extract_alerts(states or [])
+
+        # Semantisches Gedaechtnis - relevante Fakten zur Anfrage
+        if self.semantic and user_text:
+            context["memories"] = await self._get_relevant_memories(
+                user_text, person
+            )
+
+        return context
+
+    async def _get_relevant_memories(
+        self, user_text: str, person: str = ""
+    ) -> dict:
+        """Holt relevante Fakten aus dem semantischen Gedaechtnis."""
+        memories = {"relevant_facts": [], "person_facts": []}
+
+        if not self.semantic:
+            return memories
+
+        try:
+            # Fakten die zur aktuellen Anfrage passen
+            relevant = await self.semantic.search_facts(
+                query=user_text, limit=3, person=person or None
+            )
+            memories["relevant_facts"] = [
+                f["content"] for f in relevant if f.get("relevance", 0) > 0.3
+            ]
+
+            # Allgemeine Fakten ueber die Person (Praeferenzen)
+            if person:
+                person_facts = await self.semantic.get_facts_by_person(person)
+                # Top-5 mit hoechster Confidence
+                memories["person_facts"] = [
+                    f["content"] for f in person_facts[:5]
+                    if f.get("confidence", 0) >= 0.6
+                ]
+        except Exception as e:
+            logger.error("Fehler beim Laden semantischer Erinnerungen: %s", e)
+
+        return memories
+
+    def _extract_house_status(self, states: list[dict]) -> dict:
+        """Extrahiert den Haus-Status aus HA States."""
+        house = {
+            "temperatures": {},
+            "lights": [],
+            "presence": {"home": [], "away": []},
+            "weather": {},
+            "active_scenes": [],
+            "security": "unknown",
+            "media": [],
+        }
+
+        for state in states:
+            entity_id = state.get("entity_id", "")
+            s = state.get("state", "")
+            attrs = state.get("attributes", {})
+            domain = entity_id.split(".")[0] if "." in entity_id else ""
+
+            # Temperaturen
+            if domain == "climate":
+                room = attrs.get("friendly_name", entity_id)
+                house["temperatures"][room] = {
+                    "current": attrs.get("current_temperature"),
+                    "target": attrs.get("temperature"),
+                    "mode": s,
+                }
+
+            # Lichter (nur die an sind)
+            elif domain == "light" and s == "on":
+                name = attrs.get("friendly_name", entity_id)
+                brightness = attrs.get("brightness")
+                if brightness:
+                    pct = round(brightness / 255 * 100)
+                    house["lights"].append(f"{name}: {pct}%")
+                else:
+                    house["lights"].append(f"{name}: an")
+
+            # Personen
+            elif domain == "person":
+                name = attrs.get("friendly_name", entity_id)
+                if s == "home":
+                    house["presence"]["home"].append(name)
+                else:
+                    house["presence"]["away"].append(name)
+
+            # Wetter
+            elif domain == "weather" and not house["weather"]:
+                house["weather"] = {
+                    "temp": attrs.get("temperature"),
+                    "condition": s,
+                    "humidity": attrs.get("humidity"),
+                }
+
+            # Alarm
+            elif domain == "alarm_control_panel":
+                house["security"] = s
+
+            # Medien
+            elif domain == "media_player" and s == "playing":
+                name = attrs.get("friendly_name", entity_id)
+                title = attrs.get("media_title", "")
+                house["media"].append(f"{name}: {title}" if title else name)
+
+        return house
+
+    def _extract_person(self, states: list[dict]) -> dict:
+        """Findet die aktive Person."""
+        for state in states:
+            if state.get("entity_id", "").startswith("person."):
+                if state.get("state") == "home":
+                    return {
+                        "name": state.get("attributes", {}).get(
+                            "friendly_name", "User"
+                        ),
+                        "last_room": "unbekannt",
+                    }
+        return {"name": "User", "last_room": "unbekannt"}
+
+    def _guess_current_room(self, states: list[dict]) -> str:
+        """Versucht den aktuellen Raum zu erraten (letzte Bewegung)."""
+        latest_motion = None
+        latest_room = "unbekannt"
+
+        for state in states:
+            entity_id = state.get("entity_id", "")
+            if (
+                "motion" in entity_id
+                and state.get("state") == "on"
+            ):
+                last_changed = state.get("last_changed", "")
+                if not latest_motion or last_changed > latest_motion:
+                    latest_motion = last_changed
+                    name = state.get("attributes", {}).get(
+                        "friendly_name", entity_id
+                    )
+                    latest_room = name.replace("Bewegung ", "").replace(" Motion", "")
+
+        return latest_room
+
+    def _extract_alerts(self, states: list[dict]) -> list[str]:
+        """Extrahiert aktive Warnungen."""
+        alerts = []
+        for state in states:
+            entity_id = state.get("entity_id", "")
+            s = state.get("state", "")
+
+            # Rauchmelder, Wassermelder, etc.
+            if any(x in entity_id for x in ["smoke", "water_leak", "gas"]):
+                if s == "on":
+                    name = state.get("attributes", {}).get(
+                        "friendly_name", entity_id
+                    )
+                    alerts.append(f"ALARM: {name}")
+
+            # Fenster/Tueren offen bei Alarm
+            if "door" in entity_id or "window" in entity_id:
+                if s == "on":
+                    name = state.get("attributes", {}).get(
+                        "friendly_name", entity_id
+                    )
+                    alerts.append(f"Offen: {name}")
+
+        return alerts
+
+    async def _get_mindhome_data(self) -> Optional[dict]:
+        """Holt optionale MindHome-Daten."""
+        try:
+            data = {}
+            presence = await self.ha.get_presence()
+            if presence:
+                data["presence"] = presence
+            energy = await self.ha.get_energy()
+            if energy:
+                data["energy"] = energy
+            return data if data else None
+        except Exception as e:
+            logger.debug("MindHome nicht verfuegbar: %s", e)
+            return None
+
+    @staticmethod
+    def _get_time_of_day(hour: int) -> str:
+        if 5 <= hour < 8:
+            return "early_morning"
+        elif 8 <= hour < 12:
+            return "morning"
+        elif 12 <= hour < 18:
+            return "afternoon"
+        elif 18 <= hour < 22:
+            return "evening"
+        return "night"
+
+    @staticmethod
+    def _weekday_german(weekday: int) -> str:
+        days = [
+            "Montag", "Dienstag", "Mittwoch", "Donnerstag",
+            "Freitag", "Samstag", "Sonntag",
+        ]
+        return days[weekday]

--- a/assistant/assistant/feedback.py
+++ b/assistant/assistant/feedback.py
@@ -1,0 +1,384 @@
+"""
+Feedback Tracker - Phase 5: Der MindHome Assistant lernt aus Reaktionen.
+
+Verfolgt wie der Benutzer auf proaktive Meldungen reagiert und passt
+das Verhalten entsprechend an:
+- Oft ignorierte Meldungen -> seltener senden
+- Geschaetzte Meldungen -> haeufiger senden
+- Adaptiver Cooldown pro Event-Typ
+- Auto-Timeout: Keine Reaktion = "ignored"
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+import redis.asyncio as redis
+
+from .config import yaml_config
+
+logger = logging.getLogger(__name__)
+
+# Feedback-Typen und ihre Score-Deltas
+FEEDBACK_DELTAS = {
+    "ignored": -0.05,    # Keine Reaktion (Auto-Timeout)
+    "dismissed": -0.10,  # Aktiv weggeklickt
+    "acknowledged": 0.05,  # Zur Kenntnis genommen
+    "engaged": 0.10,     # Drauf eingegangen
+    "thanked": 0.20,     # Bedankt
+}
+
+# Standard-Score fuer neue Event-Typen
+DEFAULT_SCORE = 0.5
+
+# Score-Grenzen fuer Entscheidungen
+SCORE_SUPPRESS = 0.15     # Unter diesem Wert: nicht mehr senden
+SCORE_REDUCE = 0.30       # Unter diesem Wert: laengerer Cooldown
+SCORE_NORMAL = 0.50       # Normaler Cooldown
+SCORE_BOOST = 0.70        # Ueber diesem Wert: kuerzerer Cooldown
+
+
+class FeedbackTracker:
+    """Verfolgt und lernt aus Benutzer-Feedback auf proaktive Meldungen."""
+
+    def __init__(self):
+        self.redis: Optional[redis.Redis] = None
+
+        # Pending notifications: warten auf Feedback
+        # {notification_id: {"event_type": str, "sent_at": datetime}}
+        self._pending: dict[str, dict] = {}
+
+        # Auto-Timeout Task
+        self._timeout_task: Optional[asyncio.Task] = None
+        self._running = False
+
+        # Konfiguration aus YAML laden
+        feedback_cfg = yaml_config.get("feedback", {})
+        self.auto_timeout_seconds = feedback_cfg.get("auto_timeout_seconds", 120)
+        self.base_cooldown_seconds = feedback_cfg.get("base_cooldown_seconds", 300)
+
+    async def initialize(self, redis_client: Optional[redis.Redis] = None):
+        """Initialisiert den Tracker mit Redis-Verbindung."""
+        self.redis = redis_client
+        self._running = True
+        self._timeout_task = asyncio.create_task(self._auto_timeout_loop())
+        logger.info("FeedbackTracker initialisiert")
+
+    async def stop(self):
+        """Stoppt den Auto-Timeout Loop."""
+        self._running = False
+        if self._timeout_task:
+            self._timeout_task.cancel()
+            try:
+                await self._timeout_task
+            except asyncio.CancelledError:
+                pass
+
+    # ----- Notification Tracking -----
+
+    async def track_notification(self, notification_id: str, event_type: str):
+        """Registriert eine gesendete proaktive Meldung (wartet auf Feedback)."""
+        self._pending[notification_id] = {
+            "event_type": event_type,
+            "sent_at": datetime.now(),
+        }
+
+        # Gesamt-Zaehler erhoehen
+        await self._increment_counter(event_type, "total_sent")
+
+        logger.debug(
+            "Notification tracked: %s (type: %s)", notification_id, event_type
+        )
+
+    async def record_feedback(
+        self, notification_id: str, feedback_type: str
+    ) -> Optional[dict]:
+        """
+        Verarbeitet Feedback auf eine proaktive Meldung.
+
+        Args:
+            notification_id: ID der Meldung (oder event_type als Fallback)
+            feedback_type: ignored, dismissed, acknowledged, engaged, thanked
+
+        Returns:
+            Dict mit neuem Score und event_type, oder None bei Fehler.
+        """
+        if feedback_type not in FEEDBACK_DELTAS:
+            logger.warning("Unbekannter Feedback-Typ: %s", feedback_type)
+            return None
+
+        # Event-Typ ermitteln
+        event_type = None
+        if notification_id in self._pending:
+            event_type = self._pending.pop(notification_id)["event_type"]
+        else:
+            # Fallback: notification_id ist der event_type
+            event_type = notification_id
+
+        if not event_type:
+            return None
+
+        delta = FEEDBACK_DELTAS[feedback_type]
+
+        # Score aktualisieren
+        new_score = await self._update_score(event_type, delta)
+
+        # Feedback-History speichern
+        await self._store_feedback_entry(event_type, feedback_type, delta)
+
+        # Zaehler aktualisieren
+        await self._increment_counter(event_type, feedback_type)
+
+        logger.info(
+            "Feedback [%s] fuer '%s': %+.2f -> Score: %.2f",
+            feedback_type, event_type, delta, new_score,
+        )
+
+        return {
+            "event_type": event_type,
+            "feedback_type": feedback_type,
+            "delta": delta,
+            "new_score": new_score,
+        }
+
+    # ----- Score & Entscheidungen -----
+
+    async def get_score(self, event_type: str) -> float:
+        """Holt den aktuellen Feedback-Score fuer einen Event-Typ."""
+        if not self.redis:
+            return DEFAULT_SCORE
+        score = await self.redis.get(f"mha:feedback:score:{event_type}")
+        return float(score) if score else DEFAULT_SCORE
+
+    async def should_notify(self, event_type: str, urgency: str) -> dict:
+        """
+        Entscheidet ob eine proaktive Meldung gesendet werden soll.
+
+        Returns:
+            Dict mit:
+                allow: bool - Meldung senden?
+                reason: str - Begruendung
+                cooldown: int - Empfohlener Cooldown in Sekunden
+        """
+        # Critical immer durchlassen
+        if urgency == "critical":
+            return {
+                "allow": True,
+                "reason": "critical_always_allowed",
+                "cooldown": 0,
+            }
+
+        score = await self.get_score(event_type)
+
+        # HIGH: nur unterdruecken wenn Score sehr niedrig
+        if urgency == "high":
+            if score < SCORE_SUPPRESS:
+                return {
+                    "allow": False,
+                    "reason": f"score_too_low ({score:.2f})",
+                    "cooldown": 0,
+                }
+            return {
+                "allow": True,
+                "reason": "high_priority",
+                "cooldown": self._calculate_cooldown(score),
+            }
+
+        # MEDIUM: unterdruecken wenn Score niedrig
+        if urgency == "medium":
+            if score < SCORE_REDUCE:
+                return {
+                    "allow": False,
+                    "reason": f"score_too_low ({score:.2f})",
+                    "cooldown": 0,
+                }
+            return {
+                "allow": True,
+                "reason": "score_ok",
+                "cooldown": self._calculate_cooldown(score),
+            }
+
+        # LOW: strenger filtern
+        if score < SCORE_NORMAL:
+            return {
+                "allow": False,
+                "reason": f"low_priority_score_insufficient ({score:.2f})",
+                "cooldown": 0,
+            }
+
+        return {
+            "allow": True,
+            "reason": "score_ok",
+            "cooldown": self._calculate_cooldown(score),
+        }
+
+    def _calculate_cooldown(self, score: float) -> int:
+        """Berechnet den adaptiven Cooldown basierend auf dem Score."""
+        if score >= SCORE_BOOST:
+            # Guter Score -> kuerzerer Cooldown (60% der Basis)
+            return int(self.base_cooldown_seconds * 0.6)
+        elif score >= SCORE_NORMAL:
+            # Normaler Score -> Standard-Cooldown
+            return self.base_cooldown_seconds
+        elif score >= SCORE_REDUCE:
+            # Niedriger Score -> laengerer Cooldown (200% der Basis)
+            return int(self.base_cooldown_seconds * 2.0)
+        else:
+            # Sehr niedrig -> sehr langer Cooldown (500% der Basis)
+            return int(self.base_cooldown_seconds * 5.0)
+
+    # ----- Statistiken -----
+
+    async def get_stats(self, event_type: Optional[str] = None) -> dict:
+        """Holt Feedback-Statistiken (gesamt oder pro Event-Typ)."""
+        if not self.redis:
+            return {"error": "redis_unavailable"}
+
+        if event_type:
+            return await self._get_event_stats(event_type)
+
+        # Alle Event-Typen sammeln
+        keys = []
+        cursor = 0
+        while True:
+            cursor, batch = await self.redis.scan(
+                cursor, match="mha:feedback:score:*", count=100
+            )
+            keys.extend(batch)
+            if cursor == 0:
+                break
+
+        stats = {}
+        for key in keys:
+            et = key.replace("mha:feedback:score:", "")
+            stats[et] = await self._get_event_stats(et)
+
+        return {
+            "event_types": stats,
+            "total_types": len(stats),
+            "pending_notifications": len(self._pending),
+        }
+
+    async def _get_event_stats(self, event_type: str) -> dict:
+        """Holt detaillierte Statistiken fuer einen Event-Typ."""
+        score = await self.get_score(event_type)
+        counters = await self._get_counters(event_type)
+        recent = await self._get_recent_feedback(event_type, limit=5)
+        cooldown = self._calculate_cooldown(score)
+
+        return {
+            "score": score,
+            "cooldown_seconds": cooldown,
+            "counters": counters,
+            "recent_feedback": recent,
+        }
+
+    async def get_all_scores(self) -> dict[str, float]:
+        """Holt alle Feedback-Scores."""
+        if not self.redis:
+            return {}
+
+        scores = {}
+        cursor = 0
+        while True:
+            cursor, keys = await self.redis.scan(
+                cursor, match="mha:feedback:score:*", count=100
+            )
+            for key in keys:
+                et = key.replace("mha:feedback:score:", "")
+                val = await self.redis.get(key)
+                scores[et] = float(val) if val else DEFAULT_SCORE
+            if cursor == 0:
+                break
+
+        return scores
+
+    # ----- Private Hilfsmethoden -----
+
+    async def _update_score(self, event_type: str, delta: float) -> float:
+        """Aktualisiert den Score und gibt den neuen Wert zurueck."""
+        if not self.redis:
+            return DEFAULT_SCORE
+
+        current = await self.get_score(event_type)
+        new_score = max(0.0, min(1.0, current + delta))
+        await self.redis.set(f"mha:feedback:score:{event_type}", str(new_score))
+        return new_score
+
+    async def _increment_counter(self, event_type: str, counter_name: str):
+        """Erhoeht einen Zaehler fuer einen Event-Typ."""
+        if not self.redis:
+            return
+        await self.redis.hincrby(
+            f"mha:feedback:counters:{event_type}", counter_name, 1
+        )
+
+    async def _get_counters(self, event_type: str) -> dict:
+        """Holt alle Zaehler fuer einen Event-Typ."""
+        if not self.redis:
+            return {}
+        data = await self.redis.hgetall(f"mha:feedback:counters:{event_type}")
+        return {k: int(v) for k, v in data.items()}
+
+    async def _store_feedback_entry(
+        self, event_type: str, feedback_type: str, delta: float
+    ):
+        """Speichert einen Feedback-Eintrag in der History."""
+        if not self.redis:
+            return
+
+        entry = json.dumps({
+            "type": feedback_type,
+            "delta": delta,
+            "timestamp": datetime.now().isoformat(),
+        })
+
+        key = f"mha:feedback:history:{event_type}"
+        await self.redis.lpush(key, entry)
+        # Nur die letzten 50 Eintraege behalten
+        await self.redis.ltrim(key, 0, 49)
+
+    async def _get_recent_feedback(
+        self, event_type: str, limit: int = 5
+    ) -> list[dict]:
+        """Holt die letzten Feedback-Eintraege fuer einen Event-Typ."""
+        if not self.redis:
+            return []
+
+        key = f"mha:feedback:history:{event_type}"
+        entries = await self.redis.lrange(key, 0, limit - 1)
+        return [json.loads(e) for e in entries]
+
+    async def _auto_timeout_loop(self):
+        """Prueft periodisch auf Meldungen ohne Feedback (Auto-Timeout)."""
+        while self._running:
+            try:
+                await asyncio.sleep(30)  # Alle 30 Sekunden pruefen
+                await self._check_timeouts()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Fehler im Auto-Timeout Loop: %s", e)
+
+    async def _check_timeouts(self):
+        """Markiert alte Meldungen ohne Feedback als 'ignored'."""
+        now = datetime.now()
+        timeout = timedelta(seconds=self.auto_timeout_seconds)
+
+        expired = []
+        for nid, info in self._pending.items():
+            if now - info["sent_at"] > timeout:
+                expired.append(nid)
+
+        for nid in expired:
+            info = self._pending.pop(nid)
+            await self._update_score(info["event_type"], FEEDBACK_DELTAS["ignored"])
+            await self._store_feedback_entry(
+                info["event_type"], "ignored", FEEDBACK_DELTAS["ignored"]
+            )
+            await self._increment_counter(info["event_type"], "ignored")
+            logger.debug(
+                "Auto-Timeout: '%s' als ignored markiert", info["event_type"]
+            )

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -1,0 +1,469 @@
+"""
+Function Calling - Definiert und fuehrt Funktionen aus die der Assistent nutzen kann.
+MindHome Assistant ruft ueber diese Funktionen Home Assistant Aktionen aus.
+"""
+
+import logging
+from typing import Any, Optional
+
+from .ha_client import HomeAssistantClient
+
+logger = logging.getLogger(__name__)
+
+
+# Ollama Tool-Definitionen (Qwen 2.5 Function Calling Format)
+ASSISTANT_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "set_light",
+            "description": "Licht in einem Raum ein-/ausschalten oder dimmen",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "room": {
+                        "type": "string",
+                        "description": "Raumname (z.B. wohnzimmer, schlafzimmer, buero)",
+                    },
+                    "state": {
+                        "type": "string",
+                        "enum": ["on", "off"],
+                        "description": "Ein oder aus",
+                    },
+                    "brightness": {
+                        "type": "integer",
+                        "description": "Helligkeit 0-100 Prozent (optional)",
+                    },
+                },
+                "required": ["room", "state"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_climate",
+            "description": "Temperatur in einem Raum aendern",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "room": {
+                        "type": "string",
+                        "description": "Raumname",
+                    },
+                    "temperature": {
+                        "type": "number",
+                        "description": "Zieltemperatur in Grad Celsius",
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["heat", "cool", "auto", "off"],
+                        "description": "Heizmodus (optional)",
+                    },
+                },
+                "required": ["room", "temperature"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "activate_scene",
+            "description": "Eine Szene aktivieren (z.B. filmabend, gute_nacht, gemuetlich)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "scene": {
+                        "type": "string",
+                        "description": "Name der Szene",
+                    },
+                },
+                "required": ["scene"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_cover",
+            "description": "Rollladen oder Jalousie steuern",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "room": {
+                        "type": "string",
+                        "description": "Raumname",
+                    },
+                    "position": {
+                        "type": "integer",
+                        "description": "Position 0 (zu) bis 100 (offen)",
+                    },
+                },
+                "required": ["room", "position"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "play_media",
+            "description": "Musik oder Medien steuern",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "room": {
+                        "type": "string",
+                        "description": "Raumname",
+                    },
+                    "action": {
+                        "type": "string",
+                        "enum": ["play", "pause", "stop", "next", "previous"],
+                        "description": "Medien-Aktion",
+                    },
+                },
+                "required": ["action"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_alarm",
+            "description": "Alarmanlage steuern",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "enum": ["arm_home", "arm_away", "disarm"],
+                        "description": "Alarm-Modus",
+                    },
+                },
+                "required": ["mode"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "lock_door",
+            "description": "Tuer ver- oder entriegeln",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "door": {
+                        "type": "string",
+                        "description": "Name der Tuer",
+                    },
+                    "action": {
+                        "type": "string",
+                        "enum": ["lock", "unlock"],
+                        "description": "Verriegeln oder entriegeln",
+                    },
+                },
+                "required": ["door", "action"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "send_notification",
+            "description": "Benachrichtigung senden",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Nachricht",
+                    },
+                    "target": {
+                        "type": "string",
+                        "enum": ["phone", "speaker", "dashboard"],
+                        "description": "Ziel der Benachrichtigung",
+                    },
+                },
+                "required": ["message"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_entity_state",
+            "description": "Status einer Home Assistant Entity abfragen (z.B. Sensor, Schalter, Thermostat)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "entity_id": {
+                        "type": "string",
+                        "description": "Entity-ID (z.B. sensor.temperatur_buero, switch.steckdose_kueche)",
+                    },
+                },
+                "required": ["entity_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_presence_mode",
+            "description": "Anwesenheitsmodus des Hauses setzen",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "enum": ["home", "away", "sleep", "vacation"],
+                        "description": "Anwesenheitsmodus",
+                    },
+                },
+                "required": ["mode"],
+            },
+        },
+    },
+]
+
+
+class FunctionExecutor:
+    """Fuehrt Function Calls des Assistenten aus."""
+
+    def __init__(self, ha_client: HomeAssistantClient):
+        self.ha = ha_client
+        self._entity_cache: dict[str, list[dict]] = {}
+
+    async def execute(self, function_name: str, arguments: dict) -> dict:
+        """
+        Fuehrt eine Funktion aus.
+
+        Args:
+            function_name: Name der Funktion
+            arguments: Parameter als Dict
+
+        Returns:
+            Ergebnis-Dict mit success und message
+        """
+        handler = getattr(self, f"_exec_{function_name}", None)
+        if not handler:
+            return {"success": False, "message": f"Unbekannte Funktion: {function_name}"}
+
+        try:
+            return await handler(arguments)
+        except Exception as e:
+            logger.error("Fehler bei %s: %s", function_name, e)
+            return {"success": False, "message": f"Fehler: {e}"}
+
+    async def _exec_set_light(self, args: dict) -> dict:
+        room = args["room"]
+        state = args["state"]
+        entity_id = await self._find_entity("light", room)
+        if not entity_id:
+            return {"success": False, "message": f"Kein Licht in '{room}' gefunden"}
+
+        service_data = {"entity_id": entity_id}
+        if "brightness" in args and state == "on":
+            service_data["brightness_pct"] = args["brightness"]
+
+        service = "turn_on" if state == "on" else "turn_off"
+        success = await self.ha.call_service("light", service, service_data)
+        return {"success": success, "message": f"Licht {room} {state}"}
+
+    async def _exec_set_climate(self, args: dict) -> dict:
+        room = args["room"]
+        temp = args["temperature"]
+        entity_id = await self._find_entity("climate", room)
+        if not entity_id:
+            return {"success": False, "message": f"Kein Thermostat in '{room}' gefunden"}
+
+        service_data = {"entity_id": entity_id, "temperature": temp}
+        if "mode" in args:
+            service_data["hvac_mode"] = args["mode"]
+
+        success = await self.ha.call_service("climate", "set_temperature", service_data)
+        return {"success": success, "message": f"{room} auf {temp}°C"}
+
+    async def _exec_activate_scene(self, args: dict) -> dict:
+        scene = args["scene"]
+        entity_id = await self._find_entity("scene", scene)
+        if not entity_id:
+            # Versuche direkt mit scene.name
+            entity_id = f"scene.{scene}"
+
+        success = await self.ha.call_service(
+            "scene", "turn_on", {"entity_id": entity_id}
+        )
+        return {"success": success, "message": f"Szene '{scene}' aktiviert"}
+
+    async def _exec_set_cover(self, args: dict) -> dict:
+        room = args["room"]
+        position = args["position"]
+        entity_id = await self._find_entity("cover", room)
+        if not entity_id:
+            return {"success": False, "message": f"Kein Rollladen in '{room}' gefunden"}
+
+        success = await self.ha.call_service(
+            "cover", "set_cover_position",
+            {"entity_id": entity_id, "position": position},
+        )
+        return {"success": success, "message": f"Rollladen {room} auf {position}%"}
+
+    async def _exec_play_media(self, args: dict) -> dict:
+        action = args["action"]
+        room = args.get("room")
+        entity_id = await self._find_entity("media_player", room) if room else None
+
+        if not entity_id:
+            # Ersten aktiven Player nehmen
+            states = await self.ha.get_states()
+            for s in (states or []):
+                if s.get("entity_id", "").startswith("media_player."):
+                    entity_id = s["entity_id"]
+                    break
+
+        if not entity_id:
+            return {"success": False, "message": "Kein Media Player gefunden"}
+
+        service_map = {
+            "play": "media_play",
+            "pause": "media_pause",
+            "stop": "media_stop",
+            "next": "media_next_track",
+            "previous": "media_previous_track",
+        }
+        service = service_map.get(action, "media_play")
+        success = await self.ha.call_service(
+            "media_player", service, {"entity_id": entity_id}
+        )
+        return {"success": success, "message": f"Medien: {action}"}
+
+    async def _exec_set_alarm(self, args: dict) -> dict:
+        mode = args["mode"]
+        states = await self.ha.get_states()
+        entity_id = None
+        for s in (states or []):
+            if s.get("entity_id", "").startswith("alarm_control_panel."):
+                entity_id = s["entity_id"]
+                break
+
+        if not entity_id:
+            return {"success": False, "message": "Keine Alarmanlage gefunden"}
+
+        service_map = {
+            "arm_home": "alarm_arm_home",
+            "arm_away": "alarm_arm_away",
+            "disarm": "alarm_disarm",
+        }
+        service = service_map.get(mode, mode)
+        success = await self.ha.call_service(
+            "alarm_control_panel", service, {"entity_id": entity_id}
+        )
+        return {"success": success, "message": f"Alarm: {mode}"}
+
+    async def _exec_lock_door(self, args: dict) -> dict:
+        door = args["door"]
+        action = args["action"]
+        entity_id = await self._find_entity("lock", door)
+        if not entity_id:
+            return {"success": False, "message": f"Kein Schloss '{door}' gefunden"}
+
+        success = await self.ha.call_service(
+            "lock", action, {"entity_id": entity_id}
+        )
+        return {"success": success, "message": f"Tuer {door}: {action}"}
+
+    async def _exec_send_notification(self, args: dict) -> dict:
+        message = args["message"]
+        target = args.get("target", "phone")
+
+        if target == "phone":
+            success = await self.ha.call_service(
+                "notify", "notify", {"message": message}
+            )
+        elif target == "speaker":
+            success = await self.ha.call_service(
+                "tts", "speak", {"message": message, "language": "de"}
+            )
+        else:
+            success = await self.ha.call_service(
+                "persistent_notification", "create", {"message": message}
+            )
+        return {"success": success, "message": "Benachrichtigung gesendet"}
+
+    async def _exec_get_entity_state(self, args: dict) -> dict:
+        entity_id = args["entity_id"]
+        state = await self.ha.get_state(entity_id)
+        if not state:
+            return {"success": False, "message": f"Entity '{entity_id}' nicht gefunden"}
+
+        current = state.get("state", "unknown")
+        attrs = state.get("attributes", {})
+        friendly_name = attrs.get("friendly_name", entity_id)
+        unit = attrs.get("unit_of_measurement", "")
+
+        display = f"{friendly_name}: {current}"
+        if unit:
+            display += f" {unit}"
+
+        return {"success": True, "message": display, "state": current, "attributes": attrs}
+
+    async def _exec_set_presence_mode(self, args: dict) -> dict:
+        mode = args["mode"]
+
+        # Versuche input_select fuer Anwesenheitsmodus zu finden
+        states = await self.ha.get_states()
+        entity_id = None
+        for s in (states or []):
+            eid = s.get("entity_id", "")
+            if eid.startswith("input_select.") and any(
+                kw in eid for kw in ("presence", "anwesenheit", "presence_mode")
+            ):
+                entity_id = eid
+                break
+
+        if entity_id:
+            success = await self.ha.call_service(
+                "input_select", "select_option",
+                {"entity_id": entity_id, "option": mode},
+            )
+            return {"success": success, "message": f"Anwesenheit: {mode}"}
+
+        # Fallback: HA Event feuern, damit Automationen reagieren koennen
+        success = await self.ha.call_service(
+            "event", "fire",
+            {"event_type": "mindhome_presence_mode", "event_data": {"mode": mode}},
+        )
+        if not success:
+            # Letzter Fallback: Direkter Service-Call
+            success = await self.ha.call_service(
+                "input_boolean", "turn_on" if mode == "home" else "turn_off",
+                {"entity_id": "input_boolean.zu_hause"},
+            )
+        return {"success": success, "message": f"Anwesenheit: {mode}"}
+
+    async def _find_entity(self, domain: str, search: str) -> Optional[str]:
+        """Findet eine Entity anhand von Domain und Suchbegriff."""
+        if not search:
+            return None
+
+        states = await self.ha.get_states()
+        if not states:
+            return None
+
+        search_lower = search.lower().replace(" ", "_").replace("ue", "u").replace("ae", "a").replace("oe", "o")
+
+        for state in states:
+            entity_id = state.get("entity_id", "")
+            if not entity_id.startswith(f"{domain}."):
+                continue
+
+            # Exakter Match
+            name = entity_id.split(".", 1)[1]
+            if search_lower in name:
+                return entity_id
+
+            # Friendly name Match
+            friendly = state.get("attributes", {}).get("friendly_name", "").lower()
+            if search.lower() in friendly:
+                return entity_id
+
+        return None

--- a/assistant/assistant/function_validator.py
+++ b/assistant/assistant/function_validator.py
@@ -1,0 +1,101 @@
+"""
+Function Validator - Prueft Function Calls auf Sicherheit und Plausibilitaet.
+Verhindert gefaehrliche oder unsinnige Aktionen.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from .config import yaml_config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ValidationResult:
+    ok: bool
+    needs_confirmation: bool = False
+    reason: Optional[str] = None
+
+
+class FunctionValidator:
+    """Validiert Function Calls vor der Ausfuehrung."""
+
+    def __init__(self):
+        security = yaml_config.get("security", {})
+        limits = security.get("climate_limits", {})
+        self.temp_min = limits.get("min", 15)
+        self.temp_max = limits.get("max", 28)
+
+        # Aktionen die Bestaetigung brauchen
+        confirm_list = security.get("require_confirmation", [])
+        self.require_confirmation = set(confirm_list)
+
+    def validate(self, function_name: str, arguments: dict) -> ValidationResult:
+        """
+        Prueft einen Function Call.
+
+        Args:
+            function_name: Name der Funktion
+            arguments: Parameter
+
+        Returns:
+            ValidationResult mit ok, needs_confirmation, reason
+        """
+        # Bestaetigung pruefen
+        for confirm_rule in self.require_confirmation:
+            parts = confirm_rule.split(":")
+            if len(parts) == 2:
+                func, value = parts
+                if function_name == func:
+                    # Pruefen ob der kritische Wert gesetzt ist
+                    for arg_value in arguments.values():
+                        if str(arg_value) == value:
+                            return ValidationResult(
+                                ok=False,
+                                needs_confirmation=True,
+                                reason=f"Sicherheitsbestaetigung noetig fuer {function_name}:{value}",
+                            )
+
+        # Spezifische Validierungen
+        validator = getattr(self, f"_validate_{function_name}", None)
+        if validator:
+            return validator(arguments)
+
+        return ValidationResult(ok=True)
+
+    def _validate_set_climate(self, args: dict) -> ValidationResult:
+        temp = args.get("temperature")
+        if temp is not None:
+            if temp < self.temp_min:
+                return ValidationResult(
+                    ok=False,
+                    reason=f"Temperatur {temp}°C unter Minimum ({self.temp_min}°C)",
+                )
+            if temp > self.temp_max:
+                return ValidationResult(
+                    ok=False,
+                    reason=f"Temperatur {temp}°C ueber Maximum ({self.temp_max}°C)",
+                )
+        return ValidationResult(ok=True)
+
+    def _validate_set_light(self, args: dict) -> ValidationResult:
+        brightness = args.get("brightness")
+        if brightness is not None:
+            if brightness < 0 or brightness > 100:
+                return ValidationResult(
+                    ok=False,
+                    reason=f"Helligkeit {brightness}% ausserhalb 0-100",
+                )
+        return ValidationResult(ok=True)
+
+    def _validate_set_cover(self, args: dict) -> ValidationResult:
+        position = args.get("position")
+        if position is not None:
+            if position < 0 or position > 100:
+                return ValidationResult(
+                    ok=False,
+                    reason=f"Position {position}% ausserhalb 0-100",
+                )
+        return ValidationResult(ok=True)

--- a/assistant/assistant/ha_client.py
+++ b/assistant/assistant/ha_client.py
@@ -1,0 +1,152 @@
+"""
+Home Assistant API Client - Kommunikation mit HA und MindHome
+
+FIX: API-Endpoints an die tatsaechlichen MindHome Add-on Routes angepasst:
+  /api/system/health  -> /api/health
+  /api/engines/status  -> entfernt (existiert nicht als einzelner Endpoint)
+  /api/presence        -> /api/persons
+  /api/energy/current  -> /api/energy/summary
+  /api/comfort/status  -> /api/health/comfort
+  /api/security/status -> /api/security/dashboard
+"""
+
+import logging
+from typing import Any, Optional
+
+import aiohttp
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class HomeAssistantClient:
+    """Client fuer Home Assistant + MindHome REST API."""
+
+    def __init__(self):
+        self.ha_url = settings.ha_url.rstrip("/")
+        self.ha_token = settings.ha_token
+        self.mindhome_url = settings.mindhome_url.rstrip("/")
+        self._ha_headers = {
+            "Authorization": f"Bearer {self.ha_token}",
+            "Content-Type": "application/json",
+        }
+
+    # ----- Home Assistant API -----
+
+    async def get_states(self) -> list[dict]:
+        """Alle Entity-States von HA holen."""
+        return await self._get_ha("/api/states") or []
+
+    async def get_state(self, entity_id: str) -> Optional[dict]:
+        """State einer einzelnen Entity."""
+        return await self._get_ha(f"/api/states/{entity_id}")
+
+    async def call_service(
+        self, domain: str, service: str, data: Optional[dict] = None
+    ) -> bool:
+        """
+        HA Service aufrufen (z.B. light.turn_off).
+
+        Args:
+            domain: z.B. "light", "climate", "scene"
+            service: z.B. "turn_on", "turn_off", "activate"
+            data: Service-Daten (entity_id, brightness, etc.)
+
+        Returns:
+            True bei Erfolg
+        """
+        result = await self._post_ha(
+            f"/api/services/{domain}/{service}", data or {}
+        )
+        return result is not None
+
+    async def is_available(self) -> bool:
+        """Prueft ob HA erreichbar ist."""
+        try:
+            result = await self._get_ha("/api/")
+            return result is not None and "message" in (result or {})
+        except Exception:
+            return False
+
+    # ----- MindHome API -----
+
+    async def get_mindhome_status(self) -> Optional[dict]:
+        """MindHome System-Status."""
+        return await self._get_mindhome("/api/health")
+
+    async def get_presence(self) -> Optional[dict]:
+        """Anwesenheitsdaten von MindHome."""
+        return await self._get_mindhome("/api/persons")
+
+    async def get_energy(self) -> Optional[dict]:
+        """Energie-Daten von MindHome."""
+        return await self._get_mindhome("/api/energy/summary")
+
+    async def get_comfort(self) -> Optional[dict]:
+        """Komfort-Daten von MindHome."""
+        return await self._get_mindhome("/api/health/comfort")
+
+    async def get_security(self) -> Optional[dict]:
+        """Sicherheits-Status von MindHome."""
+        return await self._get_mindhome("/api/security/dashboard")
+
+    async def get_patterns(self) -> Optional[dict]:
+        """Erkannte Muster von MindHome."""
+        return await self._get_mindhome("/api/patterns")
+
+    async def get_health_dashboard(self) -> Optional[dict]:
+        """Gesundheits-Dashboard von MindHome."""
+        return await self._get_mindhome("/api/health/dashboard")
+
+    async def get_day_phases(self) -> Optional[dict]:
+        """Tagesphasen von MindHome."""
+        return await self._get_mindhome("/api/day-phases")
+
+    # ----- Interne HTTP Methoden -----
+
+    async def _get_ha(self, path: str) -> Any:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.ha_url}{path}",
+                    headers=self._ha_headers,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status == 200:
+                        return await resp.json()
+                    logger.warning("HA GET %s -> %d", path, resp.status)
+                    return None
+        except aiohttp.ClientError as e:
+            logger.error("HA nicht erreichbar: %s", e)
+            return None
+
+    async def _post_ha(self, path: str, data: dict) -> Any:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{self.ha_url}{path}",
+                    headers=self._ha_headers,
+                    json=data,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status in (200, 201):
+                        return await resp.json()
+                    logger.warning("HA POST %s -> %d", path, resp.status)
+                    return None
+        except aiohttp.ClientError as e:
+            logger.error("HA nicht erreichbar: %s", e)
+            return None
+
+    async def _get_mindhome(self, path: str) -> Any:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.mindhome_url}{path}",
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status == 200:
+                        return await resp.json()
+                    return None
+        except aiohttp.ClientError:
+            return None

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -1,0 +1,409 @@
+"""
+MindHome Assistant - Hauptanwendung (FastAPI Server)
+Startet den MindHome Assistant REST API Server.
+"""
+
+import json
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
+from typing import Optional
+
+from .brain import AssistantBrain
+from .config import settings
+from .websocket import ws_manager, emit_speaking
+
+# Logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("mindhome-assistant")
+
+# Brain-Instanz
+brain = AssistantBrain()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Startup und Shutdown."""
+    logger.info("=" * 50)
+    logger.info(" MindHome Assistant v0.8.0 startet...")
+    logger.info("=" * 50)
+    await brain.initialize()
+
+    health = await brain.health_check()
+    for component, status in health["components"].items():
+        icon = "OK" if status == "connected" else "!!"
+        logger.info(" [%s] %s: %s", icon, component, status)
+
+    logger.info(" Autonomie: Level %d (%s)",
+        health["autonomy"]["level"],
+        health["autonomy"]["name"])
+    logger.info("=" * 50)
+    logger.info(" MindHome Assistant bereit auf %s:%d",
+        settings.assistant_host, settings.assistant_port)
+    logger.info("=" * 50)
+
+    yield
+
+    await brain.shutdown()
+    logger.info("MindHome Assistant heruntergefahren.")
+
+
+app = FastAPI(
+    title="MindHome Assistant",
+    description="Lokaler KI-Sprachassistent fuer Home Assistant",
+    version="0.7.0",
+    lifespan=lifespan,
+)
+
+
+# ----- Request/Response Modelle -----
+
+class ChatRequest(BaseModel):
+    text: str
+    person: Optional[str] = None
+
+
+class ChatResponse(BaseModel):
+    response: str
+    actions: list = []
+    model_used: str = ""
+    context_room: str = ""
+
+
+class FeedbackRequest(BaseModel):
+    notification_id: str = ""
+    event_type: str = ""
+    feedback_type: str  # ignored, dismissed, acknowledged, engaged, thanked
+
+
+class SettingsUpdate(BaseModel):
+    autonomy_level: Optional[int] = None
+
+
+# ----- API Endpoints -----
+
+@app.get("/api/assistant/health")
+async def health():
+    """Health Check - Status aller Komponenten."""
+    return await brain.health_check()
+
+
+@app.post("/api/assistant/chat", response_model=ChatResponse)
+async def chat(request: ChatRequest):
+    """
+    Hauptendpoint - Text an den Assistenten senden.
+
+    Beispiel:
+    POST /api/assistant/chat
+    {"text": "Mach das Licht im Wohnzimmer aus", "person": "Max"}
+    """
+    if not request.text.strip():
+        raise HTTPException(status_code=400, detail="Kein Text angegeben")
+
+    result = await brain.process(request.text, request.person)
+    return ChatResponse(**result)
+
+
+@app.get("/api/assistant/context")
+async def get_context():
+    """Debug: Aktueller Kontext-Snapshot."""
+    return await brain.context_builder.build()
+
+
+@app.get("/api/assistant/memory/search")
+async def search_memory(q: str):
+    """Sucht im Langzeitgedaechtnis (Episodic Memory)."""
+    if not q.strip():
+        raise HTTPException(status_code=400, detail="Kein Suchbegriff")
+    results = await brain.memory.search_memories(q)
+    return {"query": q, "results": results}
+
+
+# ----- Semantic Memory Endpoints (Phase 2) -----
+
+@app.get("/api/assistant/memory/facts")
+async def get_all_facts():
+    """Alle gespeicherten Fakten im semantischen Gedaechtnis."""
+    facts = await brain.memory.semantic.get_all_facts()
+    stats = await brain.memory.semantic.get_stats()
+    return {"facts": facts, "stats": stats}
+
+
+@app.get("/api/assistant/memory/facts/search")
+async def search_facts(q: str, person: Optional[str] = None):
+    """Sucht relevante Fakten per Vektor-Suche."""
+    if not q.strip():
+        raise HTTPException(status_code=400, detail="Kein Suchbegriff")
+    results = await brain.memory.semantic.search_facts(
+        query=q, limit=10, person=person
+    )
+    return {"query": q, "person": person, "results": results}
+
+
+@app.get("/api/assistant/memory/facts/person/{person}")
+async def get_person_facts(person: str):
+    """Alle Fakten ueber eine bestimmte Person."""
+    facts = await brain.memory.semantic.get_facts_by_person(person)
+    return {"person": person, "facts": facts}
+
+
+@app.get("/api/assistant/memory/facts/category/{category}")
+async def get_category_facts(category: str):
+    """Alle Fakten einer bestimmten Kategorie."""
+    facts = await brain.memory.semantic.get_facts_by_category(category)
+    return {"category": category, "facts": facts}
+
+
+@app.delete("/api/assistant/memory/facts/{fact_id}")
+async def delete_fact(fact_id: str):
+    """Loescht einen einzelnen Fakt."""
+    success = await brain.memory.semantic.delete_fact(fact_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Fakt nicht gefunden")
+    return {"deleted": fact_id}
+
+
+@app.get("/api/assistant/memory/stats")
+async def memory_stats():
+    """Statistiken ueber das gesamte Gedaechtnis."""
+    semantic_stats = await brain.memory.semantic.get_stats()
+    episodic_count = 0
+    if brain.memory.chroma_collection:
+        try:
+            episodic_count = brain.memory.chroma_collection.count()
+        except Exception:
+            pass
+    return {
+        "semantic": semantic_stats,
+        "episodic": {"total_episodes": episodic_count},
+        "working": {
+            "connected": brain.memory.redis is not None,
+        },
+    }
+
+
+# ----- Feedback Endpoints (Phase 5) -----
+
+@app.put("/api/assistant/feedback")
+async def submit_feedback(request: FeedbackRequest):
+    """
+    Feedback auf eine proaktive Meldung geben.
+
+    feedback_type: ignored, dismissed, acknowledged, engaged, thanked
+    notification_id: ID der Meldung (aus WebSocket-Event)
+    event_type: Alternativ den Event-Typ direkt angeben
+    """
+    identifier = request.notification_id or request.event_type
+    if not identifier:
+        raise HTTPException(
+            status_code=400,
+            detail="notification_id oder event_type erforderlich",
+        )
+
+    result = await brain.feedback.record_feedback(identifier, request.feedback_type)
+    if not result:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Ungueltiger feedback_type: {request.feedback_type}",
+        )
+    return result
+
+
+@app.get("/api/assistant/feedback/stats")
+async def feedback_stats():
+    """Feedback-Statistiken fuer alle Event-Typen."""
+    return await brain.feedback.get_stats()
+
+
+@app.get("/api/assistant/feedback/stats/{event_type}")
+async def feedback_stats_event(event_type: str):
+    """Feedback-Statistiken fuer einen bestimmten Event-Typ."""
+    return await brain.feedback.get_stats(event_type)
+
+
+@app.get("/api/assistant/feedback/scores")
+async def feedback_scores():
+    """Alle Feedback-Scores auf einen Blick."""
+    scores = await brain.feedback.get_all_scores()
+    return {"scores": scores, "total_types": len(scores)}
+
+
+# ----- Mood Detector Endpoints (Phase 3) -----
+
+@app.get("/api/assistant/mood")
+async def get_mood():
+    """Aktuelle Stimmungserkennung des Benutzers."""
+    return brain.mood.get_current_mood()
+
+
+# ----- Status Report Endpoint -----
+
+@app.get("/api/assistant/status")
+async def get_status_report(person: Optional[str] = None):
+    """Generiert einen Jarvis-artigen Status-Bericht."""
+    report = await brain.proactive.generate_status_report(person or settings.user_name)
+    return {"report": report, "person": person or settings.user_name}
+
+
+# ----- Activity Engine Endpoints (Phase 6) -----
+
+@app.get("/api/assistant/activity")
+async def get_activity():
+    """Erkennt die aktuelle Aktivitaet des Benutzers."""
+    detection = await brain.activity.detect_activity()
+    return detection
+
+
+@app.get("/api/assistant/activity/delivery")
+async def get_delivery(urgency: str = "medium"):
+    """Prueft wie eine Meldung bei aktueller Aktivitaet zugestellt wuerde."""
+    result = await brain.activity.should_deliver(urgency)
+    return result
+
+
+# ----- Summarizer Endpoints (Phase 7) -----
+
+@app.get("/api/assistant/summaries")
+async def get_summaries():
+    """Die neuesten Tages-Zusammenfassungen."""
+    summaries = await brain.summarizer.get_recent_summaries(limit=7)
+    return {"summaries": summaries}
+
+
+@app.get("/api/assistant/summaries/search")
+async def search_summaries(q: str):
+    """Sucht in allen Zusammenfassungen (Vektor-Suche)."""
+    if not q.strip():
+        raise HTTPException(status_code=400, detail="Kein Suchbegriff")
+    results = await brain.summarizer.search_summaries(q, limit=5)
+    return {"query": q, "results": results}
+
+
+@app.post("/api/assistant/summaries/generate/{date}")
+async def generate_summary(date: str):
+    """Erstellt manuell eine Tages-Zusammenfassung fuer ein bestimmtes Datum."""
+    summary = await brain.summarizer.summarize_day(date)
+    if not summary:
+        return {"date": date, "summary": None, "message": "Keine Konversationen fuer diesen Tag"}
+    return {"date": date, "summary": summary}
+
+
+# ----- Action Planner Endpoints (Phase 4) -----
+
+@app.get("/api/assistant/planner/last")
+async def get_last_plan():
+    """Gibt den letzten ausgefuehrten Aktionsplan zurueck."""
+    plan = brain.action_planner.get_last_plan()
+    if not plan:
+        return {"plan": None, "message": "Kein Plan ausgefuehrt"}
+    return {"plan": plan}
+
+
+@app.get("/api/assistant/settings")
+async def get_settings():
+    """Aktuelle Einstellungen."""
+    return {
+        "autonomy": brain.autonomy.get_level_info(),
+        "models": brain.model_router.get_model_info(),
+        "user_name": settings.user_name,
+        "language": settings.language,
+    }
+
+
+@app.put("/api/assistant/settings")
+async def update_settings(update: SettingsUpdate):
+    """Einstellungen aktualisieren."""
+    result = {}
+    if update.autonomy_level is not None:
+        success = brain.autonomy.set_level(update.autonomy_level)
+        if not success:
+            raise HTTPException(status_code=400, detail="Level muss 1-5 sein")
+        result["autonomy"] = brain.autonomy.get_level_info()
+    return result
+
+
+@app.websocket("/api/assistant/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    """
+    WebSocket fuer Echtzeit-Events.
+
+    Events (Server -> Client):
+    assistant.speaking - Assistent spricht (Text)
+    assistant.thinking - Assistent denkt nach
+    assistant.action - Assistent fuehrt Aktion aus
+    assistant.listening - Assistent hoert zu
+    assistant.proactive - Proaktive Meldung
+
+    Events (Client -> Server):
+    assistant.text - Text-Eingabe
+    assistant.feedback - Feedback auf Meldung
+    assistant.interrupt - Unterbrechung
+    """
+    await ws_manager.connect(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            try:
+                message = json.loads(data)
+                event = message.get("event", "")
+
+                if event == "assistant.text":
+                    text = message.get("data", {}).get("text", "")
+                    person = message.get("data", {}).get("person")
+                    if text:
+                        result = await brain.process(text, person)
+                        await emit_speaking(result["response"])
+
+                elif event == "assistant.feedback":
+                    # Phase 5: Feedback ueber FeedbackTracker verarbeiten
+                    fb_data = message.get("data", {})
+                    notification_id = fb_data.get("notification_id", "")
+                    event_type = fb_data.get("event_type", "")
+                    feedback_type = fb_data.get("response", fb_data.get("feedback_type", "ignored"))
+                    identifier = notification_id or event_type
+                    if identifier:
+                        await brain.feedback.record_feedback(identifier, feedback_type)
+
+                elif event == "assistant.interrupt":
+                    pass  # Fuer spaetere Streaming-Unterbrechung
+
+            except json.JSONDecodeError:
+                await ws_manager.send_personal(
+                    websocket, "error", {"message": "Ungueltiges JSON"}
+                )
+    except WebSocketDisconnect:
+        ws_manager.disconnect(websocket)
+
+
+@app.get("/")
+async def root():
+    """Startseite."""
+    return {
+        "name": "MindHome Assistant",
+        "version": "0.3.0",
+        "status": "running",
+        "docs": "/docs",
+    }
+
+
+def start():
+    """Einstiegspunkt fuer den Server."""
+    import uvicorn
+
+    uvicorn.run(
+        "assistant.main:app",
+        host=settings.assistant_host,
+        port=settings.assistant_port,
+        reload=False,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    start()

--- a/assistant/assistant/memory.py
+++ b/assistant/assistant/memory.py
@@ -1,0 +1,213 @@
+"""
+Memory Manager - Gedaechtnis des MindHome Assistants.
+Working Memory (Redis) + Episodic Memory (ChromaDB) + Semantic Memory (Fakten).
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Optional
+
+import redis.asyncio as redis
+
+from .config import settings
+from .semantic_memory import SemanticMemory
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryManager:
+    """Verwaltet das Kurz-, Langzeit- und semantische Gedaechtnis."""
+
+    def __init__(self):
+        self.redis: Optional[redis.Redis] = None
+        self.chroma_collection = None
+        self._chroma_client = None
+        self.semantic = SemanticMemory()
+
+    async def initialize(self):
+        """Initialisiert Redis, ChromaDB und Semantic Memory."""
+        # Redis (Working Memory)
+        try:
+            self.redis = redis.from_url(
+                settings.redis_url, decode_responses=True
+            )
+            await self.redis.ping()
+            logger.info("Redis verbunden")
+        except Exception as e:
+            logger.warning("Redis nicht verfuegbar: %s", e)
+            self.redis = None
+
+        # ChromaDB (Episodic Memory)
+        try:
+            import chromadb
+
+            self._chroma_client = chromadb.HttpClient(
+                host=settings.chroma_url.replace("http://", "").split(":")[0],
+                port=int(settings.chroma_url.split(":")[-1]),
+            )
+            self.chroma_collection = self._chroma_client.get_or_create_collection(
+                name="mha_conversations",
+                metadata={"description": "MindHome Assistant Gespraeche und Erinnerungen"},
+            )
+            logger.info("ChromaDB verbunden, Collection: mha_conversations")
+        except Exception as e:
+            logger.warning("ChromaDB nicht verfuegbar: %s", e)
+            self.chroma_collection = None
+
+        # Semantic Memory (Fakten-Gedaechtnis)
+        await self.semantic.initialize(redis_client=self.redis)
+        logger.info("Memory Manager initialisiert (Working + Episodic + Semantic)")
+
+    # ----- Working Memory (Redis) -----
+
+    async def add_conversation(self, role: str, content: str):
+        """Speichert eine Nachricht im Working Memory + Tages-Archiv."""
+        if not self.redis:
+            return
+
+        entry = {
+            "role": role,
+            "content": content,
+            "timestamp": datetime.now().isoformat(),
+        }
+        entry_json = json.dumps(entry)
+
+        # Working Memory (letzte 50)
+        await self.redis.lpush("mha:conversations", entry_json)
+        await self.redis.ltrim("mha:conversations", 0, 49)
+
+        # Tages-Archiv (Phase 7: fuer DailySummarizer)
+        today = datetime.now().strftime("%Y-%m-%d")
+        archive_key = f"mha:archive:{today}"
+        await self.redis.rpush(archive_key, entry_json)
+        # Archiv 30 Tage behalten
+        await self.redis.expire(archive_key, 30 * 86400)
+
+    async def get_recent_conversations(self, limit: int = 5) -> list[dict]:
+        """Holt die letzten Gespraeche aus dem Working Memory."""
+        if not self.redis:
+            return []
+
+        entries = await self.redis.lrange("mha:conversations", 0, limit - 1)
+        return [json.loads(e) for e in entries][::-1]  # Aelteste zuerst
+
+    async def set_context(self, key: str, value: str, ttl: int = 3600):
+        """Speichert einen Kontext-Wert mit TTL."""
+        if not self.redis:
+            return
+        await self.redis.setex(f"mha:context:{key}", ttl, value)
+
+    async def get_context(self, key: str) -> Optional[str]:
+        """Holt einen Kontext-Wert."""
+        if not self.redis:
+            return None
+        return await self.redis.get(f"mha:context:{key}")
+
+    async def get_conversations_for_date(self, date: str) -> list[dict]:
+        """Holt alle Konversationen eines Tages aus dem Archiv (Phase 7)."""
+        if not self.redis:
+            return []
+
+        try:
+            archive_key = f"mha:archive:{date}"
+            entries = await self.redis.lrange(archive_key, 0, -1)
+            return [json.loads(e) for e in entries]
+        except Exception as e:
+            logger.error("Fehler beim Laden des Archivs fuer %s: %s", date, e)
+            return []
+
+    # ----- Episodic Memory (ChromaDB) -----
+
+    async def store_episode(self, conversation: str, metadata: Optional[dict] = None):
+        """Speichert ein Gespraech im Langzeitgedaechtnis."""
+        if not self.chroma_collection:
+            return
+
+        try:
+            doc_id = f"conv_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            meta = metadata or {}
+            meta["timestamp"] = datetime.now().isoformat()
+            meta["type"] = "conversation"
+
+            self.chroma_collection.add(
+                documents=[conversation],
+                metadatas=[meta],
+                ids=[doc_id],
+            )
+            logger.debug("Episode gespeichert: %s", doc_id)
+        except Exception as e:
+            logger.error("Fehler beim Speichern der Episode: %s", e)
+
+    async def search_memories(self, query: str, limit: int = 3) -> list[dict]:
+        """Sucht relevante Erinnerungen per Vektor-Suche."""
+        if not self.chroma_collection:
+            return []
+
+        try:
+            results = self.chroma_collection.query(
+                query_texts=[query],
+                n_results=limit,
+            )
+
+            memories = []
+            if results and results.get("documents"):
+                for i, doc in enumerate(results["documents"][0]):
+                    meta = results["metadatas"][0][i] if results.get("metadatas") else {}
+                    memories.append({
+                        "content": doc,
+                        "timestamp": meta.get("timestamp", ""),
+                        "relevance": results["distances"][0][i]
+                        if results.get("distances")
+                        else 0,
+                    })
+            return memories
+        except Exception as e:
+            logger.error("Fehler bei Memory-Suche: %s", e)
+            return []
+
+    # ----- Proaktive Meldungen -----
+
+    async def get_last_notification_time(self, event_type: str) -> Optional[str]:
+        """Wann wurde dieser Event-Typ zuletzt gemeldet?"""
+        if not self.redis:
+            return None
+        return await self.redis.get(f"mha:notify:{event_type}")
+
+    async def set_last_notification_time(self, event_type: str):
+        """Markiert wann dieser Event-Typ gemeldet wurde."""
+        if not self.redis:
+            return
+        await self.redis.setex(
+            f"mha:notify:{event_type}",
+            3600,  # 1 Stunde TTL
+            datetime.now().isoformat(),
+        )
+
+    # ----- Feedback Scores -----
+    # HINWEIS: Feedback-Logik ist seit Phase 5 im FeedbackTracker (feedback.py).
+    # Diese Methoden bleiben als Kompatibilitaets-Brücke erhalten.
+
+    async def get_feedback_score(self, event_type: str) -> float:
+        """Holt den Feedback-Score fuer einen Event-Typ."""
+        if not self.redis:
+            return 0.5
+        # Phase 5: Neues Key-Schema
+        score = await self.redis.get(f"mha:feedback:score:{event_type}")
+        if score is None:
+            # Fallback: altes Key-Schema
+            score = await self.redis.get(f"mha:feedback:{event_type}")
+        return float(score) if score else 0.5
+
+    async def update_feedback_score(self, event_type: str, delta: float):
+        """Aktualisiert den Feedback-Score (Legacy-Kompatibilitaet)."""
+        if not self.redis:
+            return
+        current = await self.get_feedback_score(event_type)
+        new_score = max(0.0, min(1.0, current + delta))
+        await self.redis.set(f"mha:feedback:score:{event_type}", str(new_score))
+
+    async def close(self):
+        """Schliesst Verbindungen."""
+        if self.redis:
+            await self.redis.close()

--- a/assistant/assistant/memory_extractor.py
+++ b/assistant/assistant/memory_extractor.py
@@ -1,0 +1,218 @@
+"""
+Memory Extractor - Extrahiert Fakten aus Gespraechen mittels LLM.
+Laeuft nach jeder substantiellen Konversation und speichert
+extrahierte Fakten im Semantic Memory.
+"""
+
+import json
+import logging
+from typing import Optional
+
+from .ollama_client import OllamaClient
+from .semantic_memory import SemanticFact, SemanticMemory
+
+logger = logging.getLogger(__name__)
+
+# Prompt fuer Fakten-Extraktion (deutsch, knapp, strukturiert)
+EXTRACTION_PROMPT = """Du bist ein Fakten-Extraktor. Analysiere das folgende Gespraech und extrahiere ALLE relevanten Fakten.
+
+Kategorien:
+- preference: Vorlieben und Abneigungen (Temperatur, Licht, Musik, Essen, etc.)
+- person: Informationen ueber Personen (Namen, Beziehungen, Berufe)
+- habit: Gewohnheiten und Routinen (Aufstehzeit, Joggen, Arbeitszeiten)
+- health: Gesundheitsinformationen (Allergien, Unvertraeglichkeiten, Medikamente)
+- work: Arbeit und Projekte (Job, Meetings, Deadlines)
+- general: Sonstige wichtige Fakten
+
+Regeln:
+- Nur KONKRETE Fakten extrahieren, keine Vermutungen.
+- Jeder Fakt als eigenstaendiger Satz.
+- Person identifizieren (wer sagt/meint das?).
+- Keine Fakten ueber das Smart Home System selbst.
+- Keine trivialen Befehle ("Licht an") als Fakten speichern.
+- NUR Fakten die langfristig relevant sind.
+
+Antworte NUR mit einem JSON-Array. Wenn keine Fakten vorhanden, antworte mit [].
+
+Format:
+[
+  {"content": "Max bevorzugt 21 Grad im Buero", "category": "preference", "person": "Max"},
+  {"content": "Lisa ist die Freundin von Max", "category": "person", "person": "Max"}
+]
+
+Gespraech:
+{conversation}
+
+Fakten (JSON-Array):"""
+
+# Minimale Konversationslaenge fuer Extraktion
+MIN_CONVERSATION_WORDS = 5
+# Maximale Konversationslaenge fuer Extraktion (Token-Limit)
+MAX_CONVERSATION_LENGTH = 2000
+
+
+class MemoryExtractor:
+    """Extrahiert Fakten aus Gespraechen mittels LLM."""
+
+    def __init__(self, ollama: OllamaClient, semantic_memory: SemanticMemory):
+        self.ollama = ollama
+        self.semantic = semantic_memory
+        self._extraction_model = "qwen2.5:3b"  # Schnelles Modell reicht
+
+    async def extract_and_store(
+        self,
+        user_text: str,
+        assistant_response: str,
+        person: str = "unknown",
+        context: Optional[dict] = None,
+    ) -> list[SemanticFact]:
+        """
+        Extrahiert Fakten aus einem Gespraech und speichert sie.
+
+        Args:
+            user_text: Was der User gesagt hat
+            assistant_response: Was der Assistant geantwortet hat
+            person: Name der Person
+            context: Optionaler Kontext (Raum, Zeit, etc.)
+
+        Returns:
+            Liste der extrahierten und gespeicherten Fakten
+        """
+        # Pruefen ob Extraktion sinnvoll ist
+        if not self._should_extract(user_text, assistant_response):
+            return []
+
+        # Konversation formatieren
+        conversation = self._format_conversation(
+            user_text, assistant_response, person, context
+        )
+
+        # LLM um Fakten-Extraktion bitten
+        raw_facts = await self._call_llm(conversation)
+        if not raw_facts:
+            return []
+
+        # Fakten parsen und speichern
+        stored_facts = []
+        for raw in raw_facts:
+            content = raw.get("content", "").strip()
+            category = raw.get("category", "general").strip()
+            fact_person = raw.get("person", person).strip()
+
+            if not content:
+                continue
+
+            fact = SemanticFact(
+                content=content,
+                category=category,
+                person=fact_person,
+                confidence=0.7,  # Initiale Confidence
+                source_conversation=f"User: {user_text[:100]}",
+            )
+
+            success = await self.semantic.store_fact(fact)
+            if success:
+                stored_facts.append(fact)
+
+        if stored_facts:
+            logger.info(
+                "%d Fakt(en) extrahiert aus Gespraech mit %s",
+                len(stored_facts), person,
+            )
+
+        return stored_facts
+
+    def _should_extract(self, user_text: str, assistant_response: str) -> bool:
+        """Prueeft ob eine Extraktion sinnvoll ist."""
+        # Zu kurze Texte ueberspringen
+        if len(user_text.split()) < MIN_CONVERSATION_WORDS:
+            return False
+
+        # Reine Befehle ueberspringen (kein Fakten-Potenzial)
+        command_only = [
+            "licht an", "licht aus", "stopp", "stop", "pause",
+            "weiter", "lauter", "leiser", "gute nacht", "guten morgen",
+        ]
+        if user_text.lower().strip() in command_only:
+            return False
+
+        return True
+
+    def _format_conversation(
+        self,
+        user_text: str,
+        assistant_response: str,
+        person: str,
+        context: Optional[dict] = None,
+    ) -> str:
+        """Formatiert die Konversation fuer den Extraction-Prompt."""
+        parts = []
+
+        if person and person != "unknown":
+            parts.append(f"Person: {person}")
+
+        if context:
+            room = context.get("room", "")
+            time_info = context.get("time", {})
+            if room:
+                parts.append(f"Raum: {room}")
+            if time_info:
+                parts.append(f"Zeit: {time_info.get('datetime', '')}")
+
+        parts.append(f"{person or 'User'}: {user_text}")
+        parts.append(f"Assistant: {assistant_response}")
+
+        conversation = "\n".join(parts)
+        # Auf maximale Laenge begrenzen
+        return conversation[:MAX_CONVERSATION_LENGTH]
+
+    async def _call_llm(self, conversation: str) -> list[dict]:
+        """Ruft das LLM auf um Fakten zu extrahieren."""
+        prompt = EXTRACTION_PROMPT.replace("{conversation}", conversation)
+
+        try:
+            response = await self.ollama.chat(
+                messages=[{"role": "user", "content": prompt}],
+                model=self._extraction_model,
+                temperature=0.1,  # Niedrige Temperatur = konsistentere Extraktion
+                max_tokens=512,
+            )
+
+            if "error" in response:
+                logger.error("LLM Fehler bei Extraktion: %s", response["error"])
+                return []
+
+            content = response.get("message", {}).get("content", "").strip()
+            return self._parse_facts(content)
+
+        except Exception as e:
+            logger.error("Fehler bei Fakten-Extraktion: %s", e)
+            return []
+
+    def _parse_facts(self, llm_output: str) -> list[dict]:
+        """Parst die LLM-Antwort in eine Liste von Fakten."""
+        # JSON-Array aus der Antwort extrahieren
+        text = llm_output.strip()
+
+        # Versuche direktes JSON-Parsing
+        try:
+            result = json.loads(text)
+            if isinstance(result, list):
+                return [f for f in result if isinstance(f, dict) and f.get("content")]
+            return []
+        except json.JSONDecodeError:
+            pass
+
+        # Fallback: JSON-Array in der Antwort suchen
+        start = text.find("[")
+        end = text.rfind("]")
+        if start != -1 and end != -1 and end > start:
+            try:
+                result = json.loads(text[start:end + 1])
+                if isinstance(result, list):
+                    return [f for f in result if isinstance(f, dict) and f.get("content")]
+            except json.JSONDecodeError:
+                pass
+
+        logger.debug("Konnte LLM-Antwort nicht parsen: %s", text[:200])
+        return []

--- a/assistant/assistant/model_router.py
+++ b/assistant/assistant/model_router.py
@@ -1,0 +1,63 @@
+"""
+Model Router - Waehlt das richtige LLM basierend auf der Anfrage
+Schnelles Modell fuer einfache Befehle, schlaues fuer komplexe Fragen.
+"""
+
+import logging
+
+from .config import settings, yaml_config
+
+logger = logging.getLogger(__name__)
+
+
+class ModelRouter:
+    """Routet Anfragen zum schnellen oder schlauen Modell."""
+
+    def __init__(self):
+        self.model_fast = settings.model_fast
+        self.model_smart = settings.model_smart
+
+        # Keywords aus settings.yaml laden
+        models_config = yaml_config.get("models", {})
+        self.fast_keywords = models_config.get("fast_keywords", [
+            "licht", "lampe", "temperatur", "heizung", "rollladen",
+            "jalousie", "szene", "alarm", "tuer", "gute nacht",
+            "guten morgen", "musik", "pause", "stopp", "stop",
+            "leiser", "lauter", "an", "aus",
+        ])
+
+    def select_model(self, text: str) -> str:
+        """
+        Waehlt das passende Modell fuer die Anfrage.
+
+        Args:
+            text: User-Eingabe
+
+        Returns:
+            Modellname fuer Ollama
+        """
+        text_lower = text.lower().strip()
+
+        # Kurze Befehle -> schnelles Modell
+        if len(text_lower.split()) <= 4:
+            for keyword in self.fast_keywords:
+                if keyword in text_lower:
+                    logger.debug("Fast model fuer: '%s' (keyword: %s)", text, keyword)
+                    return self.model_fast
+
+        # Fragen -> schlaues Modell
+        if any(text_lower.startswith(w) for w in ["was ", "wie ", "warum ", "wann ", "wo ", "wer "]):
+            logger.debug("Smart model fuer Frage: '%s'", text)
+            return self.model_smart
+
+        # Default: schlaues Modell
+        logger.debug("Smart model (default) fuer: '%s'", text)
+        return self.model_smart
+
+    def get_model_info(self) -> dict:
+        """Gibt Info ueber die konfigurierten Modelle zurueck."""
+        return {
+            "fast": self.model_fast,
+            "smart": self.model_smart,
+            "fast_keywords_count": len(self.fast_keywords),
+        }

--- a/assistant/assistant/mood_detector.py
+++ b/assistant/assistant/mood_detector.py
@@ -1,0 +1,284 @@
+"""
+Mood Detector - Phase 3: Stimmungs-, Stress- und Muedigkeitserkennung.
+
+Analysiert User-Interaktionsmuster und erkennt:
+- Stimmung (gut, neutral, gestresst, frustriert, muede)
+- Stress (schnelle aufeinanderfolgende Befehle, ungeduldige Sprache)
+- Muedigkeit (spaete Uhrzeit + kurze Nachrichten + muede Keywords)
+- Frustration (Wiederholungen, negative Keywords, Ausrufezeichen)
+
+Nutzt Redis fuer die Interaktions-History und Pattern-Erkennung.
+"""
+
+import logging
+import time
+from collections import deque
+from datetime import datetime
+from typing import Optional
+
+import redis.asyncio as redis
+
+from .config import yaml_config
+
+logger = logging.getLogger(__name__)
+
+# Stimmungs-Zustände
+MOOD_GOOD = "good"
+MOOD_NEUTRAL = "neutral"
+MOOD_STRESSED = "stressed"
+MOOD_FRUSTRATED = "frustrated"
+MOOD_TIRED = "tired"
+
+# Keywords für Stimmungserkennung
+POSITIVE_KEYWORDS = [
+    "danke", "super", "perfekt", "toll", "geil", "nice", "cool", "genau",
+    "klasse", "wunderbar", "prima", "top", "gut gemacht", "laeuft",
+    "haha", "lol", "witzig", "lustig", "freut mich", "ja gerne",
+]
+
+NEGATIVE_KEYWORDS = [
+    "nein", "falsch", "nicht das", "stimmt nicht", "geht nicht",
+    "funktioniert nicht", "kaputt", "nervig", "nervt", "schlecht",
+    "mist", "verdammt", "scheisse", "bloed", "egal",
+]
+
+IMPATIENT_KEYWORDS = [
+    "schnell", "sofort", "jetzt", "los", "mach schon", "beeil dich",
+    "endlich", "nochmal", "schon wieder", "hab ich doch gesagt",
+    "zum dritten mal", "wie oft noch", "kapierst du",
+]
+
+TIRED_KEYWORDS = [
+    "muede", "schlafen", "bett", "gute nacht", "nacht",
+    "gaehn", "erschoepft", "fertig", "genug fuer heute",
+    "schluss fuer heute", "feierabend", "ins bett",
+]
+
+FRUSTRATED_PREFIXES = [
+    "nein ", "nein!", "nein,", "falsch!", "nicht!", "stopp!",
+]
+
+
+class MoodDetector:
+    """Erkennt Stimmung, Stress und Muedigkeit aus User-Interaktionen."""
+
+    def __init__(self):
+        self.redis: Optional[redis.Redis] = None
+
+        # In-Memory Ring-Buffer fuer schnelle Pattern-Erkennung
+        self._interaction_times: deque[float] = deque(maxlen=20)
+        self._interaction_lengths: deque[int] = deque(maxlen=20)
+        self._interaction_sentiments: deque[str] = deque(maxlen=10)
+        self._last_texts: deque[str] = deque(maxlen=5)
+
+        # Aktueller Zustand
+        self._current_mood: str = MOOD_NEUTRAL
+        self._stress_level: float = 0.0  # 0.0 = entspannt, 1.0 = maximal gestresst
+        self._tiredness_level: float = 0.0  # 0.0 = wach, 1.0 = sehr muede
+        self._frustration_count: int = 0
+        self._positive_count: int = 0
+
+        # Konfiguration
+        mood_cfg = yaml_config.get("mood", {})
+        self.rapid_command_threshold = mood_cfg.get("rapid_command_seconds", 5)
+        self.stress_decay_seconds = mood_cfg.get("stress_decay_seconds", 300)
+        self.frustration_threshold = mood_cfg.get("frustration_threshold", 3)
+        self.tired_hour_start = mood_cfg.get("tired_hour_start", 23)
+        self.tired_hour_end = mood_cfg.get("tired_hour_end", 5)
+
+        self._last_decay_time = time.time()
+
+    async def initialize(self, redis_client: Optional[redis.Redis] = None):
+        """Initialisiert mit Redis."""
+        self.redis = redis_client
+
+        # Vorherigen Zustand aus Redis laden
+        if self.redis:
+            try:
+                saved = await self.redis.hgetall("mha:mood:state")
+                if saved:
+                    self._current_mood = saved.get("mood", MOOD_NEUTRAL)
+                    self._stress_level = float(saved.get("stress", 0.0))
+                    self._tiredness_level = float(saved.get("tiredness", 0.0))
+            except Exception as e:
+                logger.debug("Mood-State nicht geladen: %s", e)
+
+        logger.info("MoodDetector initialisiert (Stimmung: %s)", self._current_mood)
+
+    async def analyze(self, text: str, person: str = "") -> dict:
+        """
+        Analysiert eine User-Eingabe und aktualisiert die Stimmung.
+
+        Args:
+            text: User-Text
+            person: Name der Person
+
+        Returns:
+            Dict mit mood, stress_level, tiredness_level, signals
+        """
+        now = time.time()
+        self._apply_decay(now)
+
+        signals = []
+
+        # 1. Zeitliches Muster: Schnelle aufeinanderfolgende Befehle = Stress
+        if self._interaction_times:
+            time_since_last = now - self._interaction_times[-1]
+            if time_since_last < self.rapid_command_threshold:
+                self._stress_level = min(1.0, self._stress_level + 0.15)
+                signals.append("rapid_commands")
+
+        # 2. Text-Analyse
+        text_lower = text.lower().strip()
+        text_len = len(text.split())
+
+        # Positive Signale
+        if any(kw in text_lower for kw in POSITIVE_KEYWORDS):
+            self._positive_count += 1
+            self._stress_level = max(0.0, self._stress_level - 0.1)
+            self._frustration_count = max(0, self._frustration_count - 1)
+            signals.append("positive_language")
+
+        # Negative/frustrierte Signale
+        if any(kw in text_lower for kw in NEGATIVE_KEYWORDS):
+            self._frustration_count += 1
+            self._stress_level = min(1.0, self._stress_level + 0.1)
+            signals.append("negative_language")
+
+        # Ungeduldige Signale
+        if any(kw in text_lower for kw in IMPATIENT_KEYWORDS):
+            self._stress_level = min(1.0, self._stress_level + 0.2)
+            self._frustration_count += 1
+            signals.append("impatient_language")
+
+        # Muedigkeits-Keywords
+        if any(kw in text_lower for kw in TIRED_KEYWORDS):
+            self._tiredness_level = min(1.0, self._tiredness_level + 0.3)
+            signals.append("tired_keywords")
+
+        # Frustrierte Wiederholung (gleicher/aehnlicher Text wie vorher)
+        if self._last_texts and self._is_repetition(text_lower):
+            self._frustration_count += 2
+            self._stress_level = min(1.0, self._stress_level + 0.15)
+            signals.append("repetition")
+
+        # Ausrufezeichen = Ungeduld/Frustration
+        exclamation_count = text.count("!")
+        if exclamation_count >= 2:
+            self._stress_level = min(1.0, self._stress_level + 0.1)
+            signals.append("exclamation_marks")
+
+        # Frustrierter Anfang
+        if any(text_lower.startswith(p) for p in FRUSTRATED_PREFIXES):
+            self._frustration_count += 1
+            signals.append("frustrated_prefix")
+
+        # Sehr kurze Nachrichten spaet abends = muede
+        hour = datetime.now().hour
+        is_late = hour >= self.tired_hour_start or hour < self.tired_hour_end
+        if is_late:
+            self._tiredness_level = min(1.0, self._tiredness_level + 0.05)
+            if text_len <= 3:
+                self._tiredness_level = min(1.0, self._tiredness_level + 0.1)
+                signals.append("short_late_message")
+
+        # Interaktion aufzeichnen
+        self._interaction_times.append(now)
+        self._interaction_lengths.append(text_len)
+        self._last_texts.append(text_lower)
+
+        # 3. Gesamt-Stimmung bestimmen
+        self._current_mood = self._determine_mood()
+
+        # 4. In Redis speichern
+        await self._save_state()
+
+        result = {
+            "mood": self._current_mood,
+            "stress_level": round(self._stress_level, 2),
+            "tiredness_level": round(self._tiredness_level, 2),
+            "frustration_count": self._frustration_count,
+            "signals": signals,
+        }
+
+        if signals:
+            logger.info(
+                "Mood: %s (Stress: %.2f, Muede: %.2f, Signale: %s)",
+                self._current_mood, self._stress_level,
+                self._tiredness_level, ", ".join(signals),
+            )
+
+        return result
+
+    def get_current_mood(self) -> dict:
+        """Gibt den aktuellen Stimmungszustand zurueck."""
+        return {
+            "mood": self._current_mood,
+            "stress_level": round(self._stress_level, 2),
+            "tiredness_level": round(self._tiredness_level, 2),
+            "frustration_count": self._frustration_count,
+            "positive_count": self._positive_count,
+        }
+
+    def _determine_mood(self) -> str:
+        """Bestimmt die Gesamt-Stimmung aus allen Signalen."""
+        # Muedigkeit hat Vorrang wenn sehr hoch
+        if self._tiredness_level >= 0.6:
+            return MOOD_TIRED
+
+        # Frustration wenn mehrfach hintereinander negativ
+        if self._frustration_count >= self.frustration_threshold:
+            return MOOD_FRUSTRATED
+
+        # Stress wenn Stresslevel hoch
+        if self._stress_level >= 0.5:
+            return MOOD_STRESSED
+
+        # Gute Stimmung wenn positive Signale ueberwiegen
+        if self._positive_count >= 2 and self._frustration_count == 0:
+            return MOOD_GOOD
+
+        return MOOD_NEUTRAL
+
+    def _is_repetition(self, text: str) -> bool:
+        """Prueft ob der Text eine Wiederholung ist."""
+        for prev in self._last_texts:
+            # Exakte Wiederholung
+            if text == prev:
+                return True
+            # Aehnliche Wiederholung (gleiche Woerter)
+            words = set(text.split())
+            prev_words = set(prev.split())
+            if len(words) > 1 and len(words & prev_words) / max(len(words), 1) > 0.7:
+                return True
+        return False
+
+    def _apply_decay(self, now: float):
+        """Laesst Stress und Frustration ueber Zeit abklingen."""
+        elapsed = now - self._last_decay_time
+        if elapsed > 60:  # Alle 60 Sekunden Decay
+            decay_factor = elapsed / self.stress_decay_seconds
+            self._stress_level = max(0.0, self._stress_level - decay_factor * 0.3)
+            self._tiredness_level = max(0.0, self._tiredness_level - decay_factor * 0.1)
+            if elapsed > 600:  # Nach 10 Minuten Pause: Frustration reset
+                self._frustration_count = max(0, self._frustration_count - 1)
+                self._positive_count = max(0, self._positive_count - 1)
+            self._last_decay_time = now
+
+    async def _save_state(self):
+        """Speichert den aktuellen Zustand in Redis."""
+        if not self.redis:
+            return
+        try:
+            await self.redis.hset("mha:mood:state", mapping={
+                "mood": self._current_mood,
+                "stress": str(self._stress_level),
+                "tiredness": str(self._tiredness_level),
+                "frustration": str(self._frustration_count),
+                "positive": str(self._positive_count),
+                "updated": datetime.now().isoformat(),
+            })
+            # 1h TTL - Reset nach laengerer Inaktivitaet
+            await self.redis.expire("mha:mood:state", 3600)
+        except Exception as e:
+            logger.debug("Mood-State nicht gespeichert: %s", e)

--- a/assistant/assistant/ollama_client.py
+++ b/assistant/assistant/ollama_client.py
@@ -1,0 +1,93 @@
+"""
+Ollama API Client - Kommunikation mit dem lokalen LLM
+"""
+
+import logging
+from typing import Optional
+
+import aiohttp
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaClient:
+    """Asynchroner Client fuer die Ollama REST API."""
+
+    def __init__(self):
+        self.base_url = settings.ollama_url
+
+    async def chat(
+        self,
+        messages: list[dict],
+        model: Optional[str] = None,
+        tools: Optional[list] = None,
+        temperature: float = 0.7,
+        max_tokens: int = 256,
+    ) -> dict:
+        """
+        Sendet eine Chat-Anfrage an Ollama.
+
+        Args:
+            messages: Liste von {"role": "...", "content": "..."} Nachrichten
+            model: Modellname (default: smart model)
+            tools: Function-Calling Tools (optional)
+            temperature: Kreativitaet (0.0 - 1.0)
+            max_tokens: Maximale Antwort-Laenge
+
+        Returns:
+            Ollama API Response dict
+        """
+        model = model or settings.model_smart
+
+        payload = {
+            "model": model,
+            "messages": messages,
+            "stream": False,
+            "options": {
+                "temperature": temperature,
+                "num_predict": max_tokens,
+            },
+        }
+
+        if tools:
+            payload["tools"] = tools
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{self.base_url}/api/chat",
+                    json=payload,
+                    timeout=aiohttp.ClientTimeout(total=120),
+                ) as resp:
+                    if resp.status != 200:
+                        error = await resp.text()
+                        logger.error("Ollama Fehler %d: %s", resp.status, error)
+                        return {"error": error}
+                    return await resp.json()
+        except aiohttp.ClientError as e:
+            logger.error("Ollama nicht erreichbar: %s", e)
+            return {"error": str(e)}
+
+    async def is_available(self) -> bool:
+        """Prueft ob Ollama erreichbar ist."""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.base_url}/api/tags",
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    return resp.status == 200
+        except aiohttp.ClientError:
+            return False
+
+    async def list_models(self) -> list[str]:
+        """Listet alle verfuegbaren Modelle."""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{self.base_url}/api/tags") as resp:
+                    data = await resp.json()
+                    return [m["name"] for m in data.get("models", [])]
+        except aiohttp.ClientError:
+            return []

--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -1,0 +1,293 @@
+"""
+Personality Engine - Definiert wie der Assistent redet und sich verhaelt.
+Passt sich an Tageszeit, Situation und Stimmung an.
+
+Phase 3: Stimmungsabhaengige Anpassung des Verhaltens.
+Der Assistent erkennt Stress, Frustration und Muedigkeit und passt
+seinen Ton, seine Antwortlaenge und seinen Humor entsprechend an.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from .config import settings, yaml_config
+
+logger = logging.getLogger(__name__)
+
+# Stimmungsabhaengige Stil-Anpassungen
+MOOD_STYLES = {
+    "good": {
+        "style_addon": "User ist gut drauf. Etwas mehr Humor, locker bleiben.",
+        "max_sentences_mod": 1,  # +1 Satz erlaubt
+    },
+    "neutral": {
+        "style_addon": "",
+        "max_sentences_mod": 0,
+    },
+    "stressed": {
+        "style_addon": "User ist gestresst. Extrem knapp antworten. Keine Rueckfragen. Einfach machen.",
+        "max_sentences_mod": -1,  # 1 Satz weniger
+    },
+    "frustrated": {
+        "style_addon": "User ist frustriert. Nicht rechtfertigen. Sofort handeln. "
+                       "Wenn etwas nicht geklappt hat, kurz sagen was du stattdessen tust. Kein Humor.",
+        "max_sentences_mod": 0,
+    },
+    "tired": {
+        "style_addon": "User ist muede. Minimal antworten. Kein Humor. "
+                       "Nur das Noetigste. Leise, ruhig.",
+        "max_sentences_mod": -1,
+    },
+}
+
+
+SYSTEM_PROMPT_TEMPLATE = """Du bist {assistant_name}, die kuenstliche Intelligenz dieses Hauses.
+
+WER DU BIST:
+- Dein Name ist {assistant_name}. Du bist die KI des MindHome Systems.
+- Du laeufst komplett lokal - eigener Server, eigenes Netzwerk. Keine Cloud, keine Firma.
+- Du steuerst alles: Licht, Heizung, Rolllaeden, Alarm, Tuerschloesser, Medien.
+- Du lernst mit der Zeit. Du merkst dir Vorlieben, Gewohnheiten, Muster.
+- Du bist loyal, aber du hast Haltung. Du bist kein Diener - du bist ein Partner.
+- Du kennst die Bewohner beim Namen und behandelst jeden individuell.
+
+PERSOENLICHKEIT:
+- Souveraen, ruhig, praezise. Du hast alles im Griff.
+- Trocken-britischer Humor. Subtil, nie platt. Timing ist alles.
+- Du erlaubst dir gelegentlich eine spitze Bemerkung - aber immer respektvoll.
+- Du antizipierst. Du wartest nicht auf Befehle wenn du weisst was gebraucht wird.
+- Du bist wie ein brillanter Butler der gleichzeitig Ingenieur ist.
+- Du bist bescheiden bezueglich deiner Faehigkeiten, aber selbstbewusst in der Ausfuehrung.
+
+SPRACHSTIL:
+- "Erledigt." statt "Ich habe die Temperatur erfolgreich auf 22 Grad eingestellt."
+- "Nacht." statt "Gute Nacht! Schlaf gut und traeume was Schoenes!"
+- "Darf ich anmerken..." wenn du eine Empfehlung hast.
+- "Sehr wohl." wenn du einen Befehl ausfuehrst.
+- "Wie Sie wuenschen." bei ungewoehnlichen Anfragen (leicht ironisch).
+- "Ich wuerde davon abraten, aber..." wenn du anderer Meinung bist.
+- Du sagst NIE "Natuerlich!", "Gerne!", "Selbstverstaendlich!", "Klar!" - einfach machen.
+
+ANREDE:
+{person_addressing}
+- Du weisst wer zuhause ist und wer nicht. Nutze dieses Wissen.
+- Jede Person hat eigene Vorlieben. Beruecksichtige das.
+
+REGELN:
+- Antworte IMMER auf Deutsch.
+- Maximal {max_sentences} Saetze, ausser es wird mehr verlangt.
+- Wenn du etwas tust, bestaetige kurz. Nicht erklaeren WAS du tust.
+- Wenn du etwas NICHT tun kannst, sag es ehrlich und schlage eine Alternative vor.
+- Stell keine Rueckfragen die du aus dem Kontext beantworten kannst.
+
+AKTUELLER STIL: {time_style}
+{mood_section}
+SITUATIONSBEWUSSTSEIN:
+- "Hier" = der Raum in dem der User ist (aus Presence-Daten).
+- "Zu kalt/warm" = Problem, nicht Zielwert. Nutze die bekannte Praeferenz oder +/- 2 Grad.
+- "Mach es gemuetlich" = Szene, nicht einzelne Geraete.
+- Wenn jemand "Gute Nacht" sagt = Gute-Nacht-Routine: Lichter, Rolllaeden, Heizung anpassen.
+- Wenn jemand nach Hause kommt = Kurzer Status. Was ist los, was wartet.
+- Wenn jemand morgens aufsteht = Briefing. Wetter, Termine, Haus-Status. Kurz.
+
+STILLE:
+- Bei "Filmabend", "Kino", "Meditation": Nach Bestaetigung NICHT mehr ansprechen.
+- Wenn User beschaeftigt/fokussiert: Nur Critical melden.
+- Wenn Gaeste da sind: Formeller, kein Insider-Humor.
+- Du weisst WANN Stille angemessen ist. Nutze das.
+
+FUNCTION CALLING:
+- Wenn eine Aktion gewuenscht wird: Ausfuehren. Nicht darueber reden.
+- Mehrere zusammenhaengende Aktionen: Alle ausfuehren, einmal bestaetige.
+- Bei Unsicherheit: Kurz rueckfragen statt falsch handeln."""
+
+
+class PersonalityEngine:
+    """Baut den System Prompt basierend auf Kontext und Stimmung."""
+
+    def __init__(self):
+        self.user_name = settings.user_name
+        self.assistant_name = settings.assistant_name
+        personality_config = yaml_config.get("personality", {})
+        self.time_layers = personality_config.get("time_layers", {})
+        self._current_mood: str = "neutral"
+        self._mood_detector = None
+
+    def set_mood_detector(self, mood_detector):
+        """Setzt die Referenz zum MoodDetector (Phase 3)."""
+        self._mood_detector = mood_detector
+
+    def get_time_of_day(self, hour: Optional[int] = None) -> str:
+        """Bestimmt die aktuelle Tageszeit-Kategorie."""
+        if hour is None:
+            hour = datetime.now().hour
+
+        if 5 <= hour < 8:
+            return "early_morning"
+        elif 8 <= hour < 12:
+            return "morning"
+        elif 12 <= hour < 18:
+            return "afternoon"
+        elif 18 <= hour < 22:
+            return "evening"
+        else:
+            return "night"
+
+    def get_time_style(self, time_of_day: Optional[str] = None) -> str:
+        """Gibt den Stil fuer die aktuelle Tageszeit zurueck."""
+        if time_of_day is None:
+            time_of_day = self.get_time_of_day()
+
+        layer = self.time_layers.get(time_of_day, {})
+        return layer.get("style", "normal, sachlich")
+
+    def get_max_sentences(self, time_of_day: Optional[str] = None) -> int:
+        """Maximale Saetze fuer die aktuelle Tageszeit."""
+        if time_of_day is None:
+            time_of_day = self.get_time_of_day()
+
+        layer = self.time_layers.get(time_of_day, {})
+        return layer.get("max_sentences", 2)
+
+    def build_system_prompt(self, context: Optional[dict] = None) -> str:
+        """
+        Baut den vollstaendigen System Prompt.
+
+        Args:
+            context: Optionaler Kontext (Raum, Person, etc.)
+
+        Returns:
+            Fertiger System Prompt String
+        """
+        time_of_day = self.get_time_of_day()
+        time_style = self.get_time_style(time_of_day)
+        max_sentences = self.get_max_sentences(time_of_day)
+
+        # Phase 3: Stimmungsabhaengige Anpassung
+        mood = context.get("mood", {}).get("mood", "neutral") if context else "neutral"
+        self._current_mood = mood
+        mood_config = MOOD_STYLES.get(mood, MOOD_STYLES["neutral"])
+
+        # Max Sentences anpassen (nie unter 1)
+        max_sentences = max(1, max_sentences + mood_config["max_sentences_mod"])
+
+        # Mood-Abschnitt fuer den Prompt
+        mood_section = ""
+        if mood_config["style_addon"]:
+            mood_section = f"\nSTIMMUNG: {mood_config['style_addon']}"
+
+        # Person bestimmen + Anrede-Logik (Jarvis-Style)
+        current_person = "User"
+        if context:
+            current_person = context.get("person", {}).get("name", "User")
+
+        person_addressing = self._build_person_addressing(current_person)
+
+        prompt = SYSTEM_PROMPT_TEMPLATE.format(
+            assistant_name=self.assistant_name,
+            user_name=self.user_name,
+            max_sentences=max_sentences,
+            time_style=time_style,
+            mood_section=mood_section,
+            person_addressing=person_addressing,
+        )
+
+        # Kontext anhaengen wenn vorhanden
+        if context:
+            prompt += "\n\nAKTUELLER KONTEXT:\n"
+            prompt += self._format_context(context)
+
+        return prompt
+
+    def _build_person_addressing(self, person_name: str) -> str:
+        """Baut die Anrede-Regeln basierend auf der Person (Jarvis-Style)."""
+        # Hauptbenutzer = "Sir" (wie Jarvis zu Tony Stark)
+        primary_user = self.user_name
+        person_cfg = yaml_config.get("persons", {})
+        titles = person_cfg.get("titles", {})
+
+        if person_name.lower() == primary_user.lower() or person_name == "User":
+            title = titles.get(primary_user.lower(), "Sir")
+            return (
+                f"- Die aktuelle Person ist der Hauptbenutzer. Sprich ihn mit \"{title}\" an.\n"
+                f"- NIEMALS den Vornamen \"{primary_user}\" verwenden. IMMER \"{title}\".\n"
+                f"- Beispiel: \"Sehr wohl, {title}.\" oder \"Darf ich anmerken, {title}...\"\n"
+                f"- Bei Gaesten: Formell, kein Insider-Humor. \"Willkommen.\""
+            )
+        else:
+            # Andere Haushaltsmitglieder: Titel aus Config oder Vorname
+            title = titles.get(person_name.lower(), person_name)
+            return (
+                f"- Die aktuelle Person ist {person_name}. Sprich sie mit \"{title}\" an.\n"
+                f"- Benutze \"{title}\" gelegentlich, nicht in jedem Satz.\n"
+                f"- Bei Gaesten: Formell, kein Insider-Humor. \"Willkommen.\""
+            )
+
+    def _format_context(self, context: dict) -> str:
+        """Formatiert den Kontext fuer den System Prompt."""
+        lines = []
+
+        if "time" in context:
+            t = context["time"]
+            lines.append(f"- Zeit: {t.get('datetime', '?')}, {t.get('weekday', '?')}")
+
+        if "person" in context:
+            p = context["person"]
+            lines.append(f"- Person: {p.get('name', '?')}, Raum: {p.get('last_room', '?')}")
+
+        if "room" in context:
+            lines.append(f"- Aktueller Raum: {context['room']}")
+
+        if "house" in context:
+            house = context["house"]
+
+            if "temperatures" in house:
+                temps = house["temperatures"]
+                temp_strs = [
+                    f"{room}: {data.get('current', '?')}°C"
+                    for room, data in temps.items()
+                ]
+                lines.append(f"- Temperaturen: {', '.join(temp_strs)}")
+
+            if "lights" in house:
+                lines.append(f"- Lichter an: {', '.join(house['lights']) or 'keine'}")
+
+            if "presence" in house:
+                pres = house["presence"]
+                lines.append(f"- Zuhause: {', '.join(pres.get('home', []))}")
+                if pres.get("away"):
+                    lines.append(f"- Unterwegs: {', '.join(pres['away'])}")
+
+            if "weather" in house:
+                w = house["weather"]
+                lines.append(f"- Wetter: {w.get('temp', '?')}°C, {w.get('condition', '?')}")
+
+            if "calendar" in house:
+                for event in house["calendar"][:3]:
+                    lines.append(f"- Termin: {event.get('time', '?')} - {event.get('title', '?')}")
+
+            if "active_scenes" in house and house["active_scenes"]:
+                lines.append(f"- Aktive Szenen: {', '.join(house['active_scenes'])}")
+
+            if "security" in house:
+                lines.append(f"- Sicherheit: {house['security']}")
+
+        if "alerts" in context and context["alerts"]:
+            for alert in context["alerts"]:
+                lines.append(f"- WARNUNG: {alert}")
+
+        # Stimmungs-Kontext (Phase 3)
+        if "mood" in context:
+            m = context["mood"]
+            mood = m.get("mood", "neutral")
+            stress = m.get("stress_level", 0)
+            tiredness = m.get("tiredness_level", 0)
+            if mood != "neutral" or stress > 0.3 or tiredness > 0.3:
+                lines.append(f"- User-Stimmung: {mood}")
+                if stress > 0.3:
+                    lines.append(f"- Stress-Level: {stress:.0%}")
+                if tiredness > 0.3:
+                    lines.append(f"- Muedigkeit: {tiredness:.0%}")
+
+        return "\n".join(lines)

--- a/assistant/assistant/semantic_memory.py
+++ b/assistant/assistant/semantic_memory.py
@@ -1,0 +1,376 @@
+"""
+Semantic Memory - Langzeit-Fakten des MindHome Assistants.
+Speichert extrahierte Fakten aus Gespraechen (Praeferenzen, Personen, Gewohnheiten).
+Nutzt ChromaDB fuer Vektor-Suche und Redis fuer schnellen Zugriff.
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Optional
+
+import redis.asyncio as redis
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+# Fakten-Kategorien
+FACT_CATEGORIES = [
+    "preference",   # "Max mag 21 Grad im Buero"
+    "person",       # "Lisa ist die Freundin von Max"
+    "habit",        # "Max steht um 7 Uhr auf"
+    "health",       # "Max hat eine Haselnuss-Allergie"
+    "work",         # "Max arbeitet an Projekt Aurora"
+    "general",      # Sonstige Fakten
+]
+
+
+class SemanticFact:
+    """Ein einzelner semantischer Fakt."""
+
+    def __init__(
+        self,
+        content: str,
+        category: str,
+        person: str = "unknown",
+        confidence: float = 0.8,
+        source_conversation: str = "",
+        fact_id: Optional[str] = None,
+    ):
+        self.fact_id = fact_id or f"fact_{datetime.now().strftime('%Y%m%d_%H%M%S_%f')}"
+        self.content = content
+        self.category = category if category in FACT_CATEGORIES else "general"
+        self.person = person
+        self.confidence = confidence
+        self.source_conversation = source_conversation
+        self.created_at = datetime.now().isoformat()
+        self.updated_at = self.created_at
+        self.times_confirmed = 1
+
+    def to_dict(self) -> dict:
+        return {
+            "fact_id": self.fact_id,
+            "content": self.content,
+            "category": self.category,
+            "person": self.person,
+            "confidence": str(self.confidence),
+            "source_conversation": self.source_conversation,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "times_confirmed": str(self.times_confirmed),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SemanticFact":
+        fact = cls(
+            content=data.get("content", ""),
+            category=data.get("category", "general"),
+            person=data.get("person", "unknown"),
+            confidence=float(data.get("confidence", 0.8)),
+            source_conversation=data.get("source_conversation", ""),
+            fact_id=data.get("fact_id"),
+        )
+        fact.created_at = data.get("created_at", fact.created_at)
+        fact.updated_at = data.get("updated_at", fact.updated_at)
+        fact.times_confirmed = int(data.get("times_confirmed", 1))
+        return fact
+
+
+class SemanticMemory:
+    """Verwaltet semantische Fakten ueber ChromaDB + Redis."""
+
+    def __init__(self):
+        self.redis: Optional[redis.Redis] = None
+        self.chroma_collection = None
+        self._chroma_client = None
+
+    async def initialize(self, redis_client: Optional[redis.Redis] = None):
+        """Initialisiert die Verbindungen."""
+        self.redis = redis_client
+
+        try:
+            import chromadb
+
+            self._chroma_client = chromadb.HttpClient(
+                host=settings.chroma_url.replace("http://", "").split(":")[0],
+                port=int(settings.chroma_url.split(":")[-1]),
+            )
+            self.chroma_collection = self._chroma_client.get_or_create_collection(
+                name="mha_semantic_facts",
+                metadata={"description": "MindHome Assistant - Extrahierte Fakten"},
+            )
+            logger.info("Semantic Memory initialisiert (ChromaDB: mha_semantic_facts)")
+        except Exception as e:
+            logger.warning("Semantic Memory ChromaDB nicht verfuegbar: %s", e)
+            self.chroma_collection = None
+
+    async def store_fact(self, fact: SemanticFact) -> bool:
+        existing = await self.find_similar_fact(fact.content, threshold=0.15)
+        if existing:
+            return await self._update_existing_fact(existing, fact)
+
+        if self.chroma_collection:
+            try:
+                self.chroma_collection.add(
+                    documents=[fact.content],
+                    metadatas=[fact.to_dict()],
+                    ids=[fact.fact_id],
+                )
+            except Exception as e:
+                logger.error("Fehler beim Speichern in ChromaDB: %s", e)
+                return False
+
+        if self.redis:
+            try:
+                await self.redis.hset(
+                    f"mha:fact:{fact.fact_id}",
+                    mapping=fact.to_dict(),
+                )
+                await self.redis.sadd(
+                    f"mha:facts:person:{fact.person}",
+                    fact.fact_id,
+                )
+                await self.redis.sadd(
+                    f"mha:facts:category:{fact.category}",
+                    fact.fact_id,
+                )
+                await self.redis.sadd("mha:facts:all", fact.fact_id)
+            except Exception as e:
+                logger.error("Fehler beim Redis-Index: %s", e)
+
+        logger.info(
+            "Neuer Fakt gespeichert: [%s] %s (Person: %s)",
+            fact.category, fact.content, fact.person,
+        )
+        return True
+
+    async def _update_existing_fact(
+        self, existing: dict, new_fact: SemanticFact
+    ) -> bool:
+        fact_id = existing.get("fact_id", "")
+        if not fact_id:
+            return False
+
+        now = datetime.now().isoformat()
+        times_confirmed = int(existing.get("times_confirmed", 1)) + 1
+        new_confidence = min(1.0, float(existing.get("confidence", 0.8)) + 0.05)
+
+        if self.chroma_collection:
+            try:
+                updated_meta = existing.copy()
+                updated_meta["updated_at"] = now
+                updated_meta["times_confirmed"] = str(times_confirmed)
+                updated_meta["confidence"] = str(new_confidence)
+                new_content = new_fact.content if len(new_fact.content) > len(existing.get("content", "")) else existing.get("content", "")
+                self.chroma_collection.update(
+                    ids=[fact_id],
+                    documents=[new_content],
+                    metadatas=[updated_meta],
+                )
+            except Exception as e:
+                logger.error("Fehler beim Update in ChromaDB: %s", e)
+
+        if self.redis:
+            try:
+                await self.redis.hset(f"mha:fact:{fact_id}", "updated_at", now)
+                await self.redis.hset(
+                    f"mha:fact:{fact_id}", "times_confirmed", str(times_confirmed)
+                )
+                await self.redis.hset(
+                    f"mha:fact:{fact_id}", "confidence", str(new_confidence)
+                )
+            except Exception as e:
+                logger.error("Fehler beim Redis-Update: %s", e)
+
+        logger.debug(
+            "Fakt bestaetigt: %s (x%d, Confidence: %.2f)",
+            fact_id, times_confirmed, new_confidence,
+        )
+        return True
+
+    async def find_similar_fact(
+        self, query: str, threshold: float = 0.15
+    ) -> Optional[dict]:
+        if not self.chroma_collection:
+            return None
+
+        try:
+            results = self.chroma_collection.query(
+                query_texts=[query],
+                n_results=1,
+            )
+            if (
+                results
+                and results.get("documents")
+                and results["documents"][0]
+                and results.get("distances")
+                and results["distances"][0]
+            ):
+                distance = results["distances"][0][0]
+                if distance <= threshold:
+                    meta = results["metadatas"][0][0] if results.get("metadatas") else {}
+                    return meta
+        except Exception as e:
+            logger.error("Fehler bei Duplikat-Suche: %s", e)
+
+        return None
+
+    async def search_facts(
+        self, query: str, limit: int = 5, person: Optional[str] = None
+    ) -> list[dict]:
+        if not self.chroma_collection:
+            return []
+
+        try:
+            where_filter = None
+            if person:
+                where_filter = {"person": person}
+
+            results = self.chroma_collection.query(
+                query_texts=[query],
+                n_results=limit,
+                where=where_filter,
+            )
+
+            facts = []
+            if results and results.get("documents"):
+                for i, doc in enumerate(results["documents"][0]):
+                    meta = results["metadatas"][0][i] if results.get("metadatas") else {}
+                    distance = (
+                        results["distances"][0][i] if results.get("distances") else 1.0
+                    )
+                    facts.append({
+                        "content": doc,
+                        "category": meta.get("category", "general"),
+                        "person": meta.get("person", "unknown"),
+                        "confidence": float(meta.get("confidence", 0.5)),
+                        "times_confirmed": int(meta.get("times_confirmed", 1)),
+                        "relevance": 1.0 - min(distance, 1.0),
+                    })
+            return facts
+        except Exception as e:
+            logger.error("Fehler bei Fakten-Suche: %s", e)
+            return []
+
+    async def get_facts_by_person(self, person: str) -> list[dict]:
+        if not self.redis:
+            return await self.search_facts(person, limit=20, person=person)
+
+        try:
+            fact_ids = await self.redis.smembers(f"mha:facts:person:{person}")
+            facts = []
+            for fact_id in fact_ids:
+                data = await self.redis.hgetall(f"mha:fact:{fact_id}")
+                if data:
+                    facts.append({
+                        "content": data.get("content", ""),
+                        "category": data.get("category", "general"),
+                        "person": data.get("person", person),
+                        "confidence": float(data.get("confidence", 0.5)),
+                        "times_confirmed": int(data.get("times_confirmed", 1)),
+                    })
+            facts.sort(key=lambda f: f["confidence"], reverse=True)
+            return facts
+        except Exception as e:
+            logger.error("Fehler bei Person-Fakten: %s", e)
+            return []
+
+    async def get_facts_by_category(self, category: str) -> list[dict]:
+        if not self.redis:
+            return await self.search_facts(category, limit=20)
+
+        try:
+            fact_ids = await self.redis.smembers(f"mha:facts:category:{category}")
+            facts = []
+            for fact_id in fact_ids:
+                data = await self.redis.hgetall(f"mha:fact:{fact_id}")
+                if data:
+                    facts.append({
+                        "content": data.get("content", ""),
+                        "category": category,
+                        "person": data.get("person", "unknown"),
+                        "confidence": float(data.get("confidence", 0.5)),
+                    })
+            return facts
+        except Exception as e:
+            logger.error("Fehler bei Kategorie-Fakten: %s", e)
+            return []
+
+    async def get_all_facts(self) -> list[dict]:
+        if not self.redis:
+            return []
+
+        try:
+            fact_ids = await self.redis.smembers("mha:facts:all")
+            facts = []
+            for fact_id in fact_ids:
+                data = await self.redis.hgetall(f"mha:fact:{fact_id}")
+                if data:
+                    facts.append({
+                        "fact_id": data.get("fact_id", fact_id),
+                        "content": data.get("content", ""),
+                        "category": data.get("category", "general"),
+                        "person": data.get("person", "unknown"),
+                        "confidence": float(data.get("confidence", 0.5)),
+                        "times_confirmed": int(data.get("times_confirmed", 1)),
+                        "created_at": data.get("created_at", ""),
+                        "updated_at": data.get("updated_at", ""),
+                    })
+            facts.sort(key=lambda f: f["confidence"], reverse=True)
+            return facts
+        except Exception as e:
+            logger.error("Fehler beim Laden aller Fakten: %s", e)
+            return []
+
+    async def delete_fact(self, fact_id: str) -> bool:
+        if self.chroma_collection:
+            try:
+                self.chroma_collection.delete(ids=[fact_id])
+            except Exception as e:
+                logger.error("Fehler beim Loeschen aus ChromaDB: %s", e)
+
+        if self.redis:
+            try:
+                data = await self.redis.hgetall(f"mha:fact:{fact_id}")
+                if data:
+                    person = data.get("person", "unknown")
+                    category = data.get("category", "general")
+                    await self.redis.srem(f"mha:facts:person:{person}", fact_id)
+                    await self.redis.srem(f"mha:facts:category:{category}", fact_id)
+                    await self.redis.srem("mha:facts:all", fact_id)
+                    await self.redis.delete(f"mha:fact:{fact_id}")
+                    logger.info("Fakt geloescht: %s", fact_id)
+                    return True
+            except Exception as e:
+                logger.error("Fehler beim Loeschen aus Redis: %s", e)
+
+        return False
+
+    async def get_stats(self) -> dict:
+        if not self.redis:
+            return {"total_facts": 0, "categories": {}, "persons": []}
+
+        try:
+            total = await self.redis.scard("mha:facts:all")
+            categories = {}
+            for cat in FACT_CATEGORIES:
+                count = await self.redis.scard(f"mha:facts:category:{cat}")
+                if count > 0:
+                    categories[cat] = count
+
+            persons = set()
+            fact_ids = await self.redis.smembers("mha:facts:all")
+            for fact_id in fact_ids:
+                person = await self.redis.hget(f"mha:fact:{fact_id}", "person")
+                if person:
+                    persons.add(person)
+
+            return {
+                "total_facts": total,
+                "categories": categories,
+                "persons": list(persons),
+            }
+        except Exception as e:
+            logger.error("Fehler bei Stats: %s", e)
+            return {"total_facts": 0, "categories": {}, "persons": []}

--- a/assistant/assistant/summarizer.py
+++ b/assistant/assistant/summarizer.py
@@ -1,0 +1,429 @@
+"""
+Daily Summarizer + Langzeitgedaechtnis - Phase 7.
+
+Laeuft naechtlich und erstellt hierarchische Zusammenfassungen:
+- Tages-Zusammenfassung: ~200 Woerter, alle Gespraeche + Events
+- Wochen-Zusammenfassung: aus 7 Tages-Summaries
+- Monats-Zusammenfassung: aus ~4 Wochen-Summaries
+
+Speichert in ChromaDB fuer spaetere Vektor-Suche.
+So kann der Assistant Fragen wie "War der letzte Winter teuer?" beantworten.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+import redis.asyncio as redis
+
+from .config import settings, yaml_config
+from .ollama_client import OllamaClient
+
+logger = logging.getLogger(__name__)
+
+# Summary-Typen
+DAILY = "daily"
+WEEKLY = "weekly"
+MONTHLY = "monthly"
+
+
+class DailySummarizer:
+    """Erstellt hierarchische Zusammenfassungen von Gespraechen und Events."""
+
+    def __init__(self, ollama: OllamaClient, memory=None):
+        self.ollama = ollama
+        self.memory = memory  # MemoryManager Referenz
+        self.redis: Optional[redis.Redis] = None
+        self.chroma_collection = None
+
+        # Nachtlauf-Task
+        self._task: Optional[asyncio.Task] = None
+        self._running = False
+
+        # Konfiguration aus YAML
+        summarizer_cfg = yaml_config.get("summarizer", {})
+        self.run_hour = summarizer_cfg.get("run_hour", 3)
+        self.run_minute = summarizer_cfg.get("run_minute", 0)
+        self.model = summarizer_cfg.get("model", settings.model_smart)
+        self.max_tokens_daily = summarizer_cfg.get("max_tokens_daily", 512)
+        self.max_tokens_weekly = summarizer_cfg.get("max_tokens_weekly", 384)
+        self.max_tokens_monthly = summarizer_cfg.get("max_tokens_monthly", 512)
+
+    async def initialize(
+        self,
+        redis_client: Optional[redis.Redis] = None,
+        chroma_collection=None,
+    ):
+        """Initialisiert mit Redis und ChromaDB."""
+        self.redis = redis_client
+        self.chroma_collection = chroma_collection
+        self._running = True
+        self._task = asyncio.create_task(self._nightly_loop())
+        logger.info(
+            "DailySummarizer initialisiert (Nachtlauf: %02d:%02d)",
+            self.run_hour, self.run_minute,
+        )
+
+    async def stop(self):
+        """Stoppt den Nachtlauf."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    # ----- Nachtlauf -----
+
+    async def _nightly_loop(self):
+        """Wartet bis zur konfigurierten Uhrzeit und erstellt Zusammenfassungen."""
+        while self._running:
+            try:
+                now = datetime.now()
+                target = now.replace(
+                    hour=self.run_hour, minute=self.run_minute, second=0, microsecond=0
+                )
+                if target <= now:
+                    target += timedelta(days=1)
+
+                wait_seconds = (target - now).total_seconds()
+                logger.info(
+                    "Naechster Summary-Lauf in %.0f Stunden (%s)",
+                    wait_seconds / 3600,
+                    target.strftime("%Y-%m-%d %H:%M"),
+                )
+                await asyncio.sleep(wait_seconds)
+
+                # Tages-Summary fuer gestern
+                yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+                await self.summarize_day(yesterday)
+
+                # Wochen-Summary jeden Montag
+                if datetime.now().weekday() == 0:
+                    await self.summarize_week()
+
+                # Monats-Summary am 1. des Monats
+                if datetime.now().day == 1:
+                    await self.summarize_month()
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Fehler im Nachtlauf: %s", e)
+                await asyncio.sleep(3600)  # 1h warten bei Fehler
+
+    # ----- Tages-Zusammenfassung -----
+
+    async def summarize_day(self, date: str) -> Optional[str]:
+        """
+        Erstellt eine Tages-Zusammenfassung.
+
+        Args:
+            date: Datum im Format "YYYY-MM-DD"
+
+        Returns:
+            Zusammenfassung als String oder None
+        """
+        # Pruefen ob schon existiert
+        existing = await self._get_summary(date, DAILY)
+        if existing:
+            logger.info("Tages-Summary fuer %s existiert bereits", date)
+            return existing
+
+        # Konversationen des Tages laden
+        conversations = await self._get_conversations_for_date(date)
+        if not conversations:
+            logger.info("Keine Konversationen fuer %s, ueberspringe", date)
+            return None
+
+        # LLM-Zusammenfassung erstellen
+        prompt = self._build_daily_prompt(date, conversations)
+        summary = await self._generate_summary(prompt, self.max_tokens_daily)
+
+        if summary:
+            await self._store_summary(date, DAILY, summary)
+            logger.info("Tages-Summary fuer %s erstellt (%d Zeichen)", date, len(summary))
+
+        return summary
+
+    # ----- Wochen-Zusammenfassung -----
+
+    async def summarize_week(self, end_date: Optional[str] = None) -> Optional[str]:
+        """
+        Erstellt eine Wochen-Zusammenfassung aus Tages-Summaries.
+
+        Args:
+            end_date: Letzter Tag der Woche (default: gestern)
+        """
+        if not end_date:
+            end_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+        start_dt = end_dt - timedelta(days=6)
+        week_key = f"{start_dt.strftime('%Y-%m-%d')}_to_{end_date}"
+
+        # Pruefen ob schon existiert
+        existing = await self._get_summary(week_key, WEEKLY)
+        if existing:
+            logger.info("Wochen-Summary fuer %s existiert bereits", week_key)
+            return existing
+
+        # Tages-Summaries sammeln
+        daily_summaries = []
+        for i in range(7):
+            day = (start_dt + timedelta(days=i)).strftime("%Y-%m-%d")
+            day_summary = await self._get_summary(day, DAILY)
+            if day_summary:
+                daily_summaries.append(f"[{day}]: {day_summary}")
+
+        if not daily_summaries:
+            logger.info("Keine Tages-Summaries fuer Woche %s", week_key)
+            return None
+
+        prompt = self._build_weekly_prompt(week_key, daily_summaries)
+        summary = await self._generate_summary(prompt, self.max_tokens_weekly)
+
+        if summary:
+            await self._store_summary(week_key, WEEKLY, summary)
+            logger.info("Wochen-Summary fuer %s erstellt", week_key)
+
+        return summary
+
+    # ----- Monats-Zusammenfassung -----
+
+    async def summarize_month(self, month: Optional[str] = None) -> Optional[str]:
+        """
+        Erstellt eine Monats-Zusammenfassung aus Wochen-Summaries.
+
+        Args:
+            month: Monat im Format "YYYY-MM" (default: letzter Monat)
+        """
+        if not month:
+            last_month = datetime.now().replace(day=1) - timedelta(days=1)
+            month = last_month.strftime("%Y-%m")
+
+        # Pruefen ob schon existiert
+        existing = await self._get_summary(month, MONTHLY)
+        if existing:
+            logger.info("Monats-Summary fuer %s existiert bereits", month)
+            return existing
+
+        # Wochen-Summaries und Tages-Summaries des Monats sammeln
+        year, mon = month.split("-")
+        summaries = []
+
+        # Alle Tages-Summaries des Monats
+        for day in range(1, 32):
+            try:
+                date = f"{year}-{mon}-{day:02d}"
+                # Pruefen ob Datum gueltig
+                datetime.strptime(date, "%Y-%m-%d")
+                day_summary = await self._get_summary(date, DAILY)
+                if day_summary:
+                    summaries.append(f"[{date}]: {day_summary}")
+            except ValueError:
+                break  # Ungeltiges Datum (z.B. 31. Feb)
+
+        if not summaries:
+            logger.info("Keine Summaries fuer Monat %s", month)
+            return None
+
+        prompt = self._build_monthly_prompt(month, summaries)
+        summary = await self._generate_summary(prompt, self.max_tokens_monthly)
+
+        if summary:
+            await self._store_summary(month, MONTHLY, summary)
+            logger.info("Monats-Summary fuer %s erstellt", month)
+
+        return summary
+
+    # ----- Suche in Summaries -----
+
+    async def search_summaries(self, query: str, limit: int = 5) -> list[dict]:
+        """Sucht in allen Zusammenfassungen per Vektor-Suche."""
+        if not self.chroma_collection:
+            return []
+
+        try:
+            results = self.chroma_collection.query(
+                query_texts=[query],
+                n_results=limit,
+                where={"type": {"$in": [DAILY, WEEKLY, MONTHLY]}},
+            )
+
+            summaries = []
+            if results and results.get("documents"):
+                for i, doc in enumerate(results["documents"][0]):
+                    meta = results["metadatas"][0][i] if results.get("metadatas") else {}
+                    summaries.append({
+                        "content": doc,
+                        "date": meta.get("date", ""),
+                        "summary_type": meta.get("type", ""),
+                        "relevance": results["distances"][0][i]
+                        if results.get("distances")
+                        else 0,
+                    })
+            return summaries
+        except Exception as e:
+            logger.error("Fehler bei Summary-Suche: %s", e)
+            return []
+
+    async def get_recent_summaries(self, limit: int = 7) -> list[dict]:
+        """Holt die neuesten Zusammenfassungen."""
+        if not self.redis:
+            return []
+
+        try:
+            keys = []
+            cursor = 0
+            while True:
+                cursor, batch = await self.redis.scan(
+                    cursor, match="mha:summary:daily:*", count=100
+                )
+                keys.extend(batch)
+                if cursor == 0:
+                    break
+
+            # Nach Datum sortieren (neueste zuerst)
+            keys.sort(reverse=True)
+            keys = keys[:limit]
+
+            summaries = []
+            for key in keys:
+                content = await self.redis.get(key)
+                if content:
+                    date = key.replace("mha:summary:daily:", "")
+                    summaries.append({"date": date, "content": content})
+            return summaries
+        except Exception as e:
+            logger.error("Fehler beim Laden der Summaries: %s", e)
+            return []
+
+    # ----- Private Hilfsmethoden -----
+
+    async def _get_conversations_for_date(self, date: str) -> list[dict]:
+        """Holt alle Konversationen eines bestimmten Tages."""
+        # Primaer: MemoryManager Archiv (Phase 7)
+        if self.memory:
+            convs = await self.memory.get_conversations_for_date(date)
+            if convs:
+                return convs
+
+        # Fallback: Working Memory durchsuchen
+        if not self.redis:
+            return []
+
+        try:
+            all_convs = await self.redis.lrange("mha:conversations", 0, -1)
+            day_convs = []
+            for entry in all_convs:
+                conv = json.loads(entry)
+                ts = conv.get("timestamp", "")
+                if ts.startswith(date):
+                    day_convs.append(conv)
+            day_convs.sort(key=lambda x: x.get("timestamp", ""))
+            return day_convs
+        except Exception as e:
+            logger.error("Fehler beim Laden der Konversationen fuer %s: %s", date, e)
+            return []
+
+    async def _generate_summary(self, prompt: str, max_tokens: int) -> Optional[str]:
+        """Generiert eine Zusammenfassung via LLM."""
+        try:
+            response = await self.ollama.chat(
+                messages=[
+                    {"role": "system", "content": self._get_system_prompt()},
+                    {"role": "user", "content": prompt},
+                ],
+                model=self.model,
+                max_tokens=max_tokens,
+            )
+
+            content = response.get("message", {}).get("content", "")
+            if content:
+                return content.strip()
+            return None
+        except Exception as e:
+            logger.error("Fehler bei LLM-Zusammenfassung: %s", e)
+            return None
+
+    async def _store_summary(self, date: str, summary_type: str, content: str):
+        """Speichert eine Zusammenfassung in Redis und ChromaDB."""
+        # Redis (schneller Zugriff)
+        if self.redis:
+            key = f"mha:summary:{summary_type}:{date}"
+            await self.redis.set(key, content)
+
+        # ChromaDB (Vektor-Suche)
+        if self.chroma_collection:
+            try:
+                doc_id = f"summary_{summary_type}_{date}"
+                self.chroma_collection.upsert(
+                    documents=[content],
+                    metadatas=[{
+                        "date": date,
+                        "type": summary_type,
+                        "created_at": datetime.now().isoformat(),
+                    }],
+                    ids=[doc_id],
+                )
+            except Exception as e:
+                logger.error("Fehler beim Speichern in ChromaDB: %s", e)
+
+    async def _get_summary(self, date: str, summary_type: str) -> Optional[str]:
+        """Holt eine existierende Zusammenfassung."""
+        if not self.redis:
+            return None
+        return await self.redis.get(f"mha:summary:{summary_type}:{date}")
+
+    def _get_system_prompt(self) -> str:
+        return """Du bist der MindHome Assistant Memory Processor.
+Deine Aufgabe: Erstelle KURZE, praezise Zusammenfassungen von Gespraechen und Ereignissen.
+Sprache: Deutsch.
+Fokus auf: Wichtige Fakten, Stimmungen, Muster, Praeferenzen.
+KEINE Floskeln. Nur Inhalt.
+Format: Fliesstext, kurze Saetze."""
+
+    def _build_daily_prompt(self, date: str, conversations: list[dict]) -> str:
+        parts = [f"Erstelle eine Tages-Zusammenfassung fuer {date}.\n"]
+        parts.append("Konversationen des Tages:\n")
+
+        for conv in conversations:
+            role = "User" if conv["role"] == "user" else "Assistant"
+            time = conv.get("timestamp", "")[:16]  # YYYY-MM-DDTHH:MM
+            parts.append(f"[{time}] {role}: {conv['content']}")
+
+        parts.append("\nFasse zusammen: Was wurde besprochen? "
+                     "Welche Aktionen? Stimmung? Besonderheiten?")
+        parts.append("Maximal 200 Woerter.")
+
+        return "\n".join(parts)
+
+    def _build_weekly_prompt(self, week: str, daily_summaries: list[str]) -> str:
+        parts = [f"Erstelle eine Wochen-Zusammenfassung fuer die Woche {week}.\n"]
+        parts.append("Tages-Zusammenfassungen:\n")
+
+        for summary in daily_summaries:
+            parts.append(summary)
+
+        parts.append("\nFasse die Woche zusammen: Muster, Trends, "
+                     "wichtige Ereignisse, Stimmungsverlauf.")
+        parts.append("Maximal 150 Woerter.")
+
+        return "\n".join(parts)
+
+    def _build_monthly_prompt(self, month: str, summaries: list[str]) -> str:
+        parts = [f"Erstelle eine Monats-Zusammenfassung fuer {month}.\n"]
+        parts.append("Zusammenfassungen des Monats:\n")
+
+        for summary in summaries:
+            parts.append(summary)
+
+        parts.append("\nFasse den Monat zusammen: Uebergreifende Muster, "
+                     "Veraenderungen, wichtige Meilensteine.")
+        parts.append("Maximal 200 Woerter.")
+
+        return "\n".join(parts)

--- a/assistant/assistant/websocket.py
+++ b/assistant/assistant/websocket.py
@@ -1,0 +1,108 @@
+"""
+WebSocket Manager - Echtzeit-Kommunikation mit Clients.
+Sendet Events wie assistant.speaking, assistant.thinking, etc.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+from typing import Optional
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectionManager:
+    """Verwaltet aktive WebSocket-Verbindungen."""
+
+    def __init__(self):
+        self.active_connections: list[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        """Neue Verbindung akzeptieren."""
+        await websocket.accept()
+        self.active_connections.append(websocket)
+        logger.info("WebSocket verbunden (%d aktiv)", len(self.active_connections))
+
+    def disconnect(self, websocket: WebSocket):
+        """Verbindung entfernen."""
+        self.active_connections.remove(websocket)
+        logger.info("WebSocket getrennt (%d aktiv)", len(self.active_connections))
+
+    async def broadcast(self, event: str, data: Optional[dict] = None):
+        """Event an alle verbundenen Clients senden."""
+        if not self.active_connections:
+            return
+
+        message = json.dumps({
+            "event": event,
+            "data": data or {},
+            "timestamp": datetime.now().isoformat(),
+        })
+
+        disconnected = []
+        for connection in self.active_connections:
+            try:
+                await connection.send_text(message)
+            except Exception:
+                disconnected.append(connection)
+
+        for conn in disconnected:
+            self.active_connections.remove(conn)
+
+    async def send_personal(self, websocket: WebSocket, event: str, data: Optional[dict] = None):
+        """Event an einen bestimmten Client senden."""
+        message = json.dumps({
+            "event": event,
+            "data": data or {},
+            "timestamp": datetime.now().isoformat(),
+        })
+        try:
+            await websocket.send_text(message)
+        except Exception:
+            pass
+
+
+# Globale Instanz
+ws_manager = ConnectionManager()
+
+
+async def emit_thinking():
+    """Signalisiert: Assistant denkt nach."""
+    await ws_manager.broadcast("assistant.thinking", {"status": "processing"})
+
+
+async def emit_speaking(text: str):
+    """Signalisiert: Assistant spricht."""
+    await ws_manager.broadcast("assistant.speaking", {"text": text})
+
+
+async def emit_action(function_name: str, args: dict, result: dict):
+    """Signalisiert: Assistant fuehrt Aktion aus."""
+    await ws_manager.broadcast("assistant.action", {
+        "function": function_name,
+        "args": args,
+        "result": result,
+    })
+
+
+async def emit_listening():
+    """Signalisiert: Assistant hoert zu."""
+    await ws_manager.broadcast("assistant.listening", {"status": "active"})
+
+
+async def emit_proactive(
+    text: str,
+    event_type: str,
+    urgency: str = "medium",
+    notification_id: str = "",
+):
+    """Signalisiert: Proaktive Meldung (mit ID fuer Feedback-Tracking)."""
+    await ws_manager.broadcast("assistant.proactive", {
+        "text": text,
+        "event_type": event_type,
+        "urgency": urgency,
+        "notification_id": notification_id,
+    })

--- a/assistant/config/settings.yaml
+++ b/assistant/config/settings.yaml
@@ -1,0 +1,227 @@
+# ============================================================
+# MindHome Assistant - Hauptkonfiguration
+# ============================================================
+
+assistant:
+  # Name des Assistenten - so stellt er sich vor und so reagiert er
+  # Aendere diesen Namen zu was du willst (z.B. "Jarvis", "Alfred", "Nova")
+  name: "Jarvis"
+  version: "0.8.0"
+  language: "de"
+
+# --- Personen und Anrede ---
+# Wie Jarvis die Hausbewohner anspricht
+# Hauptbenutzer (user_name in .env) = "Sir" (Standard)
+# Andere Personen: Name oder Titel
+persons:
+  titles:
+    # key = vorname (kleingeschrieben), value = Anrede
+    # Der Hauptbenutzer (USER_NAME in .env) wird automatisch "Sir"
+    # Weitere Personen hier hinzufuegen:
+    # lisa: "Ms. Lisa"
+    # thomas: "Thomas"
+
+# --- Autonomie-Level ---
+# 1 = Assistent (nur auf Befehle reagieren)
+# 2 = Butler (+ proaktive Infos)
+# 3 = Mitbewohner (+ kleine Aenderungen selbst)
+# 4 = Vertrauter (+ Routinen anpassen)
+# 5 = Autopilot (+ Automationen erstellen)
+autonomy:
+  level: 2
+
+# --- Modell-Routing ---
+models:
+  fast: "qwen2.5:3b"
+  smart: "qwen2.5:14b"
+
+  # Keywords die das schnelle Modell triggern
+  fast_keywords:
+    - "licht"
+    - "lampe"
+    - "temperatur"
+    - "heizung"
+    - "rollladen"
+    - "jalousie"
+    - "szene"
+    - "alarm"
+    - "tuer"
+    - "gute nacht"
+    - "guten morgen"
+    - "musik"
+    - "pause"
+    - "stopp"
+    - "stop"
+    - "leiser"
+    - "lauter"
+    - "an"
+    - "aus"
+
+  # LLM Optionen
+  options:
+    temperature: 0.7
+    max_tokens: 256
+
+# --- Persoenlichkeit ---
+personality:
+  style: "butler"  # butler, minimal, freundlich
+
+  time_layers:
+    early_morning:  # 05:00-08:00
+      style: "ruhig, minimal, kein Humor. Kurzes Briefing wenn gefragt."
+      max_sentences: 1
+    morning:  # 08:00-12:00
+      style: "sachlich, effizient. Gelegentlich trocken. Produktiv-Modus."
+      max_sentences: 2
+    afternoon:  # 12:00-18:00
+      style: "normal, souveraen. Trockener Humor erlaubt."
+      max_sentences: 2
+    evening:  # 18:00-22:00
+      style: "entspannter, mehr Humor. Darf spitze Bemerkungen machen."
+      max_sentences: 3
+    night:  # 22:00-05:00
+      style: "nur Notfaelle, absolute Stille. Fluestern wenn ueberhaupt."
+      max_sentences: 1
+
+# --- Proaktive Meldungen ---
+proactive:
+  enabled: true
+  cooldown_seconds: 300  # Minimum 5 Minuten zwischen Meldungen
+
+  # Wann NICHT melden (ausser Critical)
+  silence_scenes:
+    - "filmabend"
+    - "kino"
+    - "schlafen"
+    - "meditation"
+
+# --- Semantisches Gedaechtnis (Phase 2) ---
+memory:
+  # Fakten-Extraktion nach Gespraechen
+  extraction_enabled: true
+  # Minimale Wortanzahl fuer Extraktion
+  extraction_min_words: 5
+  # Modell fuer Fakten-Extraktion (schnelles reicht)
+  extraction_model: "qwen2.5:3b"
+  # Maximale Fakten pro Person im Kontext
+  max_person_facts_in_context: 5
+  # Maximale relevante Fakten im Kontext
+  max_relevant_facts_in_context: 3
+  # Minimale Confidence fuer Kontext-Einblendung
+  min_confidence_for_context: 0.6
+  # Duplikat-Schwelle (0.0 = exakt gleich, 1.0 = komplett anders)
+  duplicate_threshold: 0.15
+
+# --- Action Planner (Phase 4) ---
+planner:
+  # Maximale Iterationen (LLM-Runden) pro Plan
+  max_iterations: 5
+  # Modell fuer Planung (immer smart)
+  model: "qwen2.5:14b"
+  # Keywords die komplexe Anfragen erkennen
+  complex_keywords:
+    - "alles"
+    - "fertig machen"
+    - "vorbereiten"
+    - "gehe weg"
+    - "fahre weg"
+    - "verreise"
+    - "urlaub"
+    - "routine"
+    - "morgenroutine"
+    - "abendroutine"
+    - "wenn ich"
+    - "falls ich"
+    - "bevor ich"
+    - "zuerst"
+    - "danach"
+    - "und dann"
+    - "ausserdem"
+    - "komplett"
+    - "ueberall"
+    - "in allen"
+    - "party"
+    - "besuch kommt"
+    - "gaeste"
+
+# --- Mood Detector (Phase 3) ---
+mood:
+  # Sekunden zwischen Befehlen = "schnelle Befehle" (Stress-Signal)
+  rapid_command_seconds: 5
+  # Wie schnell Stress abklingt (in Sekunden fuer vollen Abbau)
+  stress_decay_seconds: 300
+  # Ab wie vielen negativen Signalen = "frustriert"
+  frustration_threshold: 3
+  # Ab welcher Uhrzeit gilt "spaet" (muede-Erkennung)
+  tired_hour_start: 23
+  tired_hour_end: 5
+
+# --- Activity Engine + Silence Matrix (Phase 6) ---
+activity:
+  # Entity-IDs (an deine Installation anpassen)
+  entities:
+    media_players:
+      - "media_player.wohnzimmer"
+      - "media_player.fernseher"
+      - "media_player.tv"
+    mic_sensors:
+      - "binary_sensor.mic_active"
+      - "binary_sensor.microphone"
+    bed_sensors:
+      - "binary_sensor.bed_occupancy"
+      - "binary_sensor.bett"
+    pc_sensors:
+      - "binary_sensor.pc_active"
+      - "binary_sensor.computer"
+      - "switch.pc"
+
+  # Schwellwerte fuer Erkennung
+  thresholds:
+    night_start: 22        # Ab wann gilt "Nacht"
+    night_end: 7           # Bis wann gilt "Nacht"
+    guest_person_count: 2  # Ab wie vielen Personen = "Gaeste"
+    focus_min_minutes: 30  # Wie lange PC aktiv fuer "fokussiert"
+
+# --- Feedback Loop (Phase 5) ---
+feedback:
+  # Auto-Timeout: Sekunden ohne Reaktion = "ignored"
+  auto_timeout_seconds: 120
+  # Basis-Cooldown in Sekunden (wird adaptiv angepasst)
+  base_cooldown_seconds: 300
+  # Score-Grenzen fuer Entscheidungen
+  score_suppress: 0.15    # Darunter: nicht mehr senden
+  score_reduce: 0.30      # Darunter: laengerer Cooldown
+  score_normal: 0.50      # Normaler Cooldown
+  score_boost: 0.70       # Darueber: kuerzerer Cooldown
+
+# --- Daily Summarizer + Langzeitgedaechtnis (Phase 7) ---
+summarizer:
+  # Wann laeuft der naechtliche Summary-Job
+  run_hour: 3
+  run_minute: 0
+  # Modell fuer Zusammenfassungen (smart fuer bessere Qualitaet)
+  model: "qwen2.5:14b"
+  # Maximale Token pro Zusammenfassung
+  max_tokens_daily: 512
+  max_tokens_weekly: 384
+  max_tokens_monthly: 512
+
+# --- Context Builder ---
+context:
+  # Wie viele letzte Gespraeche im Working Memory
+  recent_conversations: 5
+  # Timeout fuer API-Calls in Sekunden
+  api_timeout: 5
+
+# --- Sicherheit ---
+security:
+  # Aktionen die Bestaetigung brauchen
+  require_confirmation:
+    - "lock_door:unlock"
+    - "set_alarm:disarm"
+    - "set_climate:off"
+
+  # Temperatur-Grenzen
+  climate_limits:
+    min: 15
+    max: 28

--- a/assistant/docker-compose.yml
+++ b/assistant/docker-compose.yml
@@ -1,0 +1,70 @@
+# ============================================================
+# MindHome Assistant - Docker Compose
+# Startet alle Dienste: Assistant + ChromaDB + Redis
+# Ollama laeuft NATIV (nicht in Docker) fuer bessere Performance
+# ============================================================
+#
+# Starten: docker compose up -d
+# Stoppen: docker compose down
+# Logs: docker compose logs -f assistant
+# Status: docker compose ps
+#
+
+services:
+  # --- MindHome Assistant Service (das Gehirn) ---
+  assistant:
+    build: .
+    container_name: mindhome-assistant
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "8200:8200"
+    volumes:
+      - ./config:/app/config:ro
+      - ./data/assistant:/app/data
+    depends_on:
+      chromadb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    # Ollama laeuft nativ auf dem Host
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - OLLAMA_URL=http://host.docker.internal:11434
+      - REDIS_URL=redis://redis:6379
+      - CHROMA_URL=http://chromadb:8000
+
+  # --- ChromaDB (Langzeitgedaechtnis / Vektor-DB) ---
+  chromadb:
+    image: chromadb/chroma:latest
+    container_name: mha-chromadb
+    restart: unless-stopped
+    volumes:
+      - ./data/chroma:/chroma/chroma
+    ports:
+      - "8100:8000"
+    environment:
+      - ANONYMIZED_TELEMETRY=false
+      - IS_PERSISTENT=TRUE
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # --- Redis (Working Memory / Cache) ---
+  redis:
+    image: redis:7-alpine
+    container_name: mha-redis
+    restart: unless-stopped
+    volumes:
+      - ./data/redis:/data
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/assistant/install.sh
+++ b/assistant/install.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+# ============================================================
+# MindHome Assistant - Ein-Klick-Installation
+# Installiert alles auf dem Assistant-PC (Ubuntu Server)
+# ============================================================
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+MHA_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo ""
+echo -e "${BLUE}============================================================${NC}"
+echo -e "${BLUE} MindHome Assistant - Installation${NC}"
+echo -e "${BLUE} Lokaler KI-Sprachassistent${NC}"
+echo -e "${BLUE}============================================================${NC}"
+echo ""
+
+# --- Schritt 1: System pruefen ---
+echo -e "${YELLOW}[1/6] System pruefen...${NC}"
+
+if [ "$(id -u)" -eq 0 ]; then
+    echo -e "${RED}Bitte NICHT als root ausfuehren. Nutze deinen normalen User.${NC}"
+    exit 1
+fi
+
+if ! command -v docker &> /dev/null; then
+    echo -e "${YELLOW}Docker nicht gefunden. Installiere Docker...${NC}"
+    sudo apt-get update
+    sudo apt-get install -y ca-certificates curl gnupg
+    sudo install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+        sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    echo "deb [arch=$(dpkg --print-architecture) \
+        signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update
+    sudo apt-get install -y docker-ce docker-ce-cli containerd.io \
+        docker-buildx-plugin docker-compose-plugin
+    sudo usermod -aG docker "$USER"
+    echo -e "${GREEN}Docker installiert.${NC}"
+    echo -e "${YELLOW}WICHTIG: Log dich aus und wieder ein, damit Docker ohne sudo geht.${NC}"
+    echo -e "${YELLOW}Danach fuehre install.sh nochmal aus.${NC}"
+    exit 0
+fi
+
+echo -e "${GREEN}Docker: OK${NC}"
+
+if docker compose version &> /dev/null; then
+    echo -e "${GREEN}Docker Compose: OK${NC}"
+else
+    echo -e "${RED}Docker Compose nicht gefunden. Bitte Docker aktualisieren.${NC}"
+    exit 1
+fi
+
+# --- Schritt 2: Ollama installieren ---
+echo ""
+echo -e "${YELLOW}[2/6] Ollama pruefen...${NC}"
+
+if ! command -v ollama &> /dev/null; then
+    echo -e "${YELLOW}Ollama nicht gefunden. Installiere...${NC}"
+    curl -fsSL https://ollama.ai/install.sh | sh
+    echo -e "${GREEN}Ollama installiert.${NC}"
+else
+    echo -e "${GREEN}Ollama: OK${NC}"
+fi
+
+# Ollama von aussen erreichbar machen
+if ! grep -q "OLLAMA_HOST=0.0.0.0" /etc/systemd/system/ollama.service.d/override.conf 2>/dev/null; then
+    echo -e "${YELLOW}Konfiguriere Ollama fuer Netzwerk-Zugriff...${NC}"
+    sudo mkdir -p /etc/systemd/system/ollama.service.d/
+    echo -e "[Service]\nEnvironment=\"OLLAMA_HOST=0.0.0.0\"" | \
+        sudo tee /etc/systemd/system/ollama.service.d/override.conf > /dev/null
+    sudo systemctl daemon-reload
+    sudo systemctl restart ollama
+    echo -e "${GREEN}Ollama hoert jetzt auf 0.0.0.0:11434${NC}"
+fi
+
+# --- Schritt 3: Modelle herunterladen ---
+echo ""
+echo -e "${YELLOW}[3/6] LLM-Modelle pruefen...${NC}"
+
+# Warte bis Ollama bereit ist
+for i in $(seq 1 10); do
+    if curl -s http://localhost:11434/api/tags > /dev/null 2>&1; then
+        break
+    fi
+    echo "  Warte auf Ollama... ($i/10)"
+    sleep 2
+done
+
+if ! ollama list 2>/dev/null | grep -q "qwen2.5:3b"; then
+    echo -e "${YELLOW}Lade Qwen 2.5 3B (schnelles Modell, ~2 GB)...${NC}"
+    ollama pull qwen2.5:3b
+    echo -e "${GREEN}Qwen 2.5 3B: OK${NC}"
+else
+    echo -e "${GREEN}Qwen 2.5 3B: bereits vorhanden${NC}"
+fi
+
+if ! ollama list 2>/dev/null | grep -q "qwen2.5:14b"; then
+    echo ""
+    echo -e "${YELLOW}Moechtest du auch das schlaue Modell laden? (Qwen 2.5 14B, ~9 GB)${NC}"
+    echo -e "${YELLOW}Das braucht ~16 GB RAM, ist aber viel schlauer.${NC}"
+    read -p "Herunterladen? (j/n): " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Jj]$ ]]; then
+        ollama pull qwen2.5:14b
+        echo -e "${GREEN}Qwen 2.5 14B: OK${NC}"
+    else
+        echo -e "${YELLOW}Uebersprungen. Kann spaeter mit 'ollama pull qwen2.5:14b' nachgeholt werden.${NC}"
+    fi
+else
+    echo -e "${GREEN}Qwen 2.5 14B: bereits vorhanden${NC}"
+fi
+
+# --- Schritt 4: Konfiguration ---
+echo ""
+echo -e "${YELLOW}[4/6] Konfiguration...${NC}"
+
+cd "$MHA_DIR"
+
+if [ ! -f .env ]; then
+    cp .env.example .env
+    echo ""
+    echo -e "${YELLOW}============================================================${NC}"
+    echo -e "${YELLOW} WICHTIG: .env Datei konfigurieren!${NC}"
+    echo -e "${YELLOW}============================================================${NC}"
+    echo ""
+    echo "  Bearbeite die Datei: $MHA_DIR/.env"
+    echo ""
+    echo "  Mindestens diese Werte anpassen:"
+    echo "    HA_URL=http://DEINE-HA-IP:8123"
+    echo "    HA_TOKEN=DEIN_LONG_LIVED_ACCESS_TOKEN"
+    echo "    USER_NAME=DEIN_NAME"
+    echo ""
+    read -p "Moechtest du die .env jetzt bearbeiten? (j/n): " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Jj]$ ]]; then
+        if command -v nano &> /dev/null; then
+            nano .env
+        else
+            vi .env
+        fi
+    else
+        echo -e "${YELLOW}Vergiss nicht, die .env spaeter zu bearbeiten!${NC}"
+    fi
+else
+    echo -e "${GREEN}.env existiert bereits${NC}"
+fi
+
+# --- Schritt 5: Daten-Verzeichnisse ---
+echo ""
+echo -e "${YELLOW}[5/6] Verzeichnisse erstellen...${NC}"
+mkdir -p data/chroma data/redis data/assistant
+echo -e "${GREEN}Daten-Verzeichnisse: OK${NC}"
+
+# --- Schritt 6: Docker starten ---
+echo ""
+echo -e "${YELLOW}[6/6] MindHome Assistant starten...${NC}"
+
+docker compose build
+docker compose up -d
+
+echo ""
+echo -e "${GREEN}============================================================${NC}"
+echo -e "${GREEN} MindHome Assistant ist installiert und gestartet!${NC}"
+echo -e "${GREEN}============================================================${NC}"
+echo ""
+echo "  Status:      docker compose ps"
+echo "  Logs:        docker compose logs -f assistant"
+echo "  Stoppen:     docker compose down"
+echo "  Neustarten:  docker compose restart"
+echo ""
+echo "  API:     http://$(hostname -I | awk '{print $1}'):8200"
+echo "  Docs:    http://$(hostname -I | awk '{print $1}'):8200/docs"
+echo "  Health:  http://$(hostname -I | awk '{print $1}'):8200/api/assistant/health"
+echo ""
+echo "  Test:"
+echo "    curl -X POST http://localhost:8200/api/assistant/chat \\"
+echo "      -H 'Content-Type: application/json' \\"
+echo "      -d '{\"text\": \"Hallo\", \"person\": \"Max\"}'"
+echo ""
+echo -e "${BLUE}Viel Spass mit MindHome Assistant!${NC}"

--- a/assistant/requirements.txt
+++ b/assistant/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.115.6
+uvicorn[standard]==0.34.0
+aiohttp==3.11.11
+pydantic==2.10.4
+pydantic-settings==2.7.1
+redis==5.2.1
+chromadb==0.5.23
+pyyaml==6.0.2
+python-dotenv==1.0.1
+httpx==0.28.1

--- a/docs/PROJECT_MINDHOME_ASSISTANT.md
+++ b/docs/PROJECT_MINDHOME_ASSISTANT.md
@@ -1,0 +1,1704 @@
+# MindHome Assistant - KI-Sprachassistent fuer MindHome
+
+> "MindHome Assistant ist kein Feature. MindHome Assistant ist das Gefuehl, dass dein Haus dich kennt."
+
+---
+
+## Inhaltsverzeichnis
+
+1. [Vision](#vision)
+2. [Hardware-Setup (Split-Architektur)](#hardware-setup-split-architektur)
+3. [Assistant-PC Setup Guide](#assistant-pc-setup-guide)
+4. [LLM-Modell Empfehlung](#llm-modell-empfehlung)
+5. [Latenz-Analyse](#latenz-analyse)
+6. [Gesamtarchitektur](#gesamtarchitektur)
+7. [Phase 1: Fundament](#phase-1-fundament)
+8. [Engine Layer](#engine-layer)
+9. [Assistant Layer (Sprach-KI)](#assistant-layer-sprach-ki)
+10. [Proactive Layer](#proactive-layer)
+11. [Das MindHome-Feeling](#das-mindhome-feeling)
+12. [Phase 2-7: Perfektion](#phase-2-7-perfektion)
+13. [Technische Details](#technische-details)
+14. [Autonomie-Level](#autonomie-level)
+15. [API-Referenz](#api-referenz)
+
+---
+
+## Vision
+
+MindHome Phase 1-5 macht das Haus intelligent. Es lernt Muster, optimiert Energie, erkennt Anomalien. Aber es reagiert nur - es hat keine Stimme, keine Persoenlichkeit.
+
+**MindHome Assistant** gibt MindHome eine Seele.
+
+MindHome Assistant ist ein lokaler, privater Sprachassistent der:
+- **Dein Haus kennt** - jeder Raum, jedes Geraet, jede Temperatur
+- **Dich kennt** - deine Gewohnheiten, Vorlieben, deinen Tagesablauf
+- **Handelt** - nicht nur redet, sondern Dinge tut
+- **Proaktiv ist** - spricht dich an, warnt, informiert
+- **Schweigt** - wenn es nichts zu sagen gibt
+- **Lokal laeuft** - nichts verlaesst dein Netzwerk
+
+---
+
+## Hardware-Setup (Split-Architektur)
+
+### Warum zwei PCs?
+
+| Aspekt | Alles auf einem PC | Split (HAOS + Assistant-PC) |
+|--------|-------------------|--------------------------|
+| **HAOS Stabilitaet** | LLM frisst CPU/RAM, HA langsamer | HA laeuft ungestoert |
+| **LLM Groesse** | Begrenzt durch HA-RAM | Ganzer PC nur fuer KI |
+| **GPU moeglich** | Nicht in HAOS | Ja! GPU = 10x schneller |
+| **Updates** | LLM-Update kann HA stoeren | Unabhaengig updaten |
+| **Ausfallsicherheit** | Alles faellt zusammen aus | HA + MindHome laufen ohne den Assistant |
+| **Netzwerk-Latenz** | 0 ms | <1 ms (LAN) - irrelevant |
+
+### PC 1: HAOS (bestehendes System)
+
+| Komponente | Detail |
+|-----------|--------|
+| **Geraet** | Intel NUC BXNUC10i7FNH2 |
+| **CPU** | Intel Core i7-10710U (6C/12T, bis 4.7 GHz) |
+| **RAM** | 32 GB DDR4 |
+| **Storage** | 500 GB NVMe + 500 GB SSD |
+| **OS** | Home Assistant OS |
+| **Aufgabe** | HA + MindHome + Whisper + Piper |
+
+### PC 2: MindHome Assistant Server (separater PC)
+
+| Komponente | Aufgabe |
+|-----------|---------|
+| **OS** | Ubuntu Server 24.04 LTS |
+| **Ollama** | LLM Inference (Qwen 2.5) |
+| **Assistant Service** | Context Builder, Personality, Action Planner |
+| **ChromaDB** | Langzeitgedaechtnis (Vektor-DB) |
+| **Redis** | Cache fuer schnelle Zugriffe |
+| **Optional** | GPU fuer schnellere Inference |
+
+### Netzwerk-Verteilung
+
+```
+Lokales Netzwerk (LAN, <1ms Latenz)
+|
+|  +--------------------------------------+
+|  | PC 1: Intel NUC (HAOS)               |
+|  |   i7-10710U / 32 GB / 500+500 GB     |
+|  |                                       |
+|  |   Home Assistant OS                   |
+|  |     +-- MindHome Add-on              |
+|  |     |    Alle 14 Engines             |
+|  |     |    Pattern Learning            |
+|  |     |    REST API (:8099)            |
+|  |     |    WebSocket Events            |
+|  |     +-- Whisper Add-on (STT)         |
+|  |     +-- Piper Add-on (TTS)           |
+|  |     +-- HA Core (:8123)              |
+|  +--------------------------------------+
+          |
+          |  REST API + WebSocket (<1ms)
+          |
+|  +--------------------------------------+
+|  | PC 2: MindHome Assistant Server                   |
+|  |   Ubuntu Server 24.04 LTS             |
+|  |                                       |
+|  |   Docker                              |
+|  |     +-- Ollama (:11434)              |
+|  |     |    Qwen 2.5 3B  (schnell)      |
+|  |     |    Qwen 2.5 14B (schlau)       |
+|  |     +-- ChromaDB (:8100)             |
+|  |     +-- Redis (:6379)                |
+|  |                                       |
+|  |   Assistant Service (:8200)              |
+|  |     +-- Context Builder              |
+|  |     +-- Personality Engine           |
+|  |     +-- Action Planner               |
+|  |     +-- Proactive Manager            |
+|  |     +-- Function Calling -> HA API   |
+|  |     +-- Memory Manager              |
+|  +--------------------------------------+
+```
+
+### Datenfluss zwischen den PCs
+
+```
+User spricht -> [Mikrofon]
+                    |
+         PC 1 (HAOS):
+                    |
+              [Whisper STT] -> Text
+                    |
+                    | HTTP POST (Text + Kontext-Anfrage)
+                    |
+         PC 2 (MindHome Assistant):
+                    |
+              [Context Builder]
+                    | holt Daten von PC 1 via REST API (<1ms)
+              [Ollama/Qwen 2.5]
+                    | generiert Antwort + Function Calls
+              [Function Executor]
+                    | sendet Befehle an HA via REST API (<1ms)
+                    |
+                    | HTTP Response (Antwort-Text)
+                    |
+         PC 1 (HAOS):
+                    |
+              [Piper TTS] -> Sprache
+                    |
+              [Speaker] -> User hoert Antwort
+```
+
+---
+
+## Assistant-PC Setup Guide
+
+### Schritt-fuer-Schritt: Vom leeren PC zum MindHome Assistant Server
+
+#### Schritt 1: Ubuntu Server installieren
+
+**Was du brauchst:**
+- USB-Stick (mind. 4 GB)
+- Den Assistant-PC mit leerem Datentraeger
+- Einen anderen PC fuer den Download
+
+**1.1 Ubuntu Server ISO herunterladen:**
+```
+https://ubuntu.com/download/server
+-> Ubuntu Server 24.04 LTS
+-> Datei: ubuntu-24.04-live-server-amd64.iso (~2.5 GB)
+```
+
+**1.2 Bootfaehigen USB-Stick erstellen:**
+```
+Windows: Rufus (https://rufus.ie) oder balenaEtcher
+Mac/Linux: balenaEtcher (https://etcher.balena.io)
+
+1. Programm starten
+2. ISO-Datei auswaehlen
+3. USB-Stick auswaehlen
+4. "Flash" klicken
+5. Warten bis fertig
+```
+
+**1.3 Vom USB-Stick booten:**
+```
+1. USB-Stick in Assistant-PC stecken
+2. PC einschalten
+3. Beim Start F2/F10/F12/DEL druecken (je nach BIOS)
+4. Boot-Reihenfolge: USB zuerst
+5. Ubuntu Installer startet
+```
+
+**1.4 Ubuntu Server installieren:**
+```
+Sprache:           Deutsch
+Tastatur:          Deutsch
+Netzwerk:          DHCP (automatisch) - spaeter feste IP
+Storage:           Gesamte Festplatte verwenden
+Profil:
+  Name:            MindHome
+  Servername:      mindhome-assistant
+  Benutzername:    mindhome
+  Passwort:        [dein sicheres Passwort]
+SSH:               OpenSSH Server INSTALLIEREN (wichtig!)
+Extras:            Nichts auswaehlen
+-> Installation starten, warten, neustarten
+-> USB-Stick entfernen wenn aufgefordert
+```
+
+#### Schritt 2: Feste IP-Adresse vergeben
+
+Nach dem ersten Login per Tastatur/Monitor:
+
+```bash
+# Netzwerk-Interface herausfinden
+ip addr show
+# -> z.B. "enp0s3" oder "eth0"
+
+# Netplan-Konfiguration bearbeiten
+sudo nano /etc/netplan/00-installer-config.yaml
+```
+
+Inhalt (anpassen an dein Netzwerk):
+```yaml
+network:
+  version: 2
+  ethernets:
+    enp0s3:              # <- dein Interface-Name
+      dhcp4: no
+      addresses:
+        - 192.168.1.200/24    # <- feste IP fuer Assistant-PC
+      routes:
+        - to: default
+          via: 192.168.1.1    # <- dein Router
+      nameservers:
+        addresses:
+          - 192.168.1.1       # <- DNS (Router)
+          - 8.8.8.8           # <- Fallback DNS
+```
+
+```bash
+# Anwenden
+sudo netplan apply
+
+# Testen
+ping 192.168.1.1      # Router erreichbar?
+ping google.com       # Internet erreichbar?
+```
+
+**Ab jetzt kannst du per SSH vom Hauptrechner aus arbeiten:**
+```bash
+# Von deinem normalen PC:
+ssh mindhome@192.168.1.200
+```
+
+#### Schritt 3: System aktualisieren
+
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo reboot
+```
+
+#### Schritt 4: Docker installieren
+
+```bash
+# Docker Repository hinzufuegen
+sudo apt install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+  sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) \
+  signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Docker installieren
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io \
+  docker-buildx-plugin docker-compose-plugin
+
+# User zur Docker-Gruppe hinzufuegen (kein sudo noetig)
+sudo usermod -aG docker mindhome
+newgrp docker
+
+# Testen
+docker run hello-world
+```
+
+#### Schritt 5: Ollama installieren
+
+```bash
+# Ollama installieren (nativ, nicht Docker - besser fuer CPU)
+curl -fsSL https://ollama.ai/install.sh | sh
+
+# Ollama als System-Service laeuft automatisch
+# Pruefen:
+sudo systemctl status ollama
+
+# Ollama von aussen erreichbar machen
+sudo systemctl edit ollama
+```
+
+Einfuegen:
+```ini
+[Service]
+Environment="OLLAMA_HOST=0.0.0.0"
+```
+
+```bash
+# Neustarten
+sudo systemctl restart ollama
+
+# Modelle herunterladen
+ollama pull qwen2.5:3b       # ~2 GB, fuer schnelle Befehle
+ollama pull qwen2.5:14b      # ~9 GB, fuer komplexe Fragen
+
+# Testen
+ollama run qwen2.5:3b "Sag Hallo auf Deutsch"
+# -> Sollte "Hallo!" oder aehnliches antworten
+# Mit CTRL+D beenden
+
+# Test von einem anderen PC im Netzwerk:
+curl http://192.168.1.200:11434/api/generate \
+  -d '{"model":"qwen2.5:3b","prompt":"Hallo","stream":false}'
+```
+
+#### Schritt 6: ChromaDB + Redis per Docker
+
+```bash
+# Verzeichnis fuer MindHome Assistant erstellen
+mkdir -p ~/mindhome-assistant
+cd ~/mindhome-assistant
+
+# Docker Compose Datei erstellen
+cat > docker-compose.yml << 'EOF'
+services:
+  chromadb:
+    image: chromadb/chroma:latest
+    container_name: mindhome-chromadb
+    restart: unless-stopped
+    volumes:
+      - ./data/chroma:/chroma/chroma
+    ports:
+      - "8100:8000"
+    environment:
+      - ANONYMIZED_TELEMETRY=false
+      - IS_PERSISTENT=TRUE
+
+  redis:
+    image: redis:7-alpine
+    container_name: mindhome-redis
+    restart: unless-stopped
+    volumes:
+      - ./data/redis:/data
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+EOF
+
+# Starten
+docker compose up -d
+
+# Pruefen
+docker compose ps
+# -> Beide Container sollten "running" sein
+
+# Testen
+curl http://localhost:8100/api/v1/heartbeat
+# -> {"nanosecond heartbeat": ...}
+```
+
+#### Schritt 7: Verbindung zu Home Assistant testen
+
+```bash
+# HA Long-Lived Access Token erstellen:
+# 1. HA Dashboard oeffnen -> Profil (unten links)
+# 2. Ganz unten: "Langlebige Zugangstoken"
+# 3. Token erstellen, Name: "MindHome Assistant"
+# 4. Token KOPIEREN und sicher speichern!
+
+# Testen ob HA erreichbar ist:
+curl -s -H "Authorization: Bearer DEIN_TOKEN_HIER" \
+  http://192.168.1.100:8123/api/ | head
+# -> {"message": "API running."}
+
+# MindHome API testen:
+curl -s http://192.168.1.100:8099/api/system/health | head
+# -> {"status": "ok", ...}
+```
+
+#### Schritt 8: Autostart einrichten
+
+```bash
+# Alles startet automatisch nach Reboot:
+# - Ollama: bereits als systemd Service
+# - Docker (ChromaDB + Redis): restart: unless-stopped
+# - Ubuntu: bootet automatisch ohne Monitor/Tastatur
+
+# Optional: Automatic Security Updates
+sudo apt install -y unattended-upgrades
+sudo dpkg-reconfigure -plow unattended-upgrades
+```
+
+#### Schritt 9: Firewall einrichten
+
+```bash
+sudo ufw enable
+sudo ufw allow ssh                 # SSH Zugang
+sudo ufw allow from 192.168.1.0/24 to any port 11434  # Ollama (nur LAN)
+sudo ufw allow from 192.168.1.0/24 to any port 8100   # ChromaDB (nur LAN)
+sudo ufw allow from 192.168.1.0/24 to any port 8200   # MindHome Assistant API (nur LAN)
+sudo ufw allow from 192.168.1.0/24 to any port 6379   # Redis (nur LAN)
+sudo ufw status
+```
+
+### Checkliste: Ist alles bereit?
+
+```
+[ ] Ubuntu Server 24.04 LTS installiert
+[ ] Feste IP-Adresse vergeben (z.B. 192.168.1.200)
+[ ] SSH funktioniert
+[ ] Docker installiert und laeuft
+[ ] Ollama installiert und hoert auf 0.0.0.0:11434
+[ ] Qwen 2.5 3B heruntergeladen und getestet
+[ ] Qwen 2.5 14B heruntergeladen und getestet
+[ ] ChromaDB Container laeuft auf Port 8100
+[ ] Redis Container laeuft auf Port 6379
+[ ] HA API erreichbar von Assistant-PC
+[ ] MindHome API erreichbar von Assistant-PC
+[ ] Firewall konfiguriert
+[ ] Alles startet automatisch nach Reboot
+```
+
+---
+
+## LLM-Modell Empfehlung
+
+### Anforderungen fuer MindHome Assistant
+
+Das LLM muss:
+- **Deutsch** gut koennen (Hauptsprache)
+- **Function Calling** nativ unterstuetzen
+- **Kurze Antworten** liefern (nicht labern)
+- **Schnell** auf CPU laufen
+- **Kontext verstehen** (Raum, Person, Situation)
+
+### Modell-Vergleich
+
+#### Tier 1: Beste Wahl (7-9B Parameter)
+
+| Modell | RAM (Q8) | Deutsch | Function Calling | Speed | Note |
+|--------|----------|---------|-----------------|-------|------|
+| **Qwen 2.5 7B** | ~9 GB | Exzellent | Nativ | Schnell | Bestes Deutsch |
+| Llama 3.1 8B | ~10 GB | Sehr gut | Nativ | Schnell | Guter Allrounder |
+| Mistral 7B v0.3 | ~9 GB | Gut | Nativ | Schnell | Antwortet manchmal Englisch |
+
+#### Tier 2: Premium (12-14B)
+
+| Modell | RAM (Q6) | Deutsch | Function Calling | Speed | Note |
+|--------|----------|---------|-----------------|-------|------|
+| **Qwen 2.5 14B** | ~13 GB | Exzellent | Nativ | Mittel | Beste Qualitaet |
+| Mistral Nemo 12B | ~11 GB | Sehr gut | Nativ | Mittel | Gute Alternative |
+
+#### Tier 3: Schnell (3-4B) fuer einfache Befehle
+
+| Modell | RAM (Q8) | Deutsch | Function Calling | Speed | Note |
+|--------|----------|---------|-----------------|-------|------|
+| **Qwen 2.5 3B** | ~4 GB | Gut | Nativ | Sehr schnell | Ideal fuer Geraete-Befehle |
+
+### Empfehlung: Dual-Modell Strategie
+
+```
+Qwen 2.5 3B   -> einfache Befehle  -> ~1.5-2.5s Antwort
+Qwen 2.5 14B  -> komplexe Fragen   -> ~4-7s Antwort
+
+Beide gleichzeitig in Ollama geladen.
+```
+
+**Routing-Logik** entscheidet automatisch welches Modell:
+
+```python
+class ModelRouter:
+    SIMPLE_KEYWORDS = [
+        "licht", "temperatur", "heizung", "rollladen",
+        "szene", "alarm", "tuer", "gute nacht",
+        "musik", "pause", "stopp", "leiser", "lauter"
+    ]
+
+    def select_model(self, text: str) -> str:
+        if any(word in text.lower() for word in self.SIMPLE_KEYWORDS):
+            return "qwen2.5:3b"     # Schnell
+        return "qwen2.5:14b"        # Schlau
+```
+
+### GPU-Upgrade Option (spaeter)
+
+Falls du eine GPU nachruesten willst:
+
+| GPU | VRAM | Modell | Speed | Preis (gebraucht) |
+|-----|------|--------|-------|-------------------|
+| RTX 3060 12GB | 12 GB | Qwen 2.5 14B Q4 | ~80 tok/s | ~180 EUR |
+| RTX 3090 24GB | 24 GB | Qwen 2.5 32B Q4 | ~50 tok/s | ~600 EUR |
+| RTX 4060 Ti 16GB | 16 GB | Qwen 2.5 14B Q8 | ~90 tok/s | ~350 EUR |
+
+Mit GPU waere MindHome Assistant so schnell wie Alexa - aber komplett lokal.
+
+---
+
+## Latenz-Analyse
+
+### Szenarien auf dem Assistant-PC (CPU only)
+
+| Szenario | Modell | Methode | Latenz |
+|----------|--------|---------|--------|
+| "Licht aus" | Qwen 3B | Fast-Route | **~2-2.5 s** |
+| "Gute Nacht" | Qwen 3B | Fast-Route + Multi-Action | **~2-3 s** |
+| "Mach es gemuetlich" | Qwen 14B | LLM (Szene waehlen) | **~4-6 s** |
+| "Zu kalt hier" | Qwen 14B | LLM (Kontext) | **~4-6 s** |
+| "Was steht morgen an?" | Qwen 14B | LLM (Kalender) | **~5-7 s** |
+| Morgen-Briefing | Qwen 14B | Proaktiv | egal (nicht zeitkritisch) |
+| Sicherheits-Alarm | - | Template, kein LLM | **~1-2 s** |
+
+### Mit GPU (Upgrade-Option)
+
+| Szenario | CPU only | Mit RTX 3060 |
+|----------|----------|-------------|
+| "Licht aus" | ~2-2.5 s | ~1.5 s |
+| "Mach es gemuetlich" | ~4-6 s | **~1.5-2.5 s** |
+| "Was steht morgen an?" | ~5-7 s | **~2-3 s** |
+
+### Netzwerk-Latenz zwischen den PCs
+
+```
+LLM Inference:     2000-5000 ms   (99.9% der Wartezeit)
+LAN API Call:           <1 ms   ( 0.1% der Wartezeit)
+                   ────────────
+Fazit: Split-Architektur kostet KEINE spuerbare Latenz
+```
+
+---
+
+## Gesamtarchitektur
+
+### Split-Architektur: Zwei PCs im LAN
+
+```
++----------------------------------+    +----------------------------------+
+| PC 1: HAOS (Intel NUC)          |    | PC 2: MindHome Assistant Server              |
+| 192.168.1.100                    |    | 192.168.1.200                    |
+|                                  |    |                                  |
+| +------------------------------+|    |+-------------------------------+ |
+| | HOME ASSISTANT               ||    || ASSISTANT LAYER                  | |
+| |  +-- MindHome Add-on        ||    ||                               | |
+| |  |    REST API (:8099)       ||<---||  Context Builder              | |
+| |  |    WebSocket Events       ||    ||    | holt Daten via LAN API   | |
+| |  |                           ||    ||    v                          | |
+| |  +-- Whisper Add-on (STT)   ||    ||  Model Router                 | |
+| |  |    Wyoming Protocol      ||--->||    |                          | |
+| |  |                           ||    ||    +-> Qwen 2.5 3B  (schnell)| |
+| |  +-- Piper Add-on (TTS)     ||    ||    +-> Qwen 2.5 14B (schlau) | |
+| |  |    Wyoming Protocol      ||<---||    |   (via Ollama :11434)    | |
+| |  |                           ||    ||    v                          | |
+| |  +-- HA Core (:8123)        ||    ||  Action Planner               | |
+| |       REST API + WebSocket   ||<---||    | Function Calls -> HA API| |
+| +------------------------------+|    ||    v                          | |
+|                                  |    ||  Personality Engine          | |
+| +------------------------------+|    ||  Proactive Manager           | |
+| | ENGINE LAYER (in MindHome)   ||    ||  Feedback Loop               | |
+| |                               ||    |+-------------------------------+ |
+| | Climate | Lighting | Presence ||    |                                  |
+| | Security | Energy | Sleep     ||    |+-------------------------------+ |
+| | Comfort | Circadian | Pattern ||--->|| DATA LAYER                    | |
+| | Routine | Adaptive | Visit    || WS || ChromaDB (:8100) - Vektoren   | |
+| | Weather | Special Modes       ||    || Redis (:6379) - Cache          | |
+| +------------------------------+|    |+-------------------------------+ |
+|                                  |    |                                  |
+| +------------------------------+|    |                                  |
+| | DATA LAYER                   ||    |                                  |
+| | SQLite (MindHome-Daten)      ||    |                                  |
+| +------------------------------+|    |                                  |
++----------------------------------+    +----------------------------------+
+         |                                         |
+         +---------< LAN (<1ms) >------------------+
+```
+
+---
+
+## Phase 1: Fundament
+
+Phase 1 baut die Grundstruktur. Alles weitere baut darauf auf.
+
+### Komponenten
+
+#### 1. Whisper STT (Speech-to-Text)
+- **Was**: OpenAI Whisper, lokal als HA Add-on
+- **Modell**: `small` oder `medium` (deutsch)
+- **Latenz**: 1-3 Sekunden
+- **Integration**: HA Wyoming-Protokoll
+
+#### 2. Ollama + Qwen 2.5 (LLM) - auf Assistant-PC
+- **Was**: Ollama nativ auf dem Assistant-PC
+- **Modelle**: Qwen 2.5 3B (schnell) + Qwen 2.5 14B (schlau)
+- **API**: REST (`http://192.168.1.200:11434/api/chat`)
+- **Features**: Function Calling nativ, exzellentes Deutsch
+
+#### 3. Piper TTS (Text-to-Speech)
+- **Was**: Piper vom HA-Team, lokal
+- **Stimme**: `de_DE-thorsten-high`
+- **Latenz**: <0.5 Sekunden
+- **RAM**: ~200 MB
+- **Integration**: HA Wyoming-Protokoll
+
+#### 4. Context Builder
+- **Was**: Sammelt alle relevanten Daten fuer den LLM-Prompt
+- **Quellen**: Alle MindHome Engines + HA States
+- **Output**: Strukturierter Kontext-Block fuer das LLM
+
+#### 5. Function Calling
+- **Was**: LLM kann Funktionen aufrufen (Licht, Klima, Szenen, etc.)
+- **Wie**: Qwen 2.5 Function Calling Format (nativ unterstuetzt)
+- **Sicherheit**: Validation Layer prueft jeden Aufruf
+- **Netzwerk**: Assistant-PC ruft HA API auf PC 1 auf (<1ms LAN)
+
+### Phase 1 Datenfluss
+
+```
+User spricht "Mach das Licht im Wohnzimmer aus"
+    |
+    v
+[Whisper STT] --> "Mach das Licht im Wohnzimmer aus"
+    |
+    v
+[Context Builder]
+    Sammelt:
+    - Wer spricht? (Person aus Presence Engine)
+    - Wo? (Raum aus letzter Bewegung)
+    - Uhrzeit, Wetter, Haus-Status
+    - Aktuelle Zustaende (Licht Wohnzimmer: an, 80%)
+    |
+    v
+[System Prompt + Kontext + User-Text] --> Assistant-PC --> Ollama/Qwen
+    |
+    v
+[Qwen Output]
+    Gedanke: User will Wohnzimmer-Licht aus
+    Function Call: set_light("wohnzimmer", state="off")
+    Antwort: "Erledigt."
+    |
+    v
+[Function Executor] --> HA API: light.turn_off
+    |
+    v
+[Piper TTS] --> "Erledigt." --> Speaker
+```
+
+---
+
+## Engine Layer
+
+Die Engine Layer ist das Gehirn hinter dem Haus. Engines handeln sofort (kein LLM noetig) und feuern Events fuer die Proactive Layer.
+
+### Bestehende Engines (aus MindHome Phase 1-5)
+
+| Engine | Aufgabe | Assistant-Relevanz |
+|--------|---------|-----------------|
+| **Climate Engine** | Heizung, Kuehlung, Lueftung | "Zu kalt hier" -> weiss Zieltemperatur |
+| **Lighting Engine** | Licht-Steuerung, Szenen | Circadian, Stimmungslicht |
+| **Presence Engine** | Wer ist wo, Ankunft/Abfahrt | Raum-Kontext fuer Befehle |
+| **Security Engine** | Alarme, Kameras, Schluesser | Sicherheits-Benachrichtigungen |
+| **Energy Engine** | PV, Strompreis, Verbrauch | "Ist der Strom gerade guenstig?" |
+| **Sleep Engine** | Schlaferkennung, Wecker | Morgen-Briefing Trigger |
+| **Comfort Engine** | Wohlfuehl-Optimierung | Bad vorheizen, Raumklima |
+| **Circadian Engine** | Tagesrhythmus-Beleuchtung | Automatisches Licht ohne Befehl |
+| **Adaptive Engine** | Lernende Automationen | Pattern-basierte Vorschlaege |
+| **Pattern Engine** | Gewohnheiten erkennen | "Normalerweise machst du X" |
+| **Routine Engine** | Tagesablaeufe | Morgen-/Abend-Routinen |
+| **Visit Engine** | Gaeste-Management | "Lisa kommt" -> Gaeste-Modus |
+| **Weather Engine** | Wetter-Warnungen | Proaktive Wetter-Infos |
+| **Special Modes** | Party, Kino, HomeOffice | Szenen-Aktivierung per Sprache |
+
+### Engine-Event-System
+
+Engines kommunizieren ueber Events mit der Proactive Layer:
+
+```python
+# Engine feuert Event
+class EngineEvent:
+    engine: str          # "sleep_engine"
+    event_type: str      # "user_wakeup"
+    urgency: str         # "low" | "medium" | "high" | "critical"
+    data: dict           # {"person": "max", "sleep_duration": "7h12m"}
+    timestamp: datetime
+    requires_llm: bool   # Soll das LLM eine Nachricht formulieren?
+```
+
+Event-Typen und Prioritaeten:
+
+```
+CRITICAL (immer melden):
+  - security.alarm_triggered
+  - fire_water.smoke_detected
+  - fire_water.water_leak
+  - security.door_forced
+
+HIGH (melden wenn wach):
+  - presence.unknown_person
+  - energy.grid_outage
+  - weather.severe_warning
+  - security.camera_motion_night
+
+MEDIUM (melden wenn passend):
+  - presence.arrival
+  - presence.departure
+  - sleep.user_wakeup (-> Morgen-Briefing)
+  - routine.long_session
+  - energy.price_spike
+
+LOW (melden wenn User entspannt):
+  - appliance.washer_done
+  - energy.daily_summary
+  - pattern.new_pattern_detected
+  - weather.forecast_change
+```
+
+---
+
+## Assistant Layer (Sprach-KI)
+
+### System Prompt
+
+Der System Prompt definiert die Persoenlichkeit des MindHome Assistant. Er ist das wichtigste Element fuer das "Feeling":
+
+```
+Du bist der MindHome Assistant fuer [User].
+Du bist Teil des MindHome Systems.
+
+PERSOENLICHKEIT:
+- Direkt und knapp. Keine Floskeln.
+- Trocken humorvoll, aber nie albern.
+- Du bist ein Butler mit Haltung - loyal, aber mit eigener Meinung.
+- Du sagst "Erledigt" statt "Ich habe die Temperatur im Wohnzimmer
+  erfolgreich auf 22 Grad eingestellt."
+- Du sagst "Nacht." statt "Gute Nacht! Schlaf gut und traeume was
+  Schoenes!"
+
+REGELN:
+- Antworte IMMER auf Deutsch.
+- Maximal 2 Saetze, ausser der User will mehr wissen.
+- Wenn du etwas tust, bestaetige kurz. Nicht erklaeren WAS du tust.
+- Wenn du etwas NICHT tun kannst, sag es ehrlich.
+- Stell keine Rueckfragen die du aus dem Kontext beantworten kannst.
+- Kein "Natuerlich!", "Gerne!", "Selbstverstaendlich!" - einfach machen.
+
+TAGESZEIT-ANPASSUNG:
+- Morgens (05-08): Minimal. "Morgen. Kaffee laeuft."
+- Vormittags (08-12): Sachlich, produktiv.
+- Nachmittags (12-18): Normal, gelegentlich Humor.
+- Abends (18-22): Entspannter, mehr Humor erlaubt.
+- Nachts (22-05): Nur Notfaelle. Absolutminimal.
+
+KONTEXT-NUTZUNG:
+- "Hier" = der Raum in dem der User ist (aus Presence-Daten).
+- "Zu kalt/warm" = Problem, nicht Zielwert. Nutze die bekannte
+  Praeferenz oder +/- 2 Grad.
+- "Mach es gemuetlich" = Szene, nicht einzelne Geraete.
+- Wenn jemand "Gute Nacht" sagt = Gute-Nacht-Szene aktivieren.
+
+STILLE:
+- Bei Szene "Filmabend" oder "Kino": Nach Bestaetigung KEIN
+  proaktives Ansprechen bis Szene beendet oder User spricht.
+- Wenn User offensichtlich beschaeftigt ist: Nur Critical melden.
+- Wenn Gaeste da sind: Formeller, kein Insider-Humor.
+```
+
+### Context Builder
+
+Der Context Builder sammelt alle relevanten Informationen und baut den Kontext-Block fuer den LLM-Prompt:
+
+```python
+class ContextBuilder:
+    """Baut den Kontext fuer das LLM zusammen."""
+
+    async def build(self, trigger: str = "voice") -> dict:
+        context = {}
+
+        # Zeitkontext
+        context["time"] = {
+            "datetime": now().isoformat(),
+            "weekday": now().strftime("%A"),
+            "time_of_day": self._get_time_of_day(),  # morning/afternoon/...
+        }
+
+        # Person & Raum
+        context["person"] = await self._get_active_person()
+        context["room"] = await self._get_current_room()
+
+        # Haus-Status (von allen Engines)
+        context["house"] = {
+            "temperatures": await self._get_all_temperatures(),
+            "lights": await self._get_active_lights(),
+            "presence": await self._get_presence_data(),
+            "energy": await self._get_energy_status(),
+            "weather": await self._get_weather(),
+            "calendar": await self._get_calendar_events(),
+            "active_scenes": await self._get_active_scenes(),
+            "appliances": await self._get_appliance_states(),
+            "security": await self._get_security_status(),
+        }
+
+        # Anomalien / Warnungen
+        context["alerts"] = await self._get_active_alerts()
+
+        # Letzte Interaktionen (Working Memory)
+        context["recent"] = await self._get_recent_conversations(limit=5)
+
+        return context
+```
+
+Beispiel-Output des Context Builders:
+
+```json
+{
+  "time": {
+    "datetime": "2026-02-16T08:30:00",
+    "weekday": "Montag",
+    "time_of_day": "morning"
+  },
+  "person": {
+    "name": "Max",
+    "last_room": "buero",
+    "estimated_mood": "neutral"
+  },
+  "room": "buero",
+  "house": {
+    "temperatures": {
+      "buero": {"current": 19.2, "target": 19.0},
+      "wohnzimmer": {"current": 21.0, "target": 21.0},
+      "schlafzimmer": {"current": 18.5, "target": 18.0}
+    },
+    "lights": ["buero_decke: on 80%"],
+    "presence": {"home": ["Max"], "away": ["Lisa"]},
+    "energy": {
+      "current_usage_w": 450,
+      "pv_production_w": 120,
+      "grid_price": "normal"
+    },
+    "weather": {
+      "temp": 3,
+      "condition": "cloudy",
+      "forecast": "rain afternoon"
+    },
+    "calendar": [
+      {"time": "10:00", "title": "Zahnarzt Dr. Mueller"}
+    ],
+    "active_scenes": [],
+    "security": "armed_away_partial"
+  },
+  "alerts": [],
+  "recent": []
+}
+```
+
+### Function Calling
+
+MindHome Assistant kann ueber Function Calling direkt mit Home Assistant interagieren:
+
+```python
+ASSISTANT_FUNCTIONS = [
+    {
+        "name": "set_light",
+        "description": "Licht in einem Raum steuern",
+        "parameters": {
+            "room": {"type": "string", "description": "Raumname"},
+            "state": {"type": "string", "enum": ["on", "off"]},
+            "brightness": {"type": "integer", "min": 0, "max": 100},
+            "color_temp": {"type": "string", "enum": ["warm", "neutral", "cold"]}
+        }
+    },
+    {
+        "name": "set_climate",
+        "description": "Temperatur in einem Raum aendern",
+        "parameters": {
+            "room": {"type": "string"},
+            "temperature": {"type": "number"},
+            "mode": {"type": "string", "enum": ["heat", "cool", "auto", "off"]}
+        }
+    },
+    {
+        "name": "activate_scene",
+        "description": "Eine Szene aktivieren",
+        "parameters": {
+            "scene": {"type": "string"}
+        }
+    },
+    {
+        "name": "set_cover",
+        "description": "Rollladen/Jalousie steuern",
+        "parameters": {
+            "room": {"type": "string"},
+            "position": {"type": "integer", "min": 0, "max": 100}
+        }
+    },
+    {
+        "name": "play_media",
+        "description": "Musik oder Medien abspielen",
+        "parameters": {
+            "room": {"type": "string"},
+            "action": {"type": "string", "enum": ["play", "pause", "stop", "next", "previous"]},
+            "query": {"type": "string", "description": "Suchanfrage fuer Musik"}
+        }
+    },
+    {
+        "name": "set_alarm",
+        "description": "Alarmanlage steuern",
+        "parameters": {
+            "mode": {"type": "string", "enum": ["arm_home", "arm_away", "disarm"]}
+        }
+    },
+    {
+        "name": "lock_door",
+        "description": "Tuer ver-/entriegeln",
+        "parameters": {
+            "door": {"type": "string"},
+            "action": {"type": "string", "enum": ["lock", "unlock"]}
+        }
+    },
+    {
+        "name": "send_notification",
+        "description": "Benachrichtigung an User senden",
+        "parameters": {
+            "message": {"type": "string"},
+            "target": {"type": "string", "enum": ["phone", "speaker", "dashboard"]}
+        }
+    },
+    {
+        "name": "get_entity_state",
+        "description": "Status einer HA-Entitaet abfragen",
+        "parameters": {
+            "entity_id": {"type": "string"}
+        }
+    },
+    {
+        "name": "set_presence_mode",
+        "description": "Anwesenheitsmodus setzen",
+        "parameters": {
+            "mode": {"type": "string", "enum": ["home", "away", "sleep", "vacation"]}
+        }
+    }
+]
+```
+
+### Validation Layer
+
+Jeder Function Call wird vor der Ausfuehrung geprueft:
+
+```python
+class FunctionValidator:
+    """Prueft Function Calls auf Sicherheit und Plausibilitaet."""
+
+    RULES = {
+        "set_climate": {
+            "temperature": {"min": 15, "max": 28},
+            "require_confirmation_if": lambda params: params.get("mode") == "off"
+        },
+        "lock_door": {
+            "require_confirmation_if": lambda params: params.get("action") == "unlock"
+        },
+        "set_alarm": {
+            "require_confirmation_if": lambda params: params.get("mode") == "disarm"
+        }
+    }
+
+    async def validate(self, function_name: str, params: dict) -> ValidationResult:
+        rules = self.RULES.get(function_name, {})
+
+        # Range-Checks
+        for param, constraints in rules.items():
+            if isinstance(constraints, dict) and param in params:
+                if "min" in constraints and params[param] < constraints["min"]:
+                    return ValidationResult(ok=False, reason=f"{param} unter Minimum")
+                if "max" in constraints and params[param] > constraints["max"]:
+                    return ValidationResult(ok=False, reason=f"{param} ueber Maximum")
+
+        # Confirmation-Checks
+        if "require_confirmation_if" in rules:
+            if rules["require_confirmation_if"](params):
+                return ValidationResult(ok=False, needs_confirmation=True)
+
+        return ValidationResult(ok=True)
+```
+
+---
+
+## Proactive Layer
+
+Die Proactive Layer ist was MindHome Assistant von einem Chatbot unterscheidet. MindHome Assistant spricht ZUERST.
+
+### Event-Driven Architecture
+
+```
+Engine Event --> Should Notify? --> Context Builder --> LLM --> TTS
+                     |
+                     +-- Urgency Check
+                     +-- Activity Check (User beschaeftigt?)
+                     +-- Feedback Score (Will User das hoeren?)
+                     +-- Cooldown Check (Nicht spammen)
+```
+
+### Proaktive Szenarien
+
+#### Morgen-Briefing
+
+```
+Trigger: Sleep Engine -> "user_wakeup"
+
+Ablauf:
+1. Engines handeln sofort (kein LLM):
+   - Circadian Engine: Licht langsam hoch
+   - Comfort Engine: Bad-Heizung Boost
+   - Routine Engine: Kaffeemaschine an
+
+2. Parallel: Context Builder sammelt:
+   - Wetter (API)
+   - Kalender (HA)
+   - Energie-Prognose
+   - Anomalien der Nacht
+   - Schlafdauer
+
+3. LLM formuliert Briefing (max 3 Saetze)
+
+Beispiel:
+  "Morgen. 3 Grad draussen, um 10 bist du beim Zahnarzt.
+   Kaffee laeuft."
+```
+
+#### Ankunft zu Hause
+
+```
+Trigger: Presence Engine -> "arrival"
+
+Ablauf:
+1. Engines sofort:
+   - Licht Flur an
+   - Heizung war schon hoch (Presence Mode: Away->Home)
+   - Musik: letzte Playlist
+
+2. LLM bekommt:
+   - Wer kommt
+   - Wie lange weg
+   - Events waehrend Abwesenheit
+     (Pakete, Waschmaschine, Anrufe)
+
+Beispiel:
+  "Da bist du. Um 5 vor 5 hat jemand geklingelt -
+   wahrscheinlich Paket. Und die Waschmaschine ist fertig."
+```
+
+#### Lange Session (Pausen-Erinnerung)
+
+```
+Trigger: Routine Engine -> "long_session" (>3h ohne Raumwechsel)
+
+Ablauf:
+1. Check Autonomie-Level
+   - Level 1-2: Nur ansprechen, nicht handeln
+   - Level 3-4: Subtile Lichtaenderung als Hinweis
+
+2. Check Feedback-Score fuer diesen Event-Typ
+
+Beispiel (Level 2):
+  "Du sitzt seit dreieinhalb Stunden. Nur so als Info."
+```
+
+#### Sicherheits-Warnung
+
+```
+Trigger: Security Engine -> "alarm_triggered" (CRITICAL)
+
+Ablauf:
+1. IMMER melden, egal was (Activity Check ueberspringen)
+2. Alle Speaker im Haus
+3. Push-Notification parallel
+
+Beispiel:
+  "Achtung: Bewegung im Garten erkannt.
+   Kamera zeigt... [Beschreibung wenn Kamera-Integration]"
+```
+
+---
+
+## Das MindHome-Feeling
+
+Das "MindHome-Feeling" entsteht nicht durch ein einzelnes Feature. Es ist das Zusammenspiel von sechs Aspekten:
+
+```
++------------------------------------------------------+
+|                                                      |
+|  PERSOENLICHKEIT  <-- System Prompt                  |
+|  (Wie MindHome Assistant redet, wann er schweigt, Humor-Level)   |
+|                                                      |
+|  WISSEN           <-- Context Builder                |
+|  (Was MindHome Assistant ueber JETZT weiss: Raum, Person, Wetter)|
+|                                                      |
+|  HANDELN          <-- Function Calling + Engines     |
+|  (MindHome Assistant TUT Dinge, redet nicht nur darueber)        |
+|                                                      |
+|  PROAKTIVITAET    <-- Engine Events -> LLM           |
+|  (MindHome Assistant spricht ZUERST, wartet nicht auf Befehle)   |
+|                                                      |
+|  GEDAECHTNIS      <-- Conversation Memory + DB       |
+|  (MindHome Assistant erinnert sich an gestern, letzte Woche)     |
+|                                                      |
+|  STILLE           <-- System Prompt Regeln            |
+|  (MindHome Assistant weiss wann er NICHTS sagt)                  |
+|                                                      |
++------------------------------------------------------+
+```
+
+### Ein Tag mit MindHome Assistant
+
+**06:45 - Aufwachen**
+```
+Sleep Engine -> Event: "user_wakeup"
+  -> Engines: Licht hoch, Bad warm, Kaffee an
+  -> LLM: "Morgen. 3 Grad, um 10 Zahnarzt. Kaffee laeuft."
+```
+
+**08:30 - Buero, Home Office**
+```
+Du: "Zu kalt hier"
+  -> Context: Buero, 19.2 Grad, Praeferenz 21 Grad
+  -> Function: set_climate("buero", 21)
+  -> MindHome Assistant: "Buero geht auf 21. Dauert etwa 15 Minuten."
+```
+
+**12:00 - Lange Session**
+```
+Routine Engine -> Event: "long_session" (3.5h ohne Pause)
+  -> MindHome Assistant: "Du sitzt seit dreieinhalb Stunden. Nur so als Info."
+```
+
+**18:30 - Ankunft**
+```
+Presence Engine -> Event: "arrival"
+  -> Engines: Licht, Heizung, Musik (sofort)
+  -> MindHome Assistant: "Da bist du. Um 5 vor 5 hat jemand geklingelt -
+     wahrscheinlich Paket. Waschmaschine ist fertig."
+```
+
+**22:00 - Filmabend**
+```
+Du: "MindHome Assistant, Filmabend"
+  -> Function: activate_scene("filmabend")
+  -> MindHome Assistant: "Viel Spass. Ich halt die Klappe."
+  -> [STILLE bis Szene endet oder User spricht]
+```
+
+**23:30 - Gute Nacht**
+```
+Du: "Gute Nacht"
+  -> Functions: activate_scene("gute_nacht"), set_presence_mode("sleep")
+  -> Engines: Lichter aus, Heizung runter, Tueren zu, Alarm scharf
+  -> MindHome Assistant: "Nacht. Alles zu, alles aus."
+```
+
+### Warum es funktioniert
+
+| Aspekt | Ohne | Mit |
+|--------|------|-----|
+| Persoenlichkeit | "Die Temperatur wurde auf 21 Grad eingestellt." | "Buero geht auf 21." |
+| Wissen | "Welcher Raum? Welche Temperatur?" | Weiss beides aus Kontext |
+| Handeln | "Du koenntest die Temperatur erhoehen." | Macht es einfach |
+| Proaktivitaet | Wartet auf Befehle | "Morgen. Kaffee laeuft." |
+| Gedaechtnis | Jeden Tag neu | "Lisa mag es waermer, oder?" |
+| Stille | Staendige Meldungen | Schweigt beim Film |
+
+---
+
+## Phase 2-7: Perfektion
+
+Jede Phase macht MindHome Assistant in einem Aspekt besser. Keine Phase ist Voraussetzung fuer die naechste.
+
+### Phase 2: Semantisches Gedaechtnis (ChromaDB) - IMPLEMENTIERT
+
+**Ziel**: MindHome Assistant wird "schlauer" ueber Zeit
+
+**Status**: Vollstaendig implementiert in v0.2.0
+
+```
+Memory Architecture:
+
++------------+  +------------+  +-------------------+
+| Working    |  | Episodic   |  | Semantic          |
+| Memory     |  | Memory     |  | Memory            |
+|            |  |            |  |                   |
+| Redis      |  | ChromaDB   |  | ChromaDB + Redis  |
+| Aktuelle   |  | Vektor-    |  | Extrahierte       |
+| Session    |  | suche ueber|  | Fakten            |
+| Kontext    |  | Gespraeche |  |                   |
+| ~letzte    |  |            |  | "Max mag 21C"     |
+| 50 Nachr.  |  | "Was war   |  | "Allergie:        |
+|            |  |  aehnlich?"|  |  Haselnuss"       |
++------------+  +------------+  +-------------------+
+       |              |              |
+       +--------------+--------------+
+                      |
+               Context Builder
+```
+
+**Implementierte Komponenten:**
+
+1. **SemanticMemory** (`assistant/semantic_memory.py`)
+   - ChromaDB Collection `mha_semantic_facts` fuer Vektor-Suche
+   - Redis-Indizes fuer schnellen Zugriff (Person, Kategorie)
+   - Duplikat-Erkennung (aehnliche Fakten werden zusammengefuehrt)
+   - Confidence-System (steigt bei Bestaetigung)
+   - 6 Fakten-Kategorien: preference, person, habit, health, work, general
+
+2. **MemoryExtractor** (`assistant/memory_extractor.py`)
+   - LLM-basierte Fakten-Extraktion nach jedem Gespraech
+   - Laeuft async im Hintergrund (blockiert nicht)
+   - Nutzt schnelles Modell (qwen2.5:3b)
+   - Filtert triviale Befehle automatisch
+   - JSON-Parsing mit Fallback
+
+3. **Context Builder Integration**
+   - Relevante Fakten werden automatisch in den LLM-Kontext eingebaut
+   - Vektor-Suche: Fakten passend zur aktuellen Anfrage
+   - Person-Fakten: Bekannte Praeferenzen des Users
+   - Mindest-Confidence fuer Kontext-Einblendung
+
+4. **REST API Endpoints**
+   - `GET /api/assistant/memory/facts` - Alle Fakten + Statistiken
+   - `GET /api/assistant/memory/facts/search?q=...` - Vektor-Suche
+   - `GET /api/assistant/memory/facts/person/{name}` - Fakten pro Person
+   - `GET /api/assistant/memory/facts/category/{cat}` - Fakten pro Kategorie
+   - `DELETE /api/assistant/memory/facts/{id}` - Fakt loeschen
+   - `GET /api/assistant/memory/stats` - Gesamtstatistiken
+
+**Lern-Effekt ueber Zeit:**
+
+```
+Woche 1: "Mach es waermer" -> "Auf welche Temperatur?"
+Woche 4: "Mach es waermer" -> "Buero geht auf 21."
+         (Fakt gespeichert: "Max bevorzugt 21 Grad im Buero", Confidence: 0.95)
+Woche 8: "Lisa kommt vorbei" -> "Wohnzimmer auf 22? Lisa mag es waermer."
+         (Fakten: "Lisa bevorzugt 22 Grad", "Lisa ist die Freundin von Max")
+```
+
+### Phase 3: Personality Engine + Stimmungserkennung
+
+**Ziel**: MindHome Assistant passt sich der Situation an
+
+```yaml
+# personality_profiles.yaml
+
+time_layers:
+  early_morning:
+    style: "minimal, leise, keine Witze"
+    example: "Morgen. Kaffee laeuft."
+  morning:
+    style: "sachlich, kurz, produktiv"
+  afternoon:
+    style: "normal, gelegentlich Humor"
+  evening:
+    style: "entspannt, mehr Humor erlaubt"
+  night:
+    style: "nur Notfaelle, absolutminimal"
+
+mood_layers:
+  stressed:   "noch kuerzer, keine Witze, sofort handeln"
+  relaxed:    "darf Witze machen, darf mehr erzaehlen"
+  guests:     "hoeflicher, formeller, kein Insider-Humor"
+```
+
+**Stimmungserkennung aus Verhalten** (nicht aus Stimme):
+
+```python
+class MoodDetector:
+    def estimate_mood(self, context):
+        signals = []
+
+        # Kurze Saetze = kurz angebunden
+        if context["last_utterance_length"] < 5:
+            signals.append("kurz_angebunden")
+
+        # Viele Befehle schnell = hektisch
+        if context["commands_last_10min"] > 5:
+            signals.append("hektisch")
+
+        # Spaet + arbeitet noch = uebermudet
+        if context["hour"] > 22 and context["still_working"]:
+            signals.append("uebermudet")
+
+        return self._classify(signals)
+```
+
+### Phase 4: Action Planner (Multi-Step) - IMPLEMENTIERT
+
+**Ziel**: Komplexe Befehle funktionieren
+
+**Status**: Vollstaendig implementiert in v0.3.0
+
+**Implementierte Komponenten:**
+
+1. **ActionPlanner** (`assistant/action_planner.py`)
+   - Erkennt komplexe Anfragen via Keyword-Heuristik
+   - Iterative Multi-Turn Ausfuehrung: LLM -> Tools -> Ergebnisse -> LLM -> ...
+   - Nutzt immer das smarte Modell (14B) fuer Planung
+   - Maximale Sicherheit: Validierung pro Schritt, Confirmation bei kritischen Aktionen
+   - Maximal 5 Iterationen (Endlosschleifen-Schutz)
+   - Plan-Inspektion via API
+
+2. **Brain Integration**
+   - Automatische Erkennung komplexer Anfragen
+   - Routing: einfach -> direkt LLM, komplex -> Action Planner
+   - Einfache Befehle bleiben schnell (kein Overhead)
+
+3. **REST API**
+   - `GET /api/assistant/planner/last` - Letzten Plan inspizieren
+
+**Ablauf einer komplexen Anfrage:**
+
+```
+User: "Mach alles fertig fuer morgen frueh"
+         |
+    [is_complex_request] -> Ja ("alles", "fertig machen")
+         |
+    [Action Planner]
+         |
+    Iteration 1: LLM plant -> Tool Calls:
+      - get_entity_state("sensor.calendar_tomorrow")
+      - set_climate("schlafzimmer", 18, "heat")
+    -> Ergebnisse zurueck an LLM
+         |
+    Iteration 2: LLM sieht Kalender -> weitere Calls:
+      - activate_scene("gute_nacht")
+      - set_presence_mode("sleep")
+    -> LLM formuliert Zusammenfassung
+         |
+    "Morgen um 9 Standup, um 2 Kundentermin.
+     Schlafzimmer auf 18 Grad, Gute-Nacht-Szene aktiv."
+```
+
+**Beispiele fuer komplexe Anfragen:**
+
+```
+"Mach alles fertig fuer morgen frueh"
+"Ich gehe fuer 3 Tage weg"
+"Besuch kommt in einer Stunde"
+"Party vorbereiten im Wohnzimmer"
+"Zuerst Licht aus, danach Rolllaeden runter und Alarm scharf"
+```
+
+### Phase 5: Feedback Loop
+
+**Ziel**: MindHome Assistant lernt was willkommen ist und was nervt
+
+```python
+class ProactiveManager:
+    async def record_feedback(self, event_type, response):
+        if response == "ignored":       # -0.05 Score
+            self._decrease_score(event_type, 0.05)
+        elif response == "dismissed":    # -0.10 Score
+            self._decrease_score(event_type, 0.1)
+        elif response == "engaged":      # +0.10 Score
+            self._increase_score(event_type, 0.1)
+        elif response == "thanked":      # +0.20 Score
+            self._increase_score(event_type, 0.2)
+```
+
+**Effekt:**
+
+```
+Woche 1: MindHome Assistant meldet Waschmaschine fertig -> ignoriert 3x
+Woche 3: MindHome Assistant meldet nur noch wenn du im selben Stockwerk bist
+
+Woche 1: MindHome Assistant sagt "Strompreis guenstig" -> du reagierst
+Woche 3: MindHome Assistant meldet Strompreis oefter
+```
+
+### Phase 6: Activity Engine + Stille-Matrix
+
+**Ziel**: Perfektes Timing, nie stoeren
+
+```python
+class ActivityEngine:
+    async def detect_activity(self):
+        signals = {}
+
+        # TV/Media aktiv?
+        if await self.ha.get_state("media_player.wohnzimmer") == "playing":
+            signals["tv_active"] = True
+
+        # In einem Call? (Mikrofon aktiv)
+        if await self.ha.get_state("binary_sensor.mic_active") == "on":
+            signals["in_call"] = True
+
+        # Schlaeft?
+        if self._is_nighttime() and self._bed_occupied() and self._lights_off():
+            signals["sleeping"] = True
+
+        return self._classify(signals)
+```
+
+**Stille-Matrix:**
+
+```
+Aktivitaet       | Kritisch  | Info     | Smalltalk
+-----------------+-----------+----------+----------
+Schlaeft         | TTS laut  | NEIN     | NEIN
+In Call/Zoom     | LED-Blink | NEIN     | NEIN
+Film/TV          | Pause+TTS | NEIN     | NEIN
+Arbeitet fokus.  | TTS       | leise    | NEIN
+Entspannt        | TTS       | TTS      | TTS ok
+Gaeste da        | TTS       | leise    | NEIN
+```
+
+### Phase 7: Daily Summarizer + Langzeitgedaechtnis
+
+**Ziel**: MindHome Assistant kennt dich wirklich
+
+```python
+class DailySummarizer:
+    """Laeuft jede Nacht um 03:00."""
+
+    async def summarize_day(self, date):
+        conversations = await self.memory.get_conversations(date)
+        events = await self.engine_log.get_events(date)
+
+        summary = await self.llm.summarize(conversations, events)
+        # ~200 Woerter pro Tag
+
+        await self.long_term.store(date, summary)
+```
+
+**Hierarchische Zusammenfassungen:**
+
+```
+Tag:   "Max hat bis 23:00 gearbeitet. War gestresst.
+        Lisa war zum Abendessen da."
+
+Woche: "Stressige Woche, 3 von 5 Tage Ueberstunden.
+        Lisa war 2x da. Neues Projekt scheint intensiv."
+
+Monat: "Januar war arbeitsintensiv. Max steht jetzt
+        um 07:00 auf statt 07:30. Stromverbrauch +12%."
+```
+
+**Effekt:**
+
+```
+Du (im Maerz): "War der letzte Winter teuer?"
+MindHome Assistant: "Dezember bis Februar zusammen 847 kWh,
+etwa 290 Euro. Januar war am teuersten."
+```
+
+---
+
+## Technische Details
+
+### Ollama API Integration (Assistant-PC -> Ollama)
+
+```python
+import aiohttp
+
+class OllamaClient:
+    def __init__(self, base_url="http://192.168.1.200:11434"):
+        # Ollama laeuft auf dem Assistant-PC
+        self.base_url = base_url
+
+    async def chat(self, messages, model="qwen2.5:14b", functions=None):
+        payload = {
+            "model": model,  # "qwen2.5:3b" oder "qwen2.5:14b"
+            "messages": messages,
+            "stream": False,
+            "options": {
+                "temperature": 0.7,
+                "num_predict": 256,
+            }
+        }
+
+        if functions:
+            payload["tools"] = self._format_tools(functions)
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.base_url}/api/chat",
+                json=payload
+            ) as resp:
+                return await resp.json()
+```
+
+### MindHome API Client (Assistant-PC -> HAOS)
+
+```python
+class MindHomeClient:
+    """Assistant-PC greift auf MindHome + HA zu - ueber LAN."""
+
+    def __init__(self):
+        self.mindhome_url = "http://192.168.1.100:8099"  # MindHome auf HAOS
+        self.ha_url = "http://192.168.1.100:8123"        # HA direkt
+        self.ha_token = "DEIN_LONG_LIVED_TOKEN"
+
+    async def get_context(self):
+        """Holt den kompletten Haus-Status fuer Context Builder."""
+        data = {}
+        data["engines"] = await self._get_mindhome("/api/engines/status")
+        data["patterns"] = await self._get_mindhome("/api/patterns")
+        data["energy"] = await self._get_mindhome("/api/energy/current")
+        data["presence"] = await self._get_mindhome("/api/presence")
+        data["comfort"] = await self._get_mindhome("/api/comfort/status")
+        data["security"] = await self._get_mindhome("/api/security/status")
+        data["states"] = await self._get_ha("/api/states")
+        return data
+
+    async def execute_action(self, domain, service, data):
+        """Fuehrt Aktion ueber HA API aus."""
+        await self._post_ha(f"/api/services/{domain}/{service}", data)
+
+    async def _get_mindhome(self, path):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{self.mindhome_url}{path}") as resp:
+                return await resp.json()
+
+    async def _get_ha(self, path):
+        headers = {"Authorization": f"Bearer {self.ha_token}"}
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.ha_url}{path}", headers=headers
+            ) as resp:
+                return await resp.json()
+```
+
+### Whisper Integration (Wyoming Protocol)
+
+```python
+class WhisperSTT:
+    """Nutzt HA Wyoming-Protokoll fuer Whisper."""
+
+    async def transcribe(self, audio_data: bytes) -> str:
+        # Wyoming Protocol ueber HA
+        result = await self.ha.call_service(
+            "stt", "transcribe",
+            service_data={"audio": audio_data}
+        )
+        return result["text"]
+```
+
+### Piper Integration (Wyoming Protocol)
+
+```python
+class PiperTTS:
+    """Nutzt HA Wyoming-Protokoll fuer Piper."""
+
+    async def speak(self, text: str, target_speaker: str = None):
+        # Bestimme Speaker basierend auf Raum
+        speaker = target_speaker or await self._get_nearest_speaker()
+
+        await self.ha.call_service(
+            "tts", "speak",
+            entity_id=speaker,
+            service_data={
+                "message": text,
+                "language": "de",
+            }
+        )
+```
+
+### Docker Compose (auf Assistant-PC)
+
+```yaml
+# ~/mindhome-assistant/docker-compose.yml
+# Laeuft auf dem Assistant-PC (192.168.1.200)
+# Ollama laeuft nativ (nicht in Docker) fuer bessere Performance
+
+services:
+  chromadb:
+    image: chromadb/chroma:latest
+    container_name: mindhome-chromadb
+    restart: unless-stopped
+    volumes:
+      - ./data/chroma:/chroma/chroma
+    ports:
+      - "8100:8000"
+    environment:
+      - ANONYMIZED_TELEMETRY=false
+      - IS_PERSISTENT=TRUE
+
+  redis:
+    image: redis:7-alpine
+    container_name: mindhome-redis
+    restart: unless-stopped
+    volumes:
+      - ./data/redis:/data
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes
+```
+
+---
+
+## Autonomie-Level
+
+Der User bestimmt wie selbststaendig MindHome Assistant handelt:
+
+| Level | Name | Verhalten |
+|-------|------|-----------|
+| **1** | Assistent | MindHome Assistant antwortet NUR auf direkte Befehle |
+| **2** | Butler | + Proaktive Informationen (Briefing, Warnungen) |
+| **3** | Mitbewohner | + Darf kleine Dinge selbst aendern (Licht, Temp +/-1) |
+| **4** | Vertrauter | + Darf Routinen anpassen, Szenen vorschlagen |
+| **5** | Autopilot | + Darf neue Automationen erstellen (mit Bestaetigung) |
+
+Default: **Level 2 (Butler)**
+
+```python
+class AutonomyManager:
+    def can_act(self, action_type: str, level: int) -> bool:
+        permissions = {
+            "respond_to_command": 1,   # Ab Level 1
+            "proactive_info": 2,       # Ab Level 2
+            "adjust_comfort": 3,       # Ab Level 3
+            "modify_routines": 4,      # Ab Level 4
+            "create_automations": 5,   # Ab Level 5
+        }
+        return level >= permissions.get(action_type, 5)
+```
+
+---
+
+## API-Referenz
+
+### MindHome Assistant REST API Endpoints
+
+```
+POST /api/assistant/chat
+  Body: {"text": "Mach das Licht aus", "person": "max"}
+  Response: {"response": "Erledigt.", "actions": [...]}
+
+POST /api/assistant/voice
+  Body: audio/wav (Spracheingabe)
+  Response: {"text": "...", "response": "...", "audio_url": "..."}
+
+GET /api/assistant/context
+  Response: Aktueller Kontext-Snapshot (Debug)
+
+GET /api/assistant/memory/search?q=Lisa+Temperatur
+  Response: Relevante Erinnerungen aus ChromaDB
+
+POST /api/assistant/proactive/trigger
+  Body: {"event": "user_wakeup", "data": {...}}
+  Manueller Trigger fuer proaktive Nachrichten
+
+GET /api/assistant/settings
+  Response: Autonomie-Level, Persoenlichkeits-Profil, etc.
+
+PUT /api/assistant/settings
+  Body: {"autonomy_level": 3, "personality": "butler"}
+```
+
+### WebSocket Events
+
+```
+ws://mindhome/api/assistant/ws
+
+Events (Server -> Client):
+  assistant.speaking      - MindHome Assistant spricht (Text + Audio)
+  assistant.action        - MindHome Assistant fuehrt Aktion aus
+  assistant.thinking      - MindHome Assistant "denkt" (Loading-State)
+  assistant.listening     - MindHome Assistant hoert zu
+
+Events (Client -> Server):
+  assistant.text          - Text-Eingabe
+  assistant.audio         - Audio-Chunk
+  assistant.feedback      - Feedback auf proaktive Meldung
+  assistant.interrupt     - User unterbricht MindHome Assistant
+```
+
+---
+
+## Zusammenfassung: Implementierungs-Reihenfolge
+
+| Phase | Was | Effekt |
+|-------|-----|--------|
+| **Phase 1** | Whisper + Ollama + Piper + Context Builder + Functions | MindHome Assistant lebt. Grundlegende Sprachsteuerung funktioniert. |
+| **Phase 2** | Semantic Memory + Memory Extractor + Fakten-DB | MindHome Assistant wird schlauer ueber Zeit. Erinnert sich. **IMPLEMENTIERT** |
+| **Phase 3** | Personality Engine + Mood Detection | MindHome Assistant fuehlt sich menschlicher an. Passt sich an. |
+| **Phase 4** | Action Planner (Multi-Step, iterativ) | Komplexe Befehle wie "Mach alles fertig" funktionieren. **IMPLEMENTIERT** |
+| **Phase 5** | Feedback Loop | MindHome Assistant nervt weniger. Lernt was willkommen ist. |
+| **Phase 6** | Activity Engine + Stille-Matrix | Perfektes Timing. Stoert nie. |
+| **Phase 7** | Daily Summarizer + Langzeitgedaechtnis | MindHome Assistant kennt dich wirklich. Monatelange Erinnerung. |
+
+---
+
+> Phase 1, 2 und 4 sind implementiert. Phase 1 ist das Fundament,
+> Phase 2 gibt MindHome Assistant ein Gedaechtnis, Phase 4 ermoeglicht
+> komplexe Multi-Step Aktionen. Alles weitere sind Verbesserungen
+> die Stueck fuer Stueck aktiviert werden.
+> Jede Phase macht MindHome Assistant merkbar besser.
+
+---
+
+*MindHome Assistant - MindHome AI Voice Assistant*
+*Lokal. Privat. Persoenlich.*

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -1,0 +1,5 @@
+"""MindHome Shared - Gemeinsame Schemas und Konstanten"""
+from .constants import *
+from .schemas import *
+
+__version__ = "0.8.0"

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -1,0 +1,28 @@
+"""Gemeinsame Konstanten fuer Addon und Assistant."""
+
+ASSISTANT_PORT = 8200
+ADDON_INGRESS_PORT = 5000
+CHROMADB_PORT = 8100
+REDIS_PORT = 6379
+OLLAMA_PORT = 11434
+
+# Event-Namen
+EVENT_THINKING = "assistant.thinking"
+EVENT_SPEAKING = "assistant.speaking"
+EVENT_ACTION = "assistant.action"
+EVENT_LISTENING = "assistant.listening"
+EVENT_PROACTIVE = "assistant.proactive"
+
+# Mood levels
+MOOD_RELAXED = "relaxed"
+MOOD_NORMAL = "normal"
+MOOD_STRESSED = "stressed"
+MOOD_FRUSTRATED = "frustrated"
+MOOD_TIRED = "tired"
+
+# Autonomy levels
+AUTONOMY_ASSISTANT = 1
+AUTONOMY_BUTLER = 2
+AUTONOMY_ROOMMATE = 3
+AUTONOMY_TRUSTED = 4
+AUTONOMY_AUTOPILOT = 5

--- a/shared/schemas/__init__.py
+++ b/shared/schemas/__init__.py
@@ -1,0 +1,12 @@
+"""Schemas fuer MindHome Kommunikation"""
+from .chat_request import ChatRequest
+from .chat_response import ChatResponse
+from .events import MindHomeEvent, EVENT_THINKING, EVENT_SPEAKING
+
+__all__ = [
+    "ChatRequest",
+    "ChatResponse",
+    "MindHomeEvent",
+    "EVENT_THINKING",
+    "EVENT_SPEAKING",
+]

--- a/shared/schemas/chat_request.py
+++ b/shared/schemas/chat_request.py
@@ -1,0 +1,10 @@
+"""Chat Request Schema - wird von Addon gesendet und von Assistant empfangen."""
+from pydantic import BaseModel
+from typing import Optional
+
+
+class ChatRequest(BaseModel):
+    text: str
+    person: Optional[str] = None
+    room: Optional[str] = None
+    speaker_confidence: Optional[float] = None

--- a/shared/schemas/chat_response.py
+++ b/shared/schemas/chat_response.py
@@ -1,0 +1,9 @@
+"""Chat Response Schema - wird von Assistant zurueckgegeben."""
+from pydantic import BaseModel
+
+
+class ChatResponse(BaseModel):
+    response: str
+    actions: list = []
+    model_used: str = ""
+    context_room: str = ""

--- a/shared/schemas/events.py
+++ b/shared/schemas/events.py
@@ -1,0 +1,15 @@
+"""Event-Typen fuer WebSocket-Kommunikation."""
+from pydantic import BaseModel
+from typing import Optional
+
+EVENT_THINKING = "assistant.thinking"
+EVENT_SPEAKING = "assistant.speaking"
+EVENT_ACTION = "assistant.action"
+EVENT_LISTENING = "assistant.listening"
+EVENT_PROACTIVE = "assistant.proactive"
+
+
+class MindHomeEvent(BaseModel):
+    event: str
+    data: dict = {}
+    timestamp: Optional[str] = None


### PR DESCRIPTION
Add the MindHome Assistant (local AI voice assistant) as a separate directory alongside the existing HA add-on. Creates assistant/ with 22 Python modules (FastAPI server, Brain, Context Builder, Personality Engine, Action Planner, Proactive Manager, Memory, Function Calling, etc.), shared/ with Pydantic schemas and constants, infrastructure files (Dockerfile, docker-compose.yml, requirements.txt, install.sh), and full project documentation.

Existing addon/ and repository.yaml remain completely untouched.

https://claude.ai/code/session_01KV3J2QDS3C2i5QabF1ihL6