### PR TITLE
fix: set_light akzeptiert entity_id als Fallback fuer room

### DIFF
--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -1111,10 +1111,24 @@ class FunctionExecutor:
     async def _exec_set_light(self, args: dict) -> dict:
         room = args.get("room")
         state = args.get("state")
+
+        # Qwen3-Fallback: entity_id statt room akzeptieren
+        if not room and args.get("entity_id"):
+            eid = args["entity_id"]
+            if eid.startswith("light."):
+                room = eid.split(".", 1)[1]
+            else:
+                room = eid
+
+        # State ableiten wenn nicht explizit angegeben
+        if not state:
+            if args.get("brightness"):
+                state = "on"
+            else:
+                state = "off"
+
         if not room:
             return {"success": False, "message": "Kein Raum angegeben"}
-        if not state:
-            return {"success": False, "message": "Kein Zustand (on/off) angegeben"}
 
         # Sonderfall: "all" -> alle Lichter schalten
         if room.lower() == "all":


### PR DESCRIPTION
Qwen3 generiert manchmal entity_id statt room im Tool-Call:
  {"entity_id": "light.julia_buro", "brightness": "20"}
statt:
  {"room": "buero", "state": "on", "brightness": 20}

Fixes:
- entity_id wird als Fallback fuer room akzeptiert
- state wird aus Kontext abgeleitet (brightness → on, sonst → off)

https://claude.ai/code/session_01Q97rKB6sa8iviL5RUk52X6