### PR TITLE
fix: brightness-Wert robust parsen (String, %-Zeichen, Float)

### DIFF
--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -1157,7 +1157,11 @@ class FunctionExecutor:
 
         service_data = {"entity_id": entity_id}
         if "brightness" in args and state == "on":
-            service_data["brightness_pct"] = args["brightness"]
+            try:
+                bri = str(args["brightness"]).replace("%", "").strip()
+                service_data["brightness_pct"] = max(1, min(100, int(float(bri))))
+            except (ValueError, TypeError):
+                pass
         # Phase 9: Transition-Parameter (sanftes Dimmen) — muss int/float sein
         if "transition" in args:
             try:


### PR DESCRIPTION
Qwen3 liefert brightness manchmal als String ("20"), mit Prozent ("20%") oder als Float (20.0). Jetzt wird der Wert sauber zu einem Integer 1-100 konvertiert.

https://claude.ai/code/session_01Q97rKB6sa8iviL5RUk52X6