### PR TITLE
fix: ChromaDB healthcheck — python statt python3, start_period hinzug…

### DIFF
--- a/assistant/docker-compose.yml
+++ b/assistant/docker-compose.yml
@@ -54,10 +54,11 @@ services:
       - ANONYMIZED_TELEMETRY=false
       - IS_PERSISTENT=TRUE
     healthcheck:
-      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/heartbeat')\""]
+      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/api/v1/heartbeat\")'  || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 15s
 
   # --- Redis (Working Memory / Cache) ---
   # Nur ueber Docker-Netzwerk erreichbar (kein externer Zugriff noetig)


### PR DESCRIPTION
…efuegt

python3 existiert nicht im ChromaDB-Container (nur python). start_period gibt ChromaDB 15s zum Hochfahren bevor der Healthcheck anfaengt zu pruefen.

https://claude.ai/code/session_01QwTqwLLUKqN1otCc6objD7