### PR TITLE
LIGHT AUDIT: Log-Level von WARNING auf DEBUG

### DIFF
--- a/assistant/assistant/ha_client.py
+++ b/assistant/assistant/ha_client.py
@@ -128,12 +128,11 @@ class HomeAssistantClient:
         Returns:
             True bei Erfolg
         """
-        # Audit-Log fuer Licht-Aktionen: Wer hat das Licht geschaltet?
+        # Audit-Log fuer Licht-Aktionen
         if domain == "light":
-            caller_stack = "".join(traceback.format_stack(limit=8)[:-1])
-            logger.warning(
-                "LIGHT AUDIT: %s.%s data=%s\nCall-Stack:\n%s",
-                domain, service, data, caller_stack,
+            logger.debug(
+                "LIGHT AUDIT: %s.%s data=%s",
+                domain, service, data,
             )
 
         result = await self._post_ha(


### PR DESCRIPTION
Das Audit-Log fuer Licht-Aktionen spammte die Logs mit WARNING und vollem Call-Stack. Auf DEBUG reduziert und Stack entfernt.

https://claude.ai/code/session_01Dv1jm9p9rGnAVAj5TQWcMC