### PR TITLE
Fix TTS: remove unsupported language param, improve speaker selection…

### DIFF
--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -1406,7 +1406,6 @@ class FunctionExecutor:
                         "entity_id": tts_entity,
                         "media_player_entity_id": speaker_entity,
                         "message": message,
-                        "language": "de",
                     },
                 )
             elif speaker_entity:
@@ -1416,7 +1415,6 @@ class FunctionExecutor:
                     {
                         "entity_id": speaker_entity,
                         "message": message,
-                        "language": "de",
                     },
                 )
             else:
@@ -1474,7 +1472,6 @@ class FunctionExecutor:
                         "entity_id": tts_entity,
                         "media_player_entity_id": speaker,
                         "message": message,
-                        "language": "de",
                     },
                 )
                 room_info = f" im {preferred_room}" if preferred_room else ""
@@ -1543,7 +1540,6 @@ class FunctionExecutor:
                     "entity_id": tts_entity,
                     "media_player_entity_id": speaker_entity,
                     "message": text,
-                    "language": "de",
                 },
             )
         else:

--- a/assistant/static/ui/index.html
+++ b/assistant/static/ui/index.html
@@ -1874,7 +1874,9 @@ function renderVoice() {
     {v:'notification',l:'Benachrichtigung'}
   ];
   return sectionWrap('&#128266;', 'Sprachausgabe (TTS)',
-    fInfo('Wie schnell und mit welchen Pausen soll der Assistent sprechen?') +
+    fInfo('Standard-Lautsprecher und TTS-Engine fuer Jarvis. Wenn leer, wird der erste Raum-Speaker verwendet.') +
+    fText('sounds.default_speaker', 'Standard-Lautsprecher', 'z.B. media_player.kuche') +
+    fText('sounds.tts_entity', 'TTS-Engine', 'z.B. tts.piper') +
     fToggle('tts.ssml_enabled', 'Fortgeschrittene Betonung (SSML)') +
     '<div style="margin:12px 0;font-weight:600;font-size:13px;">Sprechgeschwindigkeit pro Situation</div>' +
     fRange('tts.speed.confirmation', 'Bestaetigung', 50, 200, 5, {50:'Langsam',100:'Normal',150:'Schnell',200:'Sehr schnell'}) +


### PR DESCRIPTION
… + volume restore

- Remove hardcoded "language": "de" from all TTS calls (6 places) — Piper TTS rejects this param causing 1773+ errors: "Language 'de' not supported"
- Default speaker now falls back to first configured room_speaker before auto-detection (prevents accidentally selecting TV)
- Save/restore volume in speak_response() so speaker volume returns to original level after TTS playback
- Add default_speaker + tts_entity config fields to dashboard UI

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2