### PR TITLE
Cover 500er + set_light KeyError fixen

### DIFF
--- a/addon/rootfs/opt/mindhome/models.py
+++ b/addon/rootfs/opt/mindhome/models.py
@@ -2146,6 +2146,13 @@ MIGRATIONS = [
             "CREATE INDEX IF NOT EXISTS idx_cover_schedules_time ON cover_schedules(time_str, is_active)",
         ]
     },
+    {
+        "version": 14,
+        "description": "Add enabled column to cover_configs",
+        "sql": [
+            "ALTER TABLE cover_configs ADD COLUMN enabled BOOLEAN DEFAULT 1",
+        ]
+    },
 ]
 
 

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -1096,8 +1096,12 @@ class FunctionExecutor:
             return {"success": False, "message": f"Fehler: {e}"}
 
     async def _exec_set_light(self, args: dict) -> dict:
-        room = args["room"]
-        state = args["state"]
+        room = args.get("room")
+        state = args.get("state")
+        if not room:
+            return {"success": False, "message": "Kein Raum angegeben"}
+        if not state:
+            return {"success": False, "message": "Kein Zustand (on/off) angegeben"}
 
         # Sonderfall: "all" -> alle Lichter schalten
         if room.lower() == "all":
@@ -1222,7 +1226,9 @@ class FunctionExecutor:
 
     async def _exec_set_climate_room(self, args: dict) -> dict:
         """Raumthermostat-Modus: Temperatur pro Raum setzen."""
-        room = args["room"]
+        room = args.get("room")
+        if not room:
+            return {"success": False, "message": "Kein Raum angegeben"}
         entity_id = await self._find_entity("climate", room)
         if not entity_id:
             return {"success": False, "message": f"Kein Thermostat in '{room}' gefunden"}
@@ -1258,7 +1264,9 @@ class FunctionExecutor:
         return {"success": success, "message": f"{room} {direction}{temp}°C"}
 
     async def _exec_activate_scene(self, args: dict) -> dict:
-        scene = args["scene"]
+        scene = args.get("scene")
+        if not scene:
+            return {"success": False, "message": "Keine Szene angegeben"}
         entity_id = await self._find_entity("scene", scene)
         if not entity_id:
             # Versuche direkt mit scene.name
@@ -1270,7 +1278,9 @@ class FunctionExecutor:
         return {"success": success, "message": f"Szene '{scene}' aktiviert"}
 
     async def _exec_set_cover(self, args: dict) -> dict:
-        room = args["room"]
+        room = args.get("room")
+        if not room:
+            return {"success": False, "message": "Kein Raum angegeben"}
 
         entity_id = await self._find_entity("cover", room)
 


### PR DESCRIPTION
- Migration v14: Fehlende 'enabled' Spalte in cover_configs hinzufuegen (Model hatte die Spalte, Migration v13 nicht -> alle DB-Operationen 500)
- function_calling: args["room"]/args["state"] durch args.get() ersetzen bei set_light, set_climate_room, set_cover, activate_scene Gibt jetzt verstaendliche Fehlermeldung statt KeyError

https://claude.ai/code/session_01Dv1jm9p9rGnAVAj5TQWcMC