### PR TITLE
fix: mount speech source files as volumes in whisper container

### DIFF
--- a/assistant/docker-compose.yml
+++ b/assistant/docker-compose.yml
@@ -109,6 +109,8 @@ services:
       - REDIS_URL=redis://redis:6379
     volumes:
       - ${DATA_DIR:-./data}/whisper-models:/app/models
+      - ../speech/server.py:/app/server.py
+      - ../speech/handler.py:/app/handler.py
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
Docker build context in this environment doesn't pick up file changes. Mount server.py and handler.py as volumes to ensure edits are reflected at runtime without requiring image rebuild.

https://claude.ai/code/session_01M7fm9pUCJEjb5m5VLTFTH9