### PR TITLE
fix: Speech-Settings wirken sofort ohne manuellen Container-Neustart

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -2291,10 +2291,36 @@ _SETTINGS_STRIP_SUBKEYS = {
 }
 
 
+async def _restart_speech_containers(old_speech: dict, new_speech: dict):
+    """Startet nur die betroffenen Speech-Container automatisch neu.
+
+    Vergleicht alte und neue Speech-Config und startet gezielt:
+    - mha-whisper: wenn sich STT-Settings geaendert haben
+    - mha-piper:   wenn sich TTS-Settings geaendert haben
+    """
+    STT_KEYS = {"stt_model", "stt_language", "stt_beam_size", "stt_compute", "stt_device"}
+    TTS_KEYS = {"tts_voice"}
+
+    stt_changed = any(old_speech.get(k) != new_speech.get(k) for k in STT_KEYS)
+    tts_changed = any(old_speech.get(k) != new_speech.get(k) for k in TTS_KEYS)
+
+    restarted = []
+    if stt_changed:
+        ok = await _docker_restart("mha-whisper", timeout=10)
+        restarted.append(f"mha-whisper ({'OK' if ok else 'FEHLER'})")
+    if tts_changed:
+        ok = await _docker_restart("mha-piper", timeout=10)
+        restarted.append(f"mha-piper ({'OK' if ok else 'FEHLER'})")
+
+    if restarted:
+        logger.info("Speech-Container neu gestartet: %s", ", ".join(restarted))
+    return restarted
+
+
 def _sync_speech_to_env(speech_cfg: dict):
     """Synchronisiert speech-Settings aus settings.yaml in die .env Datei.
 
-    Damit docker-compose beim naechsten Neustart die neuen Werte verwendet.
+    Damit docker-compose die aktuellen Werte verwendet.
     Mapping: speech.stt_model → WHISPER_MODEL, speech.tts_voice → PIPER_VOICE, etc.
     """
     ENV_MAP = {
@@ -2425,11 +2451,13 @@ async def ui_update_settings(req: SettingsUpdateFull, token: str = ""):
             sound_cfg = cfg.yaml_config.get("sounds", {})
             brain.sound_manager.alexa_speakers = sound_cfg.get("alexa_speakers", [])
 
-        # Speech-Engine: Nur sync + restart-Hinweis wenn sich Speech tatsaechlich geaendert hat
+        # Speech-Engine: .env sync + Container automatisch neustarten
         new_speech = cfg.yaml_config.get("speech", {})
         speech_changed = (old_speech != new_speech)
+        speech_restarted = []
         if speech_changed:
             _sync_speech_to_env(new_speech)
+            speech_restarted = await _restart_speech_containers(old_speech, new_speech)
 
         # F-038: Alle weiteren Module benachrichtigen die Config bei __init__ cachen
         _reload_all_modules(cfg.yaml_config, safe_settings)
@@ -2439,14 +2467,15 @@ async def ui_update_settings(req: SettingsUpdateFull, token: str = ""):
         audit_details = {"changed_sections": changed_keys}
         if stripped:
             audit_details["stripped_protected"] = stripped
+        if speech_restarted:
+            audit_details["speech_containers_restarted"] = speech_restarted
         _audit_log("settings_update", audit_details)
 
         reloaded_count = 4 + len(_get_reloaded_modules(safe_settings))
-        restart_hint = " — Container-Neustart noetig fuer Sprach-Engine!" if speech_changed else ""
+        speech_hint = f" + Speech-Container neu gestartet: {', '.join(speech_restarted)}" if speech_restarted else ""
         return {
             "success": True,
-            "message": f"Settings gespeichert ({reloaded_count} Module aktualisiert){restart_hint}",
-            "restart_needed": speech_changed,
+            "message": f"Settings gespeichert ({reloaded_count} Module aktualisiert){speech_hint}",
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Fehler: {e}")

--- a/assistant/config/settings.yaml.example
+++ b/assistant/config/settings.yaml.example
@@ -392,13 +392,13 @@ seasonal_actions:
   check_interval_minutes: 30
   auto_execute_level: 3
 speech:
-  # STT-Engine (Whisper) — Aenderungen erfordern Container-Neustart!
+  # STT-Engine (Whisper) — Aenderungen werden sofort uebernommen
   stt_model: small            # tiny, base, small, medium, large-v3-turbo
   stt_language: de            # Sprache fuer Transkription (de, en, fr, ...)
   stt_beam_size: 5            # Beam Search Breite (1-10, hoeher = genauer, langsamer)
   stt_compute: int8           # CPU: int8 | GPU: float16
   stt_device: cpu             # cpu oder cuda (GPU)
-  # TTS-Engine (Piper) — Aenderungen erfordern Container-Neustart!
+  # TTS-Engine (Piper) — Aenderungen werden sofort uebernommen
   tts_voice: de_DE-thorsten-high  # Piper Voice (de_DE-thorsten-high = beste Qualitaet)
   # Auto-Whisper: Nachts automatisch leiser sprechen
   auto_night_whisper: true

--- a/assistant/static/ui/app.js
+++ b/assistant/static/ui/app.js
@@ -3449,11 +3449,7 @@ async function saveAllSettings() {
       _rpDirty = false;
     }
 
-    if (result && result.restart_needed) {
-      toast('Gespeichert — Container-Neustart noetig fuer Sprach-Engine!', 'warning');
-    } else {
-      toast('Einstellungen gespeichert');
-    }
+    toast(result?.message || 'Einstellungen gespeichert');
   } catch(e) {
     toast('Fehler beim Speichern' + (e.message ? ': ' + e.message : ''), 'error');
   } finally {


### PR DESCRIPTION
Speech-Container (mha-whisper, mha-piper) werden bei Settings-Aenderungen automatisch ueber die Docker API neu gestartet. Das restart_needed-Flag und der manuelle Restart-Hinweis im Frontend entfallen komplett.

https://claude.ai/code/session_01MEZCWL24VDDBAnTMtKHUZb