### PR TITLE
revert: remove ESP-IDF version pin, use ESPHome defaults

### DIFF
--- a/esphome/m5-atom-echo-test.yaml
+++ b/esphome/m5-atom-echo-test.yaml
@@ -53,8 +53,6 @@ esp32:
   board: m5stack-atom
   framework:
     type: esp-idf
-    version: 5.3.2
-    platform_version: 53.03.10
 
 # --- Logging ---
 logger:


### PR DESCRIPTION
ESP-IDF 5.3.2 broke microphone, micro_wake_word and LED on the M5 Atom Echo. Reverting to default ESP-IDF version (5.5.2) and fixing the toolchain issue by purging the PlatformIO cache instead.

https://claude.ai/code/session_0167Fg8pn3yd6TCtTaFAPEEn