### PR TITLE
fix: ENUM_RULES Validation crashte bei 3-Tupel Keys (too many values …

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -2062,11 +2062,20 @@ def _validate_settings_values(settings: dict) -> list[str]:
                     errors.append(f"{path_str}={val} (erlaubt: {min_val}-{max_val})")
             except (ValueError, TypeError):
                 errors.append(f"{path_str}={val} (kein gueltiger Wert)")
-    for (section, key), allowed in ENUM_RULES.items():
-        if section in settings and isinstance(settings[section], dict):
-            val = settings[section].get(key)
-            if val is not None and val not in allowed:
-                errors.append(f"{section}.{key}={val} (erlaubt: {', '.join(allowed)})")
+    for path_keys, allowed in ENUM_RULES.items():
+        obj = settings
+        for pk in path_keys[:-1]:
+            if isinstance(obj, dict) and pk in obj:
+                obj = obj[pk]
+            else:
+                obj = None
+                break
+        if obj is None or not isinstance(obj, dict):
+            continue
+        val = obj.get(path_keys[-1])
+        path_str = ".".join(path_keys)
+        if val is not None and val not in allowed:
+            errors.append(f"{path_str}={val} (erlaubt: {', '.join(allowed)})")
     return errors
 
 


### PR DESCRIPTION
…to unpack)

Die ENUM_RULES enthielt ("vacuum", "auto_clean", "mode") als 3-Tupel Key, aber die for-Schleife versuchte in (section, key) zu entpacken — das schlug mit "too many values to unpack (expected 2)" fehl.

Jetzt wird dieselbe flexible path_keys-Logik wie bei RANGE_RULES verwendet, die beliebig tiefe Pfade unterstuetzt.

https://claude.ai/code/session_01QX8DeZ3vuXi19TQ6sa3XVM