### PR TITLE
Add dedicated get_weather function for weather queries

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -1115,7 +1115,7 @@ class AssistantBrain(BrainCallbacksMixin):
                           "get_room_climate", "get_active_intents",
                           "get_wellness_status", "get_device_health",
                           "get_learned_patterns", "describe_doorbell",
-                          "get_house_status", "get_lights",
+                          "get_house_status", "get_weather", "get_lights",
                           "get_covers", "get_media", "get_climate", "get_switches"}
             has_query_results = False
 


### PR DESCRIPTION
LLM was using get_house_status for weather questions, returning everything instead of just weather. New get_weather function:
- Current conditions with German translations
- Temperature, humidity, wind speed+direction, pressure
- Forecast for next 6 periods with precipitation
- Registered in QUERY_TOOLS for LLM-formatted responses

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP