### PR TITLE
fix: Cast YAML config values to int/float to prevent TypeError

### DIFF
--- a/assistant/assistant/sound_manager.py
+++ b/assistant/assistant/sound_manager.py
@@ -84,8 +84,8 @@ class SoundManager:
 
         # Volume-Konfiguration
         vol_cfg = yaml_config.get("volume", {})
-        self.evening_start = vol_cfg.get("evening_start", 22)
-        self.morning_start = vol_cfg.get("morning_start", 7)
+        self.evening_start = int(vol_cfg.get("evening_start", 22))
+        self.morning_start = int(vol_cfg.get("morning_start", 7))
 
         # Letzte Sounds (Anti-Spam)
         self._last_sound_time: dict[str, float] = {}

--- a/assistant/assistant/tts_enhancer.py
+++ b/assistant/assistant/tts_enhancer.py
@@ -98,20 +98,20 @@ class TTSEnhancer:
 
         # Volume Konfiguration
         vol_cfg = yaml_config.get("volume", {})
-        self.vol_day = vol_cfg.get("day", 0.8)
-        self.vol_evening = vol_cfg.get("evening", 0.5)
-        self.vol_night = vol_cfg.get("night", 0.3)
-        self.vol_sleeping = vol_cfg.get("sleeping", 0.2)
-        self.vol_emergency = vol_cfg.get("emergency", 1.0)
-        self.vol_whisper = vol_cfg.get("whisper", 0.15)
-        self.evening_start = vol_cfg.get("evening_start", 22)
-        self.night_start = vol_cfg.get("night_start", 0)
-        self.morning_start = vol_cfg.get("morning_start", 7)
+        self.vol_day = float(vol_cfg.get("day", 0.8))
+        self.vol_evening = float(vol_cfg.get("evening", 0.5))
+        self.vol_night = float(vol_cfg.get("night", 0.3))
+        self.vol_sleeping = float(vol_cfg.get("sleeping", 0.2))
+        self.vol_emergency = float(vol_cfg.get("emergency", 1.0))
+        self.vol_whisper = float(vol_cfg.get("whisper", 0.15))
+        self.evening_start = int(vol_cfg.get("evening_start", 22))
+        self.night_start = int(vol_cfg.get("night_start", 0))
+        self.morning_start = int(vol_cfg.get("morning_start", 7))
 
         # Auto-Nacht-Whisper: Automatisch Fluestern zwischen bestimmten Uhrzeiten
         self.auto_night_whisper = tts_cfg.get("auto_night_whisper", True)
-        self.auto_whisper_start = vol_cfg.get("auto_whisper_start", 23)
-        self.auto_whisper_end = vol_cfg.get("auto_whisper_end", 6)
+        self.auto_whisper_start = int(vol_cfg.get("auto_whisper_start", 23))
+        self.auto_whisper_end = int(vol_cfg.get("auto_whisper_end", 6))
 
         # Zustand
         self._whisper_mode = False


### PR DESCRIPTION
YAML config values for evening_start, morning_start, night_start, auto_whisper_start, auto_whisper_end were strings but compared with int (datetime.hour), causing:
  TypeError: '>=' not supported between instances of 'str' and 'int'

This crash prevented the night mode volume logic from running at all, which meant the Onkyo exclusion fix was never reached - explaining why Onkyo volume kept changing.

Fixed in both sound_manager.py and tts_enhancer.py by wrapping all YAML time values with int() and volume values with float().

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2