### PR TITLE
bump addon version to 1.5.5 (build 96)

### DIFF
--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "1.4.0"
+  org.opencontainers.image.version: "1.5.5"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "1.5.4"
+version: "1.5.5"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,16 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "1.4.5"
-BUILD = 95
-BUILD_DATE = "2026-02-21"
+VERSION = "1.5.5"
+BUILD = 96
+BUILD_DATE = "2026-02-22"
 CODENAME = "Jarvis Voice"
 
 # Changelog
+# Build 96: v1.5.5 Jarvis Voice — Entity-Matching Fix
+#   - FIX: Geraetetyp-Woerter aus Room-Parameter strippen (schlafzimmer rollladen -> schlafzimmer)
+#   - FIX: Bidirektionales Entity-Matching (DB + HA-Fallback)
+#   - FIX: search_devices bidirektional (n in rn)
 # Build 95: v1.4.5 Jarvis Voice — Voice-Pipeline Performance
 #   - PERF: ffmpeg Pipe statt Temp-Files (kein Disk-I/O)
 #   - PERF: STT Platform-Name gecacht (spart HTTP-Call pro Request)


### PR DESCRIPTION
Sync all version files (config.yaml, build.yaml, version.py) to 1.5.5. Includes entity-matching fixes from this session in changelog.

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP