### PR TITLE
fix: Cast all YAML config values to int/float across 10 files

### DIFF
--- a/assistant/assistant/action_planner.py
+++ b/assistant/assistant/action_planner.py
@@ -130,9 +130,9 @@ class ActionPlanner:
         # Phase 9: Narration Mode Konfiguration
         narr_cfg = yaml_config.get("narration", {})
         self.narration_enabled = narr_cfg.get("enabled", True)
-        self.default_transition = narr_cfg.get("default_transition", 3)
+        self.default_transition = int(narr_cfg.get("default_transition", 3))
         self.scene_transitions = narr_cfg.get("scene_transitions", {})
-        self.step_delay = narr_cfg.get("step_delay", 1.5)
+        self.step_delay = float(narr_cfg.get("step_delay", 1.5))
         self.narrate_actions = narr_cfg.get("narrate_actions", True)
 
     def is_complex_request(self, text: str) -> bool:

--- a/assistant/assistant/activity.py
+++ b/assistant/assistant/activity.py
@@ -173,10 +173,10 @@ class ActivityEngine:
 
         # Schwellwerte
         thresholds = activity_cfg.get("thresholds", {})
-        self.night_start = thresholds.get("night_start", 22)
-        self.night_end = thresholds.get("night_end", 7)
-        self.guest_person_count = thresholds.get("guest_person_count", 2)
-        self.focus_min_minutes = thresholds.get("focus_min_minutes", 30)
+        self.night_start = int(thresholds.get("night_start", 22))
+        self.night_end = int(thresholds.get("night_end", 7))
+        self.guest_person_count = int(thresholds.get("guest_person_count", 2))
+        self.focus_min_minutes = int(thresholds.get("focus_min_minutes", 30))
 
         # Cache: letzte erkannte Aktivitaet
         self._last_activity = RELAXING

--- a/assistant/assistant/ambient_audio.py
+++ b/assistant/assistant/ambient_audio.py
@@ -125,8 +125,8 @@ class AmbientAudioClassifier:
 
         # Nachmodus: Strengere Reaktionen nachts
         night_cfg = cfg.get("night_mode") or {}
-        self._night_start = night_cfg.get("start_hour", 22)
-        self._night_end = night_cfg.get("end_hour", 7)
+        self._night_start = int(night_cfg.get("start_hour", 22))
+        self._night_end = int(night_cfg.get("end_hour", 7))
         self._night_escalate = night_cfg.get("escalate_severity", True)
 
         # Deaktivierte Events (z.B. wenn kein Hund da ist)

--- a/assistant/assistant/config_versioning.py
+++ b/assistant/assistant/config_versioning.py
@@ -32,7 +32,7 @@ class ConfigVersioning:
     def __init__(self):
         self._cfg = yaml_config.get("self_optimization", {}).get("rollback", {})
         self._enabled = self._cfg.get("enabled", True)
-        self._max_snapshots = self._cfg.get("max_snapshots", 20)
+        self._max_snapshots = int(self._cfg.get("max_snapshots", 20))
         self._snapshot_on_edit = self._cfg.get("snapshot_on_every_edit", True)
         self._redis = None
 

--- a/assistant/assistant/conflict_resolver.py
+++ b/assistant/assistant/conflict_resolver.py
@@ -107,16 +107,16 @@ class ConflictResolver:
         # Konfiguration laden
         cfg = yaml_config.get("conflict_resolution", {})
         self.enabled = cfg.get("enabled", True)
-        self._conflict_window = cfg.get("conflict_window_seconds", 300)
-        self._max_commands = cfg.get("max_commands_per_person", 20)
+        self._conflict_window = int(cfg.get("conflict_window_seconds", 300))
+        self._max_commands = int(cfg.get("max_commands_per_person", 20))
         self._use_trust_priority = cfg.get("use_trust_priority", True)
-        self._resolution_cooldown = cfg.get("resolution_cooldown_seconds", 120)
+        self._resolution_cooldown = int(cfg.get("resolution_cooldown_seconds", 120))
 
         # Mediations-Config
         med_cfg = cfg.get("mediation", {})
         self._mediation_enabled = med_cfg.get("enabled", True)
         self._mediation_model = med_cfg.get("model", "qwen3:14b")
-        self._mediation_max_tokens = med_cfg.get("max_tokens", 256)
+        self._mediation_max_tokens = int(med_cfg.get("max_tokens", 256))
         self._mediation_temperature = med_cfg.get("temperature", 0.7)
 
         # Domain-spezifische Konfiguration

--- a/assistant/assistant/context_builder.py
+++ b/assistant/assistant/context_builder.py
@@ -312,9 +312,9 @@ class ContextBuilder:
         if not weather_cfg.get("enabled", True):
             return warnings
 
-        temp_warn_high = weather_cfg.get("temp_high", 35)
-        temp_warn_low = weather_cfg.get("temp_low", -5)
-        wind_warn = weather_cfg.get("wind_speed_high", 60)
+        temp_warn_high = float(weather_cfg.get("temp_high", 35))
+        temp_warn_low = float(weather_cfg.get("temp_low", -5))
+        wind_warn = float(weather_cfg.get("wind_speed_high", 60))
         warn_conditions = weather_cfg.get("warn_conditions", [
             "lightning", "lightning-rainy", "hail", "exceptional",
         ])
@@ -609,7 +609,7 @@ class ContextBuilder:
         if not multi_room_cfg.get("enabled", True):
             return {}
 
-        timeout_minutes = multi_room_cfg.get("presence_timeout_minutes", 15)
+        timeout_minutes = int(multi_room_cfg.get("presence_timeout_minutes", 15))
         room_sensors = multi_room_cfg.get("room_motion_sensors", {})
         room_speakers = multi_room_cfg.get("room_speakers", {})
         now = datetime.now()

--- a/assistant/assistant/diagnostics.py
+++ b/assistant/assistant/diagnostics.py
@@ -42,11 +42,11 @@ class DiagnosticsEngine:
         # Konfiguration
         diag_cfg = yaml_config.get("diagnostics", {})
         self.enabled = diag_cfg.get("enabled", True)
-        self.check_interval = diag_cfg.get("check_interval_minutes", 30)
-        self.battery_threshold = diag_cfg.get("battery_warning_threshold", 20)
-        self.stale_minutes = diag_cfg.get("stale_sensor_minutes", 120)
-        self.offline_minutes = diag_cfg.get("offline_threshold_minutes", 30)
-        self.alert_cooldown = diag_cfg.get("alert_cooldown_minutes", 60)
+        self.check_interval = int(diag_cfg.get("check_interval_minutes", 30))
+        self.battery_threshold = int(diag_cfg.get("battery_warning_threshold", 20))
+        self.stale_minutes = int(diag_cfg.get("stale_sensor_minutes", 120))
+        self.offline_minutes = int(diag_cfg.get("offline_threshold_minutes", 30))
+        self.alert_cooldown = int(diag_cfg.get("alert_cooldown_minutes", 60))
 
         # Wartungs-Config
         maint_cfg = yaml_config.get("maintenance", {})

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -63,8 +63,8 @@ class ProactiveManager:
         # Phase 7.1: Morning Briefing Auto-Trigger
         mb_cfg = yaml_config.get("routines", {}).get("morning_briefing", {})
         self._mb_enabled = mb_cfg.get("enabled", True)
-        self._mb_window_start = mb_cfg.get("window_start_hour", 6)
-        self._mb_window_end = mb_cfg.get("window_end_hour", 10)
+        self._mb_window_start = int(mb_cfg.get("window_start_hour", 6))
+        self._mb_window_end = int(mb_cfg.get("window_end_hour", 10))
         self._mb_triggered_today = False
         self._mb_last_date = ""
 

--- a/assistant/assistant/routine_engine.py
+++ b/assistant/assistant/routine_engine.py
@@ -984,10 +984,10 @@ Kein unterwuerfiger Ton. Du bist ein brillanter Butler, kein Chatbot."""
         """Hauptloop der Abwesenheits-Simulation."""
         sim_cfg = yaml_config.get("vacation_simulation", {})
         # Typische Zeiten (konfigurierbar)
-        morning_lights = sim_cfg.get("morning_hour", 7)
-        evening_lights = sim_cfg.get("evening_hour", 18)
-        night_off = sim_cfg.get("night_hour", 23)
-        variation_minutes = sim_cfg.get("variation_minutes", 30)
+        morning_lights = int(sim_cfg.get("morning_hour", 7))
+        evening_lights = int(sim_cfg.get("evening_hour", 18))
+        night_off = int(sim_cfg.get("night_hour", 23))
+        variation_minutes = int(sim_cfg.get("variation_minutes", 30))
 
         while True:
             try:

--- a/assistant/assistant/time_awareness.py
+++ b/assistant/assistant/time_awareness.py
@@ -46,17 +46,17 @@ class TimeAwareness:
         # Konfiguration
         ta_cfg = yaml_config.get("time_awareness", {})
         self.enabled = ta_cfg.get("enabled", True)
-        self.check_interval = ta_cfg.get("check_interval_minutes", 5) * 60
+        self.check_interval = int(ta_cfg.get("check_interval_minutes", 5)) * 60
 
         thresholds = ta_cfg.get("thresholds", {})
-        self.threshold_oven = thresholds.get("oven", 60)
-        self.threshold_iron = thresholds.get("iron", 30)
-        self.threshold_light_empty = thresholds.get("light_empty_room", 30)
-        self.threshold_window_cold = thresholds.get("window_open_cold", 120)
-        self.threshold_pc_no_break = thresholds.get("pc_no_break", 360)
-        self.threshold_washer = thresholds.get("washer", 180)
-        self.threshold_dryer = thresholds.get("dryer", 150)
-        self.threshold_dishwasher = thresholds.get("dishwasher", 180)
+        self.threshold_oven = int(thresholds.get("oven", 60))
+        self.threshold_iron = int(thresholds.get("iron", 30))
+        self.threshold_light_empty = int(thresholds.get("light_empty_room", 30))
+        self.threshold_window_cold = int(thresholds.get("window_open_cold", 120))
+        self.threshold_pc_no_break = int(thresholds.get("pc_no_break", 360))
+        self.threshold_washer = int(thresholds.get("washer", 180))
+        self.threshold_dryer = int(thresholds.get("dryer", 150))
+        self.threshold_dishwasher = int(thresholds.get("dishwasher", 180))
 
         # Welche Zaehler aktiv sind
         counters_cfg = ta_cfg.get("counters", {})


### PR DESCRIPTION
Same bug as sound_manager.py/tts_enhancer.py - YAML config values come in as strings but are compared with integers using >=, <=, etc. causing TypeError at runtime.

Fixed files:
- diagnostics.py: check_interval, battery_threshold, stale/offline/cooldown
- activity.py: night_start/end, guest_person_count, focus_min_minutes
- time_awareness.py: all threshold values (oven, iron, washer, etc.)
- proactive.py: morning briefing window_start/end hours
- context_builder.py: weather temp/wind thresholds, presence timeout
- ambient_audio.py: night_start/end hours
- conflict_resolver.py: conflict_window, max_commands, cooldown, max_tokens
- config_versioning.py: max_snapshots
- action_planner.py: default_transition, step_delay
- routine_engine.py: vacation simulation hour values

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2