### PR TITLE
feat: M5Stack Atom Echo ESPHome-Konfiguration mit eingebautem Speaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ chmod +x install.sh
 
 Siehe [docs/PROJECT_MINDHOME_ASSISTANT.md](docs/PROJECT_MINDHOME_ASSISTANT.md) fuer die vollstaendige Dokumentation.
 
+### ESPHome Voice Satellites
+
+MindHome unterstuetzt ESP32-basierte Sprach-Satellites fuer die Spracheingabe in jedem Raum.
+
+| Geraet | Mikrofon | Einsatz | Preis |
+|---|---|---|---|
+| **ReSpeaker XVF3800** | 4x MEMS + DSP | Hauptraeume (Kueche, Wohnzimmer) | ~55 EUR |
+| **M5Stack Atom Echo** | 1x PDM | Nebenraeume (Flur, Bad) | ~12 EUR |
+
+ESPHome-Konfigurationen liegen unter `esphome/`. Siehe [docs/SPEAKER_RECOGNITION.md](docs/SPEAKER_RECOGNITION.md) fuer Details.
+
 ---
 
 ## Architektur

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -47,6 +47,11 @@ mindhome/
 │       ├── summarizer.py                   # Tages-/Wochen-/Monats-Summaries
 │       └── websocket.py                    # WebSocket-Verbindungsmanager
 │
+├── esphome/                               # ESPHome Voice Satellite Configs
+│   ├── m5-atom-echo-test.yaml             # M5Stack Atom Echo (Test, eingebauter Speaker)
+│   ├── secrets.yaml.example               # Vorlage fuer WiFi + API Credentials
+│   └── .gitignore                         # Schuetzt secrets.yaml
+│
 ├── addon/                                  # MindHome Add-on (HA, PC 1)
 │   ├── config.yaml                         # Add-on Konfiguration (Ingress, Permissions)
 │   ├── Dockerfile                          # Container-Build

--- a/esphome/.gitignore
+++ b/esphome/.gitignore
@@ -1,0 +1,5 @@
+# Echte Secrets (enthaelt WiFi-Passwoerter, API-Keys)
+secrets.yaml
+
+# ESPHome Build-Cache
+.esphome/

