### PR TITLE
fix: fehlende __init__ Definition in SoundManager wiederhergestellt

### DIFF
--- a/assistant/assistant/sound_manager.py
+++ b/assistant/assistant/sound_manager.py
@@ -87,6 +87,8 @@ class SoundManager:
                 return False
 
         return True
+
+    def __init__(self, ha_client: HomeAssistantClient):
         self.ha = ha_client
 
         # Konfiguration


### PR DESCRIPTION
Die class-level Methode _is_tts_speaker hatte die def __init__ Zeile ueberschrieben — der gesamte __init__-Body hing unreachable nach einem return True. SoundManager konnte nicht instanziiert werden.

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2