### PR TITLE
fix: calendar shortcut used wrong attribute name (self.executor)

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -949,7 +949,7 @@ class AssistantBrain(BrainCallbacksMixin):
             timeframe = calendar_shortcut
             logger.info("Kalender-Shortcut: '%s' -> timeframe=%s", text, timeframe)
             try:
-                cal_result = await self.function_executor.execute(
+                cal_result = await self.executor.execute(
                     "get_calendar_events", {"timeframe": timeframe}
                 )
                 cal_msg = cal_result.get("message", "") if isinstance(cal_result, dict) else str(cal_result)


### PR DESCRIPTION
The calendar shortcut silently failed because it referenced self.function_executor which doesn't exist - the correct attribute is self.executor. The AttributeError was caught by the except block, falling back to LLM tool selection which picked the wrong tool.

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP