### PR TITLE
fix: strip device-type words from room + bidirectional entity matching

### DIFF
--- a/addon/rootfs/opt/mindhome/routes/devices.py
+++ b/addon/rootfs/opt/mindhome/routes/devices.py
@@ -171,7 +171,7 @@ def api_search_devices():
                 n = n.replace(" ", "_")
                 if rn == n:
                     exact_ids.append(r.id)
-                elif rn in n:
+                elif rn in n or n in rn:
                     partial_ids.append(r.id)
             # Exakte Matches bevorzugen, dann partial
             matching_room_ids = exact_ids if exact_ids else partial_ids


### PR DESCRIPTION
Root cause: Qwen3 often puts device type into room parameter, e.g. room="schlafzimmer rollladen" instead of room="schlafzimmer". Then _find_entity fails because "schlafzimmer_rollladen" is NOT contained in "schlafzimmer".

Two fixes:

1. _clean_room() now strips device-type words (rollladen, licht, heizung, steckdose, lampe, etc.) from room names: "schlafzimmer rollladen" → "schlafzimmer" "wohnzimmer licht" → "wohnzimmer" "kueche heizung" → "kueche" Preserves person prefixes: "manuel buero" stays unchanged.

2. Bidirectional partial matching in _find_entity AND search_devices: Old: search_norm IN entity_name (one direction only) New: search_norm IN entity_name OR entity_name IN search_norm This catches cases where the search term is longer than the entity name (e.g. "schlafzimmer_rollladen" vs "schlafzimmer").

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP