### PR TITLE
fix: add JARVIS-style humanizer fallback + silence ChromaDB telemetry…

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -8,6 +8,9 @@ import json
 import logging
 import os
 import random
+
+# ChromaDB Telemetrie deaktivieren (posthog capture() Fehler vermeiden)
+os.environ["ANONYMIZED_TELEMETRY"] = "False"
 import secrets
 from collections import deque
 from contextlib import asynccontextmanager


### PR DESCRIPTION
… errors

Query Result Humanizer:
- New _humanize_query_result() with templates for weather, calendar, entity state
- Transforms raw data into natural JARVIS speech when LLM feedback loop fails
- "TERMINE MORGEN (1): - 07:45 | Blutabnahme" → "Morgen steht ein Termin an: Blutabnahme um 07:45, Sir."
- "AKTUELL: Bewoelkt, 5.2°C, ..." → "Draussen 5.2°C, bewoelkt."
- Reliable fallback that works without LLM, always produces natural language

ChromaDB Telemetry:
- Set ANONYMIZED_TELEMETRY=False at app startup in main.py
- Silences "Failed to send telemetry event ClientStartEvent: capture() takes 1 positional argument but 3 were given" errors from posthog

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP