### PR TITLE
Perf: Fast-Model-Routing auf 6 Woerter + Pre-LLM-Calls parallel

### DIFF
--- a/assistant/assistant/model_router.py
+++ b/assistant/assistant/model_router.py
@@ -59,7 +59,7 @@ class ModelRouter:
             "licht", "lampe", "temperatur", "heizung", "rollladen",
             "jalousie", "szene", "alarm", "tuer", "gute nacht",
             "guten morgen", "musik", "pause", "stopp", "stop",
-            "leiser", "lauter", "an", "aus",
+            "leiser", "lauter", "an", "aus", "schalte", "mach",
         ])
 
         self.deep_keywords = models_config.get("deep_keywords", [
@@ -212,7 +212,7 @@ class ModelRouter:
         word_count = len(text_lower.split())
 
         # 1. Kurze Befehle -> schnelles Modell (wenn aktiviert)
-        if word_count <= 4 and self._fast_enabled:
+        if word_count <= 6 and self._fast_enabled:
             for keyword in self.fast_keywords:
                 if keyword in text_lower:
                     logger.debug("FAST model fuer: '%s' (keyword: %s)", text, keyword)


### PR DESCRIPTION
Zwei Performance-Fixes fuer schnellere Befehlsverarbeitung:

1. model_router: Fast-Keyword-Limit von 4 auf 6 Woerter erhoeht, damit Befehle wie "Schalte Julia Buero Licht ein" das 3B-Modell statt 14B/32B nehmen. Keywords "schalte" und "mach" ergaenzt.

2. brain.process(): 10 sequentielle async Calls (Mood, Formality, Irony, Time-Awareness, Security-Score, Cross-Room-Context, Guest-Mode, Tutorial, Summary, RAG) laufen jetzt parallel via asyncio.gather(). Spart ~1-3s pro Anfrage.

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2