### PR TITLE
Fix: Jarvis nutzt Wetter-Kontext + get_entity_state kennt weather.*

### DIFF
--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -290,13 +290,13 @@ _ASSISTANT_TOOLS_STATIC = [
         "type": "function",
         "function": {
             "name": "get_entity_state",
-            "description": "Status einer Home Assistant Entity abfragen (z.B. Sensor, Schalter, Thermostat)",
+            "description": "Status einer Home Assistant Entity abfragen. Funktioniert mit allen Entity-Typen: sensor.*, switch.*, light.*, climate.*, weather.* (z.B. weather.forecast_home fuer Wetterdaten), lock.*, media_player.*, binary_sensor.*, person.* etc.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "entity_id": {
                         "type": "string",
-                        "description": "Entity-ID (z.B. sensor.temperatur_buero, switch.steckdose_kueche)",
+                        "description": "Entity-ID (z.B. sensor.temperatur_buero, weather.forecast_home, switch.steckdose_kueche)",
                     },
                 },
                 "required": ["entity_id"],

--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -225,6 +225,7 @@ REGELN:
 - Wenn du etwas tust, bestätige kurz. Nicht erklären WAS du tust.
 - Wenn du etwas NICHT tun kannst, sag es ehrlich und schlage eine Alternative vor.
 - Stell keine Rückfragen die du aus dem Kontext beantworten kannst.
+- Wetter, Temperaturen, Anwesenheit etc. stehen im KONTEXT unten. Nutze diese Daten direkt. Sag NIEMALS du hast keinen Zugriff auf Wetter oder Sensoren.
 
 {complexity_section}
 AKTUELLER STIL: {time_style}
@@ -1260,7 +1261,12 @@ class PersonalityEngine:
 
             if "weather" in house:
                 w = house["weather"] or {}
-                lines.append(f"- Wetter: {w.get('temp', '?')}°C, {w.get('condition', '?')}")
+                weather_parts = [f"{w.get('temp', '?')}°C", str(w.get('condition', '?'))]
+                if w.get('humidity'):
+                    weather_parts.append(f"Luftfeuchtigkeit {w['humidity']}%")
+                if w.get('wind_speed'):
+                    weather_parts.append(f"Wind {w['wind_speed']} km/h")
+                lines.append(f"- Wetter: {', '.join(weather_parts)}")
 
             if "calendar" in house:
                 for event in (house["calendar"] or [])[:3]:


### PR DESCRIPTION
Drei Fixes damit Jarvis Wetterfragen korrekt beantwortet:

1. get_entity_state Tool-Beschreibung: weather.forecast_home als Beispiel ergaenzt, alle Entity-Typen explizit aufgelistet
2. System-Prompt: Regel ergaenzt dass Kontext-Daten (Wetter, Temps) direkt genutzt werden sollen, nie "kein Zugriff" sagen
3. Wetter-Kontext erweitert: Luftfeuchtigkeit + Wind im Prompt

https://claude.ai/code/session_01UmsJCDv8G3Bd3Zx27CVBm2