### PR TITLE
fix: handle string type for health_monitor.exclude_patterns

### DIFF
--- a/assistant/assistant/health_monitor.py
+++ b/assistant/assistant/health_monitor.py
@@ -76,6 +76,8 @@ class HealthMonitor:
             "taupunkt", "dew_point",
         ]
         user_excludes = cfg.get("exclude_patterns", [])
+        if isinstance(user_excludes, str):
+            user_excludes = [p.strip() for p in user_excludes.splitlines() if p.strip()]
         self._exclude_patterns = [p.lower() for p in (self._default_excludes + user_excludes)]
         # Nach Startup erste Runde nur loggen, nicht melden (Cooldowns leer)
         self._first_check = True

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -1759,6 +1759,8 @@ def _reload_all_modules(yaml_cfg: dict, changed_settings: dict):
             hm._alert_cooldown_minutes = int(hm_cfg.get("alert_cooldown_minutes", 60))
             # Exclude-Patterns neu laden
             user_excludes = hm_cfg.get("exclude_patterns", [])
+            if isinstance(user_excludes, str):
+                user_excludes = [p.strip() for p in user_excludes.splitlines() if p.strip()]
             hm._exclude_patterns = [p.lower() for p in (hm._default_excludes + user_excludes)]
             logger.info("Health Monitor Settings aktualisiert")
 


### PR DESCRIPTION
The Dashboard textarea saves exclude_patterns as a newline-separated string, but health_monitor expected a list. This caused a TypeError on startup: "can only concatenate list (not 'str') to list".

Now converts string to list by splitting on newlines in both the initial __init__ and the hot-reload path in main.py.

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP