### PR TITLE
fix: Security-Audit — 13 Bugs und Sicherheitslücken behoben

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # MindHome Assistant
 assistant/.env
+assistant/.env.backup.*
 assistant/data/
 assistant/data/**
 

--- a/assistant/.dockerignore
+++ b/assistant/.dockerignore
@@ -1,0 +1,20 @@
+# Secrets
+.env
+.env.*
+
+# Data
+data/
+
+# Git
+.git
+.gitignore
+
+# Docs
+*.md
+LICENSE
+
+# OS
+.DS_Store
+Thumbs.db
+__pycache__/
+*.pyc

--- a/assistant/docker-compose.yml
+++ b/assistant/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - CHROMA_URL=http://chromadb:8000
 
   # --- ChromaDB (Langzeitgedaechtnis / Vektor-DB) ---
+  # Nur ueber Docker-Netzwerk erreichbar (kein externer Zugriff noetig)
   chromadb:
     image: chromadb/chroma:latest
     container_name: mha-chromadb
@@ -48,7 +49,7 @@ services:
     volumes:
       - ${DATA_DIR:-./data}/chromadb:/chroma/chroma
     ports:
-      - "8100:8000"
+      - "127.0.0.1:8100:8000"
     environment:
       - ANONYMIZED_TELEMETRY=false
       - IS_PERSISTENT=TRUE
@@ -59,6 +60,7 @@ services:
       retries: 5
 
   # --- Redis (Working Memory / Cache) ---
+  # Nur ueber Docker-Netzwerk erreichbar (kein externer Zugriff noetig)
   redis:
     image: redis:7-alpine
     container_name: mha-redis
@@ -66,7 +68,7 @@ services:
     volumes:
       - ${DATA_DIR:-./data}/redis:/data
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]


### PR DESCRIPTION
CRITICAL fixes:
- NVMe Boot-Disk Erkennung: sed -E 's/p?[0-9]+$//' statt 's/[0-9]*$/'
- NVMe Partition-Name: nvme0n1 → nvme0n1p1 (nicht nvme0n11)
- HA Token verdeckt einlesen (read -rsp statt read -p)
- .env mit chmod 600 (war world-readable mit Token drin)
- Redis/ChromaDB nur auf 127.0.0.1 binden (war 0.0.0.0 ohne Auth)

HIGH fixes:
- .env schreiben via printf statt Heredoc (keine Shell-Expansion von User-Input)
- CHOSEN_DISK gegen AVAILABLE_DISKS validieren (Path-Traversal verhindert)
- set -e/pipefail: grep-Failures mit || true/|| echo abgefangen
- Ollama Install: Download erst in tmpfile, dann ausfuehren (statt curl|sh)

MEDIUM fixes:
- Symlink-Check auf /mnt/data vor mount
- UUID leer-Check vor fstab grep
- URL-Parsing: sed statt ${%:*} fuer portlose URLs
- Alle read-Aufrufe mit -r Flag (Backslash-Schutz)
- .env.backup.* in .gitignore + chmod 600
- .dockerignore erstellt (Secrets aus Docker-Image fernhalten)
- LOCAL_IP Fallback auf 'localhost', PRETTY_NAME/VERSION_CODENAME Defaults
- Dead code MODELS_DIR entfernt

https://claude.ai/code/session_01QwTqwLLUKqN1otCc6objD7