### PR TITLE
Fix TypeError in autonomy trust check: cast YAML values to int

### DIFF
--- a/assistant/assistant/autonomy.py
+++ b/assistant/assistant/autonomy.py
@@ -58,8 +58,11 @@ class AutonomyManager:
 
         # Phase 10: Trust-Level Konfiguration laden
         trust_cfg = yaml_config.get("trust_levels", {})
-        self._default_trust = trust_cfg.get("default", 0)
-        self._person_trust: dict[str, int] = trust_cfg.get("persons", {}) or {}
+        self._default_trust = int(trust_cfg.get("default", 0))
+        raw_persons = trust_cfg.get("persons", {}) or {}
+        self._person_trust: dict[str, int] = {
+            name: int(level) for name, level in raw_persons.items()
+        }
         self._guest_actions = set(trust_cfg.get("guest_allowed_actions", [
             "set_light", "set_climate", "play_media", "get_entity_state", "play_sound",
         ]))


### PR DESCRIPTION
trust_cfg.persons values from YAML config can be strings (e.g. "2") instead of int, causing '>=' not supported between 'str' and 'int' in can_person_act(). Now explicitly cast to int on init.

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2