### PR TITLE
release: MindHome v1.1.0 — einheitliche Versionsnummer (Jarvis Complete)

### DIFF
--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "0.7.29"
+  org.opencontainers.image.version: "1.1.0"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "0.8.4"
+version: "1.1.0"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,24 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "0.8.4"
-BUILD = 87
-BUILD_DATE = "2026-02-15"
-CODENAME = "Unified Page Styling"
+VERSION = "1.1.0"
+BUILD = 88
+BUILD_DATE = "2026-02-17"
+CODENAME = "Jarvis Complete"
 
 # Changelog
+# Build 88: v1.1.0 Jarvis Complete — Einheitliche Version (Addon + Assistant + HA-Integration)
+#   - VEREINHEITLICHT: Eine Versionsnummer fuer das gesamte MindHome-Projekt
+#     Addon, Assistant (Phase 1-10) und HA Custom Component auf gleicher Version
+#   - Addon config.yaml, build.yaml, manifest.json, settings.yaml, main.py synchronisiert
+#   - Port-Mapping explizit: Addon intern 5000 → extern 8099 (fuer Assistant-Zugriff)
+#   - ha_client.py: Retry-Logik (3 Versuche, exponentieller Backoff), Error-Logging, Connection Pooling
+#   - brain.py: Activity-basiertes Volume (Silence-Matrix im Hauptchat), alle Sound-Events integriert
+#   - tts_enhancer.py: Activity-Parameter fuer kontextabhaengiges Volume
+#   - Multi-Room TTS: target_speaker in TTSInfo, room-basierte Speaker-Auswahl
+#   - mood_detector.py: rapid_follow_up Voice-Signal
+#   - conversation.py: Multi-Room TTS Support (target_speaker)
+#
 # Build 87: v0.8.4 Unified Page Styling
 #   - Einheitliches Seiten-Layout fuer alle 9 Feature-Seiten (Musterseite als Vorlage)
 #   - Alle h2 Seiten-Header entfernt (Sidebar zeigt aktive Seite)

--- a/ha_integration/custom_components/mindhome_assistant/manifest.json
+++ b/ha_integration/custom_components/mindhome_assistant/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.0.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
Alle MindHome-Komponenten auf Version 1.1.0 synchronisiert:
- addon/config.yaml: 0.8.4 -> 1.1.0 (HA Update-Erkennung)
- addon/build.yaml: 0.7.29 -> 1.1.0 (Docker Image Label)
- addon/version.py: Build 88, Codename "Jarvis Complete"
- ha_integration/manifest.json: 1.0.0 -> 1.1.0

HA erkennt das Update automatisch ueber config.yaml Version.

https://claude.ai/code/session_01FqDS3f7fFF96UFR6AUJVix