### PR TITLE
fix: Status-Queries (Licht abgedreht?) + Plan-B-Kontextverlust + Spra…

### DIFF
--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -114,9 +114,9 @@ CONFIRMATIONS_PARTIAL = [
 ]
 
 CONFIRMATIONS_FAILED = [
-    "Hat nicht funktioniert. Ich hab einen Plan B.",
+    "Hat nicht funktioniert. Versuch es nochmal.",
     "Negativ. Pruefe Alternative.",
-    "Fehlgeschlagen. Zweiter Versuch laeuft.",
+    "Fehlgeschlagen. Nochmal versuchen.",
     "Nicht durchgegangen. Bleibe dran.",
     "Geht gerade nicht. Workaround?",
 ]
@@ -124,9 +124,9 @@ CONFIRMATIONS_FAILED = [
 # Sarkasmus-Level 4-5: Spitzere Fehler-Bestaetigungen
 CONFIRMATIONS_FAILED_SNARKY = [
     "Hat nicht geklappt. Ich geb mir die Schuld. Ach nein, doch nicht.",
-    "Nicht mein bester Moment. Aber ich hab Alternativen.",
+    "Nicht mein bester Moment. Nochmal?",
     "Das war nichts. Aufgeben steht nicht im Handbuch.",
-    "Negativ. Plan B ist bereits in Arbeit.",
+    "Negativ. Wird nochmal probiert.",
 ]
 
 
@@ -1603,10 +1603,10 @@ Kein unterwuerfiger Ton. Du bist ein brillanter Butler, kein Chatbot."""
 
         templates = {
             "general": [
-                "Das hat nicht funktioniert. Ich bleibe dran.",
-                "Negativ. Pruefe Alternativen.",
-                "Da ging etwas schief. Zweiter Versuch?",
-                "Nicht mein bester Moment. Aber ich habe einen Plan B.",
+                "Das hat nicht funktioniert. Versuch es nochmal.",
+                "Negativ. Formulier es anders, dann klappt es.",
+                "Da ging etwas schief. Stell die Frage nochmal.",
+                "Nicht mein bester Moment. Versuch es nochmal.",
             ],
             "timeout": [
                 "Keine Antwort. Das System braucht einen Moment.",


### PR DESCRIPTION
…ch-Retry

Root Cause 1: "Sind alle Licht abgedreht?" schlug fehl weil _is_device_command() nur Steuerungsbefehle erkennt (Licht an/aus), aber keine Status-Abfragen. _deterministic_tool_call() konnte get_lights korrekt zurueckgeben, wurde aber nie aufgerufen.

Fix: Neue _is_status_query() Methode die Geraete-Nomen + Query-Marker erkennt (sind, welche, status, abgedreht, brennt, etc.). Beide Gating-Stellen (7b + 7d) pruefen jetzt auch Status-Queries.

Root Cause 2: Fehlermeldungen wie "Ich habe einen Plan B" oder "Zweiter Versuch?" implizierten Follow-up-Aktionen die das LLM nicht kennt. Bei "Welchen Plan B?" brach JARVIS aus dem Charakter.

Fix: Alle "Plan B"/"Zweiter Versuch" Referenzen durch ehrliche Meldungen ersetzt ("Versuch es nochmal", "Stell die Frage nochmal").

Zusaetzlich:
- Retry-Logik: Fehlgeschlagene Query wird gespeichert, bei "Ja" wird die urspruengliche Anfrage automatisch wiederholt
- Sprach-Retry: temperature 0.5->0.3, think=False explizit, "Kein Reasoning" im Retry-Prompt gegen englisches Chain-of-Thought

https://claude.ai/code/session_01M7fm9pUCJEjb5m5VLTFTH9