### PR TITLE
fix: auto-convert brightness 0-255 to 0-100 percent scale

### DIFF
--- a/assistant/assistant/function_validator.py
+++ b/assistant/assistant/function_validator.py
@@ -128,6 +128,10 @@ class FunctionValidator:
                 brightness = int(brightness)
             except (ValueError, TypeError):
                 return ValidationResult(ok=False, reason=f"Helligkeit '{brightness}' ist keine gueltige Zahl")
+            # Qwen3 sendet manchmal 0-255 (HA-Skala) statt 0-100 (Prozent)
+            if 101 <= brightness <= 255:
+                brightness = round(brightness / 255 * 100)
+                args["brightness"] = brightness
             if brightness < 0 or brightness > 100:
                 return ValidationResult(
                     ok=False,


### PR DESCRIPTION
Qwen3 sometimes sends brightness in HA's internal 0-255 scale instead of the expected 0-100 percent. E.g. user says "100%" but LLM sends brightness=255.

Now in the validator: values 101-255 are auto-converted to percent (255 -> 100%, 128 -> 50%) instead of being blocked.

Also confirms entity catalog is working: light.julia_buero was correctly resolved from "Julia Bürolicht".

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP