### PR TITLE
fix: VRAM-Verbrauch durch num_ctx Begrenzung (4096 statt Default 32K+)

### DIFF
--- a/assistant/config/settings.yaml
+++ b/assistant/config/settings.yaml
@@ -53,6 +53,8 @@ persons:
   titles: null
 autonomy:
   level: 2
+ollama:
+  num_ctx: 4096
 models:
   fast: qwen3:4b
   smart: qwen3:14b


### PR DESCRIPTION
Ollama allokiert den KV-Cache fuer das volle Kontextfenster im VRAM, auch wenn der Prompt nur 200 Tokens hat. Der Default (32768 bei qwen3:14b) verbraucht bei 8GB GPUs fast den gesamten freien VRAM.

- num_ctx=4096 als Default (konfigurierbar via ollama.num_ctx in settings.yaml). Reicht fuer Smart-Home-Befehle, Hausstatus etc.
- Wird in allen drei Methoden (chat, stream_chat, generate) gesetzt
- Spart ~2-3 GB VRAM gegenueber Default-Kontextfenster

https://claude.ai/code/session_01QX8DeZ3vuXi19TQ6sa3XVM