### PR TITLE
Alexa/Echo aus Speaker-Auto-Erkennung ausschliessen

### DIFF
--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -1902,6 +1902,7 @@ class FunctionExecutor:
         "denon", "marantz", "yamaha_receiver", "onkyo", "pioneer",
         "soundbar", "xbox", "playstation", "ps5", "ps4", "nintendo",
         "kodi", "plex", "emby", "jellyfin", "vlc", "mpd",
+        "echo", "alexa", "amazon",
     )
 
     def _is_tts_speaker(self, entity_id: str, attributes: dict = None) -> bool:

--- a/assistant/assistant/sound_manager.py
+++ b/assistant/assistant/sound_manager.py
@@ -66,6 +66,7 @@ class SoundManager:
         "denon", "marantz", "yamaha_receiver", "onkyo", "pioneer",
         "soundbar", "xbox", "playstation", "ps5", "ps4", "nintendo",
         "kodi", "plex", "emby", "jellyfin", "vlc", "mpd",
+        "echo", "alexa", "amazon",
     )
 
     def __init__(self, ha_client: HomeAssistantClient):


### PR DESCRIPTION
Echo/Alexa/Amazon Geraete koennen kein lokales Piper-TTS abspielen und verursachen HTTP 500 Fehler. Patterns zu _EXCLUDED_SPEAKER_PATTERNS in sound_manager.py und function_calling.py hinzugefuegt.

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2