### PR TITLE
fix: trailing slash in HA_URL verursacht doppelten Slash in WebSocket…

### DIFF
--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -157,7 +157,7 @@ class ProactiveManager:
 
     async def _listen_ha_events(self):
         """Hoert auf Home Assistant Events via WebSocket."""
-        ha_url = settings.ha_url.replace("http://", "ws://").replace("https://", "wss://")
+        ha_url = settings.ha_url.rstrip("/").replace("http://", "ws://").replace("https://", "wss://")
         ws_url = f"{ha_url}/api/websocket"
 
         while self._running:


### PR DESCRIPTION
…-URL

proactive.py hat rstrip('/') gefehlt, was zu
ws://host:8123//api/websocket fuehrte (404).

https://claude.ai/code/session_01QwTqwLLUKqN1otCc6objD7