### PR TITLE
Cover-Config lokal auf Assistant speichern (JSON statt Addon-Proxy)

### DIFF
--- a/assistant/assistant/cover_config.py
+++ b/assistant/assistant/cover_config.py
@@ -1,0 +1,35 @@
+"""
+Lokale Cover-Konfiguration (JSON-basiert).
+
+Speichert Cover-Typ (shutter, garage_door, etc.) und enabled-Status
+direkt auf dem Assistant, ohne Umweg ueber das Addon.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger("mindhome-assistant")
+
+_COVER_CONFIG_FILE = Path(os.environ.get("DATA_DIR", "/app/data")) / "cover_configs.json"
+
+
+def load_cover_configs() -> dict:
+    """Cover-Configs aus lokaler JSON-Datei laden."""
+    try:
+        if _COVER_CONFIG_FILE.exists():
+            return json.loads(_COVER_CONFIG_FILE.read_text())
+    except Exception as e:
+        logger.warning("Cover-Config laden fehlgeschlagen: %s", e)
+    return {}
+
+
+def save_cover_configs(configs: dict) -> None:
+    """Cover-Configs in lokale JSON-Datei speichern."""
+    try:
+        _COVER_CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _COVER_CONFIG_FILE.write_text(json.dumps(configs, indent=2, ensure_ascii=False))
+    except Exception as e:
+        logger.error("Cover-Config speichern fehlgeschlagen: %s", e)
+        raise

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -1142,9 +1142,10 @@ class FunctionExecutor:
         if any(kw in eid_lower for kw in ("garage", "tor", "gate")):
             return False
 
-        # 3. MindHome CoverConfig pruefen (cover_type + enabled)
+        # 3. Lokale CoverConfig pruefen (cover_type + enabled)
         try:
-            configs = await self.ha.mindhome_get("/api/covers/configs")
+            from .cover_config import load_cover_configs
+            configs = load_cover_configs()
             if configs and isinstance(configs, dict):
                 conf = configs.get(entity_id, {})
                 # Typ-Check: Garagentore/Tore sind unsicher


### PR DESCRIPTION
- Neues Modul cover_config.py: JSON-basierte lokale Speicherung
- GET/PUT /api/ui/covers liest/schreibt jetzt direkt lokal
- _is_safe_cover() nutzt lokale Config statt mindhome_get()
- Kein Addon-Roundtrip mehr nötig für Cover-Konfiguration
- Daten in /app/data/cover_configs.json (persistentes Volume)

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2