### PR TITLE
fix: pin ESP-IDF 5.3.2 + platform 53.03.10 to fix broken cc1 toolchain

### DIFF
--- a/esphome/m5-atom-echo-test.yaml
+++ b/esphome/m5-atom-echo-test.yaml
@@ -53,6 +53,8 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
+    version: 5.3.2
+    platform_version: 53.03.10
 
 # --- Logging ---
 logger:


### PR DESCRIPTION
The default pioarduino platform 55.03.37 ships toolchain-xtensa-esp-elf 14.2.0 which has a broken cc1 binary (posix_spawnp: No such file or directory). Pinning to an older stable platform resolves the build failure.

https://claude.ai/code/session_0167Fg8pn3yd6TCtTaFAPEEn