### PR TITLE
fix: rmt_channel entfernt (nicht mehr gueltig mit ESP-IDF Framework)

### DIFF
--- a/esphome/m5-atom-echo-test.yaml
+++ b/esphome/m5-atom-echo-test.yaml
@@ -154,7 +154,6 @@ light:
     id: led
     pin: GPIO27
     num_leds: 1
-    rmt_channel: 0
     chipset: SK6812
     rgb_order: GRB
 


### PR DESCRIPTION
https://claude.ai/code/session_0167Fg8pn3yd6TCtTaFAPEEn