### PR TITLE
Raumtemperatur-Sensoren: Mittelwert statt Vorlauftemperatur

### DIFF
--- a/assistant/assistant/autonomy.py
+++ b/assistant/assistant/autonomy.py
@@ -65,6 +65,7 @@ class AutonomyManager:
         }
         self._guest_actions = set(trust_cfg.get("guest_allowed_actions", [
             "set_light", "set_climate", "play_media", "get_entity_state", "play_sound",
+            "get_house_status", "get_room_climate",
         ]))
         self._security_actions = set(trust_cfg.get("security_actions", [
             "lock_door", "set_alarm", "set_presence_mode",

--- a/assistant/config/settings.yaml.example
+++ b/assistant/config/settings.yaml.example
@@ -488,6 +488,8 @@ trust_levels:
   - play_media
   - get_entity_state
   - play_sound
+  - get_house_status
+  - get_room_climate
   security_actions:
   - lock_door
   - set_alarm


### PR DESCRIPTION
Neues Feature: Konfigurierbare Temperatursensoren fuer die Raumtemperatur-Berechnung. Jarvis bildet den Mittelwert aller konfigurierten Sensoren statt die Vorlauftemperatur der Waermepumpe zu nehmen. Fallback auf climate.* wenn keine Sensoren konfiguriert.

- settings.yaml: room_temperature.sensors Liste
- API: GET/PUT /api/ui/room-temperature + /available
- UI: Sensor-Konfiguration im Assistant UI (Raeume-Tab)
- Boot-Announcement: Nutzt Sensor-Mittelwert
- Fix: guest_allowed_actions um get_house_status/get_room_climate erweitert

https://claude.ai/code/session_01Dv1jm9p9rGnAVAj5TQWcMC