### PR TITLE
fix: cooking intent detection, Markdown stripping, and repeat-gag timing

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -2449,6 +2449,14 @@ class AssistantBrain(BrainCallbacksMixin):
         for floskel in _chatbot_floskels:
             text = re.sub(floskel, "", text, flags=re.IGNORECASE).strip()
 
+        # 3b. Markdown-Formatierung entfernen (Chat-UI rendert kein Markdown)
+        text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)  # ### Headers
+        text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)                # **bold**
+        text = re.sub(r"\*(.+?)\*", r"\1", text)                    # *italic*
+        text = re.sub(r"^[\-\*]\s+", "", text, flags=re.MULTILINE)  # - bullet lists
+        text = re.sub(r"^\d+\.\s+", "", text, flags=re.MULTILINE)   # 1. numbered lists
+        text = re.sub(r"`(.+?)`", r"\1", text)                      # `code`
+
         # 4. Mehrere Leerzeichen / fuehrende Leerzeichen bereinigen
         text = re.sub(r"  +", " ", text).strip()
 

--- a/assistant/assistant/cooking_assistant.py
+++ b/assistant/assistant/cooking_assistant.py
@@ -104,6 +104,8 @@ COOKING_START_TRIGGERS = [
 COOKING_KEYWORDS = [
     "kochen", "backen", "zubereiten", "braten", "grillen",
     "rezept fuer", "rezept für",
+    "wie mache ich", "wie macht man", "wie bereite ich",
+    "wie koche ich", "wie backe ich", "wie brate ich",
 ]
 
 # Navigation per Sprache

--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -897,7 +897,7 @@ class PersonalityEngine:
         return gags.get(int(count))
 
     async def _check_short_memory_gag(self, text: str) -> Optional[str]:
-        """Erkennt wenn User innerhalb von 2 Minuten das gleiche fragt."""
+        """Erkennt wenn User innerhalb von 30 Sekunden das gleiche fragt."""
         key = "mha:gag:last_questions"
         now = datetime.now().timestamp()
 
@@ -911,7 +911,7 @@ class PersonalityEngine:
                 parts = item.split("|", 1)
                 ts = float(parts[0])
                 prev_text = parts[1] if len(parts) > 1 else ""
-                if now - ts < 120 and prev_text == text:
+                if now - ts < 30 and prev_text == text:
                     return "Das hatten wir gerade eben erst. Wort fuer Wort."
             except (ValueError, IndexError):
                 continue


### PR DESCRIPTION
Three fixes:

1. Cooking intent: "Wie mache ich Pasta Carbonara?" was not recognized as a cooking intent because "wie mache ich" / "wie macht man" were missing from COOKING_KEYWORDS. The question fell through to the general LLM which gave a raw Markdown recipe instead of starting the structured cooking mode.

2. Markdown stripping: The chat UI doesn't render Markdown, so ### headers, **bold**, - bullet lists, and `code` appeared as raw text. Added Markdown syntax removal to _filter_response.

3. Repeat-gag timing: Reduced the duplicate-question detection window from 120s to 30s. Users retrying after a bad response shouldn't be met with "Das hatten wir gerade eben erst."

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP