### PR TITLE
feat: Jarvis spricht Antworten ueber HA-Speaker aus (TTS)

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -1064,9 +1064,8 @@ async def websocket_endpoint(websocket: WebSocket):
                             tts_data = result.get("tts")
                             await emit_stream_end(result["response"], tts_data=tts_data)
                         else:
+                            # brain.process() sendet intern via _speak_and_emit
                             result = await brain.process(text, person)
-                            tts_data = result.get("tts")
-                            await emit_speaking(result["response"], tts_data=tts_data)
 
                 elif event == "assistant.feedback":
                     # Phase 5: Feedback ueber FeedbackTracker verarbeiten


### PR DESCRIPTION
- SoundManager.speak_response(): Neue Methode die Jarvis-Antworten ueber Home Assistant TTS auf einem physischen Speaker ausgibt. Nutzt tts.speak (Piper bevorzugt) mit Fallback auf tts.cloud_say.

- Brain._speak_and_emit(): Zentrale Methode die sowohl WebSocket-Event als auch physische Sprachausgabe triggert. Ersetzt alle direkten emit_speaking() Aufrufe in brain.py.

- Alle Antwort-Pfade (Whisper-Modus, Gute-Nacht, Koch-Assistent, Sicherheits-Bestaetigungen, Easter Eggs, proaktive Meldungen, Timer, Health Alerts etc.) nutzen jetzt _speak_and_emit().

- Volume/Speed/SSML aus dem TTS-Enhancer werden an den Speaker weitergegeben. Target-Speaker aus Multi-Room wird respektiert.

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2