### PR TITLE
fix: Einstellungs-Sektionen standardmaessig aufgeklappt

### DIFF
--- a/assistant/static/ui/index.html
+++ b/assistant/static/ui/index.html
@@ -856,9 +856,9 @@ function fInfo(text) {
 }
 
 function sectionWrap(icon, title, content) {
-  return `<div class="s-section"><div class="s-section-hdr" onclick="toggleSec(this)">
+  return `<div class="s-section"><div class="s-section-hdr open" onclick="toggleSec(this)">
     <h3>${icon} ${title}</h3><span class="arrow">&#9660;</span></div>
-    <div class="s-section-body">${content}</div></div>`;
+    <div class="s-section-body open">${content}</div></div>`;
 }
 
 function updRange(el) {


### PR DESCRIPTION
Sektionen waren eingeklappt (max-height:0) - sah aus als waere nichts da. Jetzt sind alle Sektionen beim Oeffnen eines Tabs sofort sichtbar/aufgeklappt.

https://claude.ai/code/session_01QwTqwLLUKqN1otCc6objD7