### PR TITLE
fix: git pull --rebase fuer divergente Branches im Update-System

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -2679,7 +2679,7 @@ async def ui_system_update(token: str = "", body: BranchUpdateRequest | None = N
         pull_branch = target_branch or old_branch
         _update_log.append(f"Git pull origin/{pull_branch}...")
         rc, out = _run_cmd(
-            ["git", "pull", "origin", pull_branch],
+            ["git", "pull", "--rebase", "origin", pull_branch],
             cwd=str(_REPO_DIR), timeout=60,
         )
 

--- a/assistant/update.sh
+++ b/assistant/update.sh
@@ -211,7 +211,7 @@ update_code() {
     fi
 
     info "Hole Updates von origin/$PULL_BRANCH..."
-    if ! git pull origin "$PULL_BRANCH"; then
+    if ! git pull --rebase origin "$PULL_BRANCH"; then
         error "git pull fehlgeschlagen"
         # Rollback bei Branch-Wechsel
         if [ "$SWITCHING" = true ]; then


### PR DESCRIPTION
Behebt den Fehler "Need to specify how to reconcile divergent branches" indem --rebase als Merge-Strategie gesetzt wird — sowohl in der Python-API (main.py) als auch im Shell-Script (update.sh).

https://claude.ai/code/session_01Q97rKB6sa8iviL5RUk52X6