### PR TITLE
bump: v1.5.6 Build 97 — Speech Service Fixes

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.5.6 – Jarvis Voice (Speech Service Fixes)
+
+### Whisper Fix
+- **Whisper Crash behoben**: `AsrModel.__init__() missing 'version'` — wyoming 1.8.0 erfordert `version` Parameter bei AsrModel und AsrProgram
+- **Modellname-Parsing**: `WHISPER_MODEL=small-int8` wird automatisch in Modell (`small`) und Compute-Typ (`int8`) aufgetrennt
+
+### Piper Fix
+- **Piper Crash behoben**: `--port` ist kein gueltiges Argument — ersetzt durch `--uri tcp://0.0.0.0:10200` und `--data-dir /data`
+
+### Docker
+- Speech Source-Files (server.py, handler.py) als Volume-Mounts im Whisper-Container
+
 ## 1.4.4 – Jarvis Voice (STT-Fix, Frontend-Stability)
 
 ### STT Fix

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "1.5.5"
+  org.opencontainers.image.version: "1.5.6"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "1.5.5"
+version: "1.5.6"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,17 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "1.5.5"
-BUILD = 96
-BUILD_DATE = "2026-02-22"
+VERSION = "1.5.6"
+BUILD = 97
+BUILD_DATE = "2026-02-24"
 CODENAME = "Jarvis Voice"
 
 # Changelog
+# Build 97: v1.5.6 Jarvis Voice — Speech Service Fixes
+#   - FIX: Whisper crash — AsrModel/AsrProgram fehlender 'version' Parameter (wyoming 1.8.0)
+#   - FIX: Piper crash — --port durch --uri tcp://0.0.0.0:10200 ersetzt (wyoming-piper CLI)
+#   - FIX: WHISPER_MODEL "small-int8" Parsing — Compute-Typ wird automatisch abgetrennt
+#   - NEU: Speech Source-Files als Volume-Mounts (server.py, handler.py)
 # Build 96: v1.5.5 Jarvis Voice — Entity-Matching Fix
 #   - FIX: Geraetetyp-Woerter aus Room-Parameter strippen (schlafzimmer rollladen -> schlafzimmer)
 #   - FIX: Bidirektionales Entity-Matching (DB + HA-Fallback)


### PR DESCRIPTION
- Whisper: add required version param for wyoming 1.8.0
- Piper: replace --port with --uri (wyoming-piper CLI change)
- Whisper: parse compute type from WHISPER_MODEL env var
- Docker: mount speech source files as volumes

https://claude.ai/code/session_01M7fm9pUCJEjb5m5VLTFTH9