### PR TITLE
fix: Wyoming-Server an offizielle faster-whisper Implementation angle…

### DIFF
--- a/speech/handler.py
+++ b/speech/handler.py
@@ -135,7 +135,7 @@ class WhisperEmbeddingHandler(AsyncEventHandler):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        self.wyoming_info = wyoming_info
+        self.wyoming_info_event = wyoming_info.event()
         self.model_name = model_name
         self.language = language
         self.device = device
@@ -158,7 +158,7 @@ class WhisperEmbeddingHandler(AsyncEventHandler):
         Returns True um die Verbindung offen zu halten.
         """
         if Describe.is_type(event.type):
-            await self.write_event(self.wyoming_info.event())
+            await self.write_event(self.wyoming_info_event)
             return True
 
         if Transcribe.is_type(event.type):


### PR DESCRIPTION
…ichen

- asyncio.run() statt asyncio.new_event_loop() (korrekte Event-Loop-Verwaltung)
- AsrProgram name/attribution identisch zur offiziellen wyoming-faster-whisper
- Info-Event einmal cachen statt bei jedem Describe neu zu erstellen

Behebt moegliche Kompatibilitaetsprobleme mit der HA Wyoming-Integration.

https://claude.ai/code/session_01QX8DeZ3vuXi19TQ6sa3XVM