### PR TITLE
fix: robust timeframe detection for calendar queries with "morgen"/"w…

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -3269,12 +3269,20 @@ class AssistantBrain(BrainCallbacksMixin):
         ]):
             return "week"
 
-        # Generisch "termine" / "kalender" ohne Zeitangabe → heute
-        if any(kw in t for kw in [
+        # Generisch "termine" / "kalender" ohne Zeitangabe
+        _calendar_keywords = [
             "was steht an", "meine termine", "welche termine",
             "welche termine habe ich", "welche termine stehen an",
             "habe ich termine", "zeig termine", "zeig kalender",
-        ]):
+            "am kalender", "im kalender", "auf dem kalender",
+            "steht am", "steht im",
+        ]
+        if any(kw in t for kw in _calendar_keywords):
+            # Zeitangabe im Text hat Vorrang vor Default "today"
+            if "morgen" in t:
+                return "tomorrow"
+            if "woche" in t:
+                return "week"
             return "today"
 
         return None


### PR DESCRIPTION
…oche"

Two bugs fixed:
1. "Welche Termine habe ich morgen?" matched generic "welche termine habe ich" pattern first and returned "today" — now the generic fallback checks for "morgen"/"woche" in the text before defaulting to "today".
2. "Was steht morgen am Kalender?" wasn't detected as calendar query at all because "am Kalender" wasn't in any pattern list — added "am kalender", "im kalender", etc. to generic keywords.

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP