### PR TITLE
Fix WebSocket blocked by API key middleware: add /ws to exempt paths

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -308,6 +308,7 @@ _api_key_required: bool = False
 # Pfade die OHNE API Key zugaenglich bleiben (Health fuer Discovery/Config-Flow)
 _API_KEY_EXEMPT_PATHS = frozenset({
     "/api/assistant/health",
+    "/api/assistant/ws",  # WebSocket hat eigene Auth-Pruefung im Endpoint
     "/",
     "/docs",
     "/openapi.json",


### PR DESCRIPTION
The HTTP api_key_middleware intercepts WebSocket upgrade requests at /api/assistant/ws and returns 403 before the WebSocket endpoint is reached. The WS endpoint already has its own auth check (line 1172), so the middleware check is redundant and breaks the chat UI.

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP