### PR TITLE
fix: Boot-Sequenz Crash — Variable 'state' statt 's' in _boot_announc…

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -124,7 +124,7 @@ async def _boot_announcement(brain_instance: "AssistantBrain", health_data: dict
 
             # Offene Fenster/Tueren zaehlen — MindHome-Domain + device_class
             from .function_calling import is_window_or_door
-            if state_val == "on" and is_window_or_door(eid, state):
+            if state_val == "on" and is_window_or_door(eid, s):
                 name = attrs.get("friendly_name", eid)
                 open_items.append(name)
 


### PR DESCRIPTION
…ement

In der for-Schleife heisst die Loop-Variable 's', aber is_window_or_door() wurde mit 'state' aufgerufen (NameError). Behebt beide Fehler:
- "Boot-Sequenz fehlgeschlagen: name 'state' is not defined"
- TimeAwareness Check-Fehler beim Fenster-Check

https://claude.ai/code/session_01Xv92gbaqddxSF1L8AAHXHP