### PR TITLE
fix: use configurable api_timeout for context build instead of hardco…

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -685,15 +685,16 @@ class AssistantBrain(BrainCallbacksMixin):
         await emit_thinking()
 
         # 1. Kontext sammeln (mit Subsystem-Timeout)
+        ctx_timeout = float((yaml_config.get("context") or {}).get("api_timeout", 10))
         try:
             context = await asyncio.wait_for(
                 self.context_builder.build(
                     trigger="voice", user_text=text, person=person or ""
                 ),
-                timeout=5.0,
+                timeout=ctx_timeout,
             )
         except asyncio.TimeoutError:
-            logger.warning("Context Build Timeout (5s) — Fallback auf Minimal-Kontext")
+            logger.warning("Context Build Timeout (%.0fs) — Fallback auf Minimal-Kontext", ctx_timeout)
             context = {"time": {"datetime": datetime.now().isoformat()}}
         except Exception as e:
             logger.error("Context Build Fehler: %s — Fallback auf Minimal-Kontext", e)

--- a/assistant/assistant/context_builder.py
+++ b/assistant/assistant/context_builder.py
@@ -408,14 +408,19 @@ class ContextBuilder:
         return alerts
 
     async def _get_mindhome_data(self) -> Optional[dict]:
-        """Holt optionale MindHome-Daten."""
+        """Holt optionale MindHome-Daten (parallel fuer Geschwindigkeit)."""
+        import asyncio
+
         try:
+            presence, energy = await asyncio.gather(
+                self.ha.get_presence(),
+                self.ha.get_energy(),
+                return_exceptions=True,
+            )
             data = {}
-            presence = await self.ha.get_presence()
-            if presence:
+            if isinstance(presence, dict):
                 data["presence"] = presence
-            energy = await self.ha.get_energy()
-            if energy:
+            if isinstance(energy, dict):
                 data["energy"] = energy
             return data if data else None
         except Exception as e:

--- a/assistant/config/settings.yaml.example
+++ b/assistant/config/settings.yaml.example
@@ -288,7 +288,7 @@ summarizer:
   max_tokens_monthly: 512
 context:
   recent_conversations: 5
-  api_timeout: 5
+  api_timeout: 10
   llm_timeout: 60
 heating:
   mode: room_thermostat


### PR DESCRIPTION
…ded 5s

The context builder timeout was hardcoded to 5s, causing frequent fallbacks to minimal context when HA API calls were slow. Now reads context.api_timeout from settings.yaml (default raised to 10s). Also parallelizes MindHome API calls (presence + energy) in context builder for faster response times.

https://claude.ai/code/session_01GG64EY6FxR52mSrDfcGzne