--- a/esphome/m5-atom-echo-test.yaml
+++ b/esphome/m5-atom-echo-test.yaml
@@ -1,0 +1,181 @@
+# ============================================================
+# M5Stack Atom Echo — Voice Satellite (Test-Konfiguration)
+# Mic-Input:  SPM1423 PDM Mikrofon (1x, mono)
+# TTS-Output: Eingebauter NS4168 I2S Speaker (0.5W)
+# ============================================================
+#
+# INBETRIEBNAHME:
+# ───────────────
+# 1. ESPHome Add-on in Home Assistant installieren
+#    (Einstellungen → Add-ons → ESPHome)
+#
+# 2. ESPHome Dashboard oeffnen → "New Device" klicken
+#    → Name: atom-echo-test → Weiter
+#    → Den generierten YAML-Inhalt KOMPLETT durch diese Datei ersetzen
+#
+# 3. Secrets konfigurieren:
+#    → Im ESPHome Dashboard oben rechts auf "Secrets" klicken
+#    → Folgende Eintraege hinzufuegen:
+#      wifi_ssid: "DEIN_WLAN_NAME"
+#      wifi_password: "DEIN_WLAN_PASSWORT"
+#      api_encryption_key: "xxxx"   (Base64 Key, wird beim ersten Compile generiert)
+#      ota_password: "ein-sicheres-passwort"
+#
+# 4. Erster Flash per USB:
+#    → M5 Atom Echo per USB-C an den PC/NUC anschliessen
+#      (auf dem Home Assistant laeuft)
+#    → "Install" → "Plug into this computer" waehlen
+#    → ALTERNATIV: "Install" → "Manual download" → .bin Datei
+#      herunterladen und ueber https://web.esphome.io flashen
+#
+# 5. In Home Assistant einbinden:
+#    → Einstellungen → Geraete & Dienste
+#    → "Atom Echo Test" sollte automatisch erkannt werden
+#    → "Konfigurieren" klicken
+#    → Voice Assistant Pipeline zuweisen (z.B. "Home Assistant")
+#
+# 6. Testen:
+#    → "Hey Jarvis" sagen → LED wird blau
+#    → Frage stellen → LED wird gruen (Verarbeitung)
+#    → Antwort kommt ueber den eingebauten Speaker
+#
+# HINWEIS: Der eingebaute 0.5W Speaker ist leise aber fuer Tests OK.
+# Fuer den Produktivbetrieb empfehlen wir die Sonos-Variante
+# (siehe docs/SPEAKER_RECOGNITION.md)
+# ============================================================
+
+esphome:
+  name: atom-echo-test
+  friendly_name: "Atom Echo Test"
+  min_version: 2024.11.0
+
+esp32:
+  board: m5stack-atom
+  framework:
+    type: esp-idf
+
+# --- Logging ---
+logger:
+
+# --- WiFi ---
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Fallback-Hotspot wenn WiFi nicht erreichbar
+  ap:
+    ssid: "Atom-Echo-Test"
+    password: "mindhome123"
+
+captive_portal:
+
+# --- I2S Audio Bus (Mikrofon + Speaker teilen sich den Bus) ---
+i2s_audio:
+  - id: i2s_audio_bus
+    i2s_lrclk_pin: GPIO33
+    i2s_bclk_pin: GPIO19
+
+# --- Mikrofon: SPM1423 PDM (mono) ---
+microphone:
+  - platform: i2s_audio
+    id: atom_mic
+    adc_type: external
+    i2s_audio_id: i2s_audio_bus
+    i2s_din_pin: GPIO23
+    pdm: true
+
+# --- Speaker: NS4168 I2S (0.5W, eingebaut) ---
+speaker:
+  - platform: i2s_audio
+    id: atom_speaker
+    i2s_audio_id: i2s_audio_bus
+    dac_type: external
+    i2s_dout_pin: GPIO22
+    mode: mono
+
+# --- Wake Word (lokal auf dem ESP32) ---
+micro_wake_word:
+  models:
+    - model: hey_jarvis
+  on_wake_word_detected:
+    - voice_assistant.start:
+
+# --- Voice Assistant (mit eingebautem Speaker) ---
+voice_assistant:
+  microphone: atom_mic
+  speaker: atom_speaker
+  use_wake_word: true
+  noise_suppression_level: 2
+  auto_gain: 31dBFS
+
+  # LED-Feedback
+  on_listening:
+    - light.turn_on:
+        id: led
+        blue: 100%
+        red: 0%
+        green: 0%
+        brightness: 75%
+        effect: none
+  on_stt_vad_end:
+    - light.turn_on:
+        id: led
+        blue: 0%
+        red: 0%
+        green: 100%
+        brightness: 50%
+        effect: none
+  on_tts_start:
+    - light.turn_on:
+        id: led
+        blue: 0%
+        red: 100%
+        green: 50%
+        brightness: 60%
+        effect: none
+  on_end:
+    - light.turn_off:
+        id: led
+  on_error:
+    - light.turn_on:
+        id: led
+        red: 100%
+        green: 0%
+        blue: 0%
+        brightness: 75%
+        effect: none
+    - delay: 3s
+    - light.turn_off:
+        id: led
+
+# --- RGB LED (1x SK6812) ---
+light:
+  - platform: esp32_rmt_led_strip
+    id: led
+    pin: GPIO27
+    num_leds: 1
+    rmt_channel: 0
+    chipset: SK6812
+    rgb_order: GRB
+
+# --- Button (zum manuellen Aktivieren des Voice Assistant) ---
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO39
+      inverted: true
+    name: "Button"
+    id: echo_button
+    on_press:
+      - voice_assistant.start:
+    on_release:
+      - voice_assistant.stop:
+
+# --- API & OTA ---
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  - platform: esphome
+    password: !secret ota_password

--- a/esphome/secrets.yaml.example
+++ b/esphome/secrets.yaml.example
@@ -1,0 +1,17 @@
+# ESPHome Secrets — Vorlage
+# Kopiere diese Datei zu secrets.yaml und trage deine Werte ein:
+#   cp secrets.yaml.example secrets.yaml
+#
+# HINWEIS: secrets.yaml wird NICHT ins Git committed (.gitignore)
+
+wifi_ssid: "DEIN_WLAN_NAME"
+wifi_password: "DEIN_WLAN_PASSWORT"
+
+# API Encryption Key (Base64, 32 Bytes)
+# Wird beim ersten Kompilieren im ESPHome Dashboard automatisch generiert.
+# Du kannst auch selbst einen generieren:
+#   python3 -c "import secrets, base64; print(base64.b64encode(secrets.token_bytes(32)).decode())"
+api_encryption_key: "HIER_DEINEN_KEY_EINTRAGEN"
+
+# OTA Passwort fuer kabellose Updates
+ota_password: "ein-sicheres-passwort"


### PR DESCRIPTION
Erstellt ESPHome Voice Satellite Config fuer den M5 Atom Echo mit aktiviertem eingebautem Lautsprecher (NS4168) fuer Testzwecke. Enthaelt Schritt-fuer-Schritt Inbetriebnahme-Anleitung als Kommentare.

https://claude.ai/code/session_0167Fg8pn3yd6TCtTaFAPEEn