### PR TITLE
fix: improve tool feedback loop reliability + always include weather …

### DIFF
--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -3962,7 +3962,8 @@ class FunctionExecutor:
 
     async def _exec_get_weather(self, args: dict) -> dict:
         """Aktuelles Wetter und Vorhersage von Home Assistant."""
-        include_forecast = args.get("include_forecast", False)
+        # Vorhersage immer mitliefern — LLM entscheidet was davon relevant ist
+        include_forecast = True
 
         states = await self.ha.get_states()
         if not states:


### PR DESCRIPTION
…forecast

Tool Feedback Loop:
- Add think=False to feedback LLM call (prevents Qwen3 wasting tokens on reasoning)
- Add detailed logging: input data, LLM errors, and full response preview
- Log with exc_info on feedback failure for stack trace visibility

Weather:
- Always include forecast data regardless of include_forecast param
- LLM often failed to set include_forecast=true for "Wetter morgen?" questions
- Data is small, LLM picks relevant parts based on user question

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP