### PR TITLE
fix: rename set_alarm → arm_security_system to stop LLM confusion

### DIFF
--- a/assistant/assistant/autonomy.py
+++ b/assistant/assistant/autonomy.py
@@ -68,7 +68,7 @@ class AutonomyManager:
             "get_house_status", "get_room_climate",
         ]))
         self._security_actions = set(trust_cfg.get("security_actions", [
-            "lock_door", "set_alarm", "set_presence_mode",
+            "lock_door", "arm_security_system", "set_presence_mode",
         ]))
 
     def can_act(self, action_type: str) -> bool:

--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -585,7 +585,7 @@ class AssistantBrain(BrainCallbacksMixin):
                     "_emitted": True,
                 }
 
-        # Phase 13.1: Sicherheits-Bestaetigung (lock_door:unlock, set_alarm:disarm, etc.)
+        # Phase 13.1: Sicherheits-Bestaetigung (lock_door:unlock, arm_security_system:disarm, etc.)
         security_result = await self._handle_security_confirmation(text, person or "")
         if security_result:
             await self.memory.add_conversation("user", text)
@@ -2940,7 +2940,7 @@ class AssistantBrain(BrainCallbacksMixin):
         return None
 
     # ------------------------------------------------------------------
-    # Phase 13.1: Sicherheits-Bestaetigung (lock_door, set_alarm, etc.)
+    # Phase 13.1: Sicherheits-Bestaetigung (lock_door, arm_security_system, etc.)
     # ------------------------------------------------------------------
 
     async def _handle_security_confirmation(self, text: str, person: str) -> Optional[str]:

--- a/assistant/assistant/brain_callbacks.py
+++ b/assistant/assistant/brain_callbacks.py
@@ -17,7 +17,7 @@ _SAFE_AMBIENT_ACTIONS = frozenset({"lights_on", "play_sound"})
 
 # F-026: Aktionen die Owner-Trust benoetigen
 _RESTRICTED_AMBIENT_ACTIONS = frozenset({
-    "lock_door", "unlock_door", "set_alarm", "disarm_alarm",
+    "lock_door", "unlock_door", "arm_security_system", "disarm_alarm",
     "open_garage", "close_garage",
 })
 

--- a/assistant/assistant/conditional_commands.py
+++ b/assistant/assistant/conditional_commands.py
@@ -28,7 +28,7 @@ KEY_INDEX = "mha:conditional:index"
 # F-002: Aktionen die Owner-Trust erfordern
 OWNER_ONLY_ACTIONS = frozenset({
     "lock_door", "unlock_door",
-    "set_alarm", "arm_alarm", "disarm_alarm",
+    "arm_security_system", "arm_alarm", "disarm_alarm",
     "open_garage", "close_garage",
     "open_cover",  # Sicherheitsrelevant (Rolladen/Tore)
 })

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -420,8 +420,8 @@ _ASSISTANT_TOOLS_STATIC = [
     {
         "type": "function",
         "function": {
-            "name": "set_alarm",
-            "description": "Sicherheits-Alarmanlage (Einbruchschutz) scharf/unscharf schalten. NICHT fuer Wecker — dafuer set_wakeup_alarm verwenden.",
+            "name": "arm_security_system",
+            "description": "Sicherheits-Alarmanlage (Einbruchschutz) scharf oder unscharf schalten.",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -1346,7 +1346,7 @@ class FunctionExecutor:
         "set_light", "set_light_all", "get_lights", "set_climate", "set_climate_curve",
         "set_climate_room", "activate_scene", "set_cover", "set_cover_all",
         "get_covers", "get_media", "get_climate", "get_switches", "set_switch",
-        "call_service", "play_media", "transfer_playback", "set_alarm",
+        "call_service", "play_media", "transfer_playback", "arm_security_system",
         "lock_door", "send_notification", "send_message_to_person",
         "play_sound", "get_entity_state", "get_calendar_events",
         "create_calendar_event", "delete_calendar_event",
@@ -2411,10 +2411,10 @@ class FunctionExecutor:
                        else f"Transfer nach {to_room} fehlgeschlagen",
         }
 
-    async def _exec_set_alarm(self, args: dict) -> dict:
+    async def _exec_arm_security_system(self, args: dict) -> dict:
         mode = args.get("mode")
         if not mode:
-            return {"success": False, "message": "Kein Modus angegeben. Fuer Wecker bitte set_wakeup_alarm verwenden."}
+            return {"success": False, "message": "Kein Modus angegeben (arm_home, arm_away oder disarm)."}
         states = await self.ha.get_states()
         entity_id = None
         for s in (states or []):

--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -519,7 +519,7 @@ class PersonalityEngine:
             "unlock_door": [
                 "Entriegelt.",
             ],
-            "set_alarm": [
+            "arm_security_system": [
                 "Alarm scharf.",
             ],
             "disarm_alarm": [

--- a/assistant/assistant/routine_engine.py
+++ b/assistant/assistant/routine_engine.py
@@ -691,10 +691,10 @@ Kein unterwuerfiger Ton. Du bist ein brillanter Butler, kein Chatbot."""
             actions.append({"function": "set_cover:down", "result": result})
 
         if gn_actions.get("alarm_arm_home", False):
-            result = await self._executor.execute("set_alarm", {
+            result = await self._executor.execute("arm_security_system", {
                 "mode": "arm_home",
             })
-            actions.append({"function": "set_alarm:arm_home", "result": result})
+            actions.append({"function": "arm_security_system:arm_home", "result": result})
 
         return actions
 

--- a/assistant/assistant/timer_manager.py
+++ b/assistant/assistant/timer_manager.py
@@ -35,7 +35,7 @@ def _now() -> datetime:
 logger = logging.getLogger(__name__)
 
 # F-003: Whitelist fuer erlaubte Timer-Aktionen bei Ablauf
-# Sicherheitsrelevante Aktionen (lock_door, set_alarm, etc.) sind NICHT erlaubt
+# Sicherheitsrelevante Aktionen (lock_door, arm_security_system, etc.) sind NICHT erlaubt
 TIMER_ACTION_WHITELIST = frozenset({
     "set_light", "set_climate", "set_cover",
     "play_media", "pause_media", "stop_media",


### PR DESCRIPTION
Despite improved descriptions, the LLM still picked set_alarm for "Stelle einen Wecker auf 03:00" because "alarm" in the function name matched "Wecker/Alarm". The alarm was never actually set — the user got a robotic error explanation and get_alarms returned empty.

Renamed set_alarm → arm_security_system across all files:
- function_calling.py: tool definition + executor method
- brain.py, brain_callbacks.py: security confirmation references
- conditional_commands.py: OWNER_ONLY_ACTIONS
- autonomy.py: security_actions
- personality.py: contextual confirmations
- routine_engine.py: goodnight routine
- timer_manager.py: comment

Now "Wecker" requests can only match set_wakeup_alarm.

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP