### PR TITLE
fix: calendar raw data + duplicate messages — root cause found

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -1237,9 +1237,11 @@ async def websocket_endpoint(websocket: WebSocket):
                             if stream_tokens_sent:
                                 # Es wurden Tokens gestreamt → stream_end senden
                                 await emit_stream_end(result["response"], tts_data=tts_data)
-                            else:
+                            elif not result.get("_emitted"):
                                 # Keine Tokens gestreamt (z.B. Tool-Query mit Humanizer)
                                 # → normale Antwort senden statt leerer Stream-Blase
+                                # _emitted=True: Shortcut-Pfade in brain.py haben
+                                # bereits via _speak_and_emit gesendet
                                 await emit_speaking(result["response"], tts_data=tts_data)
                         else:
                             # brain.process() sendet intern via _speak_and_emit


### PR DESCRIPTION
The calendar shortcut path (_detect_calendar_query) completely bypassed the humanizer pipeline, sending raw data like "TERMINE MORGEN (1):
- 07:45 | Blutabnahme" directly to the LLM which passed it through. It also called _speak_and_emit AND returned to main.py which called emit_speaking again, causing duplicate chat messages.

Changes:
- Calendar shortcut now uses humanizer-first architecture (same as normal tool path): _humanize_calendar() runs first, then LLM refines
- Calendar shortcut checks stream_callback to avoid duplicate emit
- _humanize_calendar() now detects today/tomorrow/week context from raw data header instead of always saying "Morgen"
- _humanize_calendar() handles ganztaegig events and strips location/info suffixes from titles
- LLM refinement rejects responses containing raw data patterns
- All early-return paths in brain.py now set _emitted=True flag
- main.py checks _emitted flag to avoid double WebSocket messages

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP