### PR TITLE
fix: NoneType crash when mood_result is None

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -2302,7 +2302,7 @@ class AssistantBrain(BrainCallbacksMixin):
         # Phase 8: Personality-Metrics tracken (ohne Sarkasmus — das laeuft jetzt separat)
         self._task_registry.create_task(
             self.personality.track_interaction_metrics(
-                mood=mood_result.get("mood", "neutral"),
+                mood=(mood_result or {}).get("mood", "neutral"),
                 response_accepted=True,
             ),
             name="track_metrics",


### PR DESCRIPTION
mood_result can be None when the mood subsystem fails or hasn't returned. Use (mood_result or {}).get() to prevent AttributeError.

https://claude.ai/code/session_01M7fm9pUCJEjb5m5VLTFTH9