### PR TITLE
fix: duplizierte get_assistant_tools() entfernt — NameError behoben

### DIFF
--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -667,11 +667,6 @@ def get_assistant_tools() -> list:
     return tools
 
 
-# Dynamic getter: Climate-Tool-Schema wird bei jedem Aufruf frisch generiert
-def get_assistant_tools() -> list:
-    """Liefert ASSISTANT_TOOLS mit aktuellem Climate-Schema."""
-    return _build_tools_with_dynamic_climate()
-
 # ASSISTANT_TOOLS: Immer die dynamische Version verwenden
 ASSISTANT_TOOLS = get_assistant_tools()
 


### PR DESCRIPTION
Zweite Definition rief _build_tools_with_dynamic_climate() auf, die nicht existiert. Erste Definition (Zeile 647) funktioniert korrekt und bleibt bestehen.

https://claude.ai/code/session_01QwTqwLLUKqN1otCc6objD7