### PR TITLE
fix: eliminate duplicate responses + fix calendar humanizer + clean w…

### DIFF
--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -4068,7 +4068,9 @@ class FunctionExecutor:
                         line += f", Luftfeuchtigkeit {fc_humidity}%"
                     parts.append(line)
             else:
-                parts.append("VORHERSAGE: Keine Daten verfuegbar")
+                # Keine Vorhersage verfuegbar — still weglassen statt Fehlermeldung
+                # Das LLM/Humanizer antwortet dann nur mit den aktuellen Daten
+                logger.info("Wetter-Vorhersage nicht verfuegbar (HA-Integration liefert keine Prognosedaten)")
 
         return {"success": True, "message": "\n".join(parts)}
 


### PR DESCRIPTION
…eather output

Duplicate Responses:
- brain.process() called _speak_and_emit even during streaming mode
- main.py also sent emit_stream_end with the same response → double chat bubble
- Fix: skip emit_speaking when stream_callback is active (main.py handles it)
- TTS speech output still runs in both modes

Calendar Humanizer:
- Single-line format "TERMINE MORGEN (1): - 07:45 | Blutabnahme" was parsed wrong
- Old code tried to split on "|" but included the header as time_part
- New approach: regex extracts all "HH:MM | Title" patterns reliably
- Works for both single-line and multi-line calendar output

Weather:
- Remove "VORHERSAGE: Keine Daten verfuegbar" from output entirely
- When HA doesn't provide forecast, just return current weather without error text
- Prevents JARVIS from saying "Keine Daten verfuegbar" which sounds robotic

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP