### PR TITLE
fix: Activity guests-Fehlklassifizierung + deutsche Marker erweitert

### DIFF
--- a/assistant/assistant/ollama_client.py
+++ b/assistant/assistant/ollama_client.py
@@ -47,10 +47,18 @@ _META_MARKERS = [
 
 # Haeufige deutsche Woerter (muessen in einer echten deutschen Meldung vorkommen)
 _GERMAN_MARKERS = [
-    "sir", "der", "die", "das", "ist", "ein", "und", "nicht",
+    "sir", "ma'am", "der", "die", "das", "ist", "ein", "und", "nicht",
     "ich", "hab", "mal", "aus", "auf", "mit", "bei", "zur",
     "noch", "nur", "etwas", "gerade", "bitte", "danke",
     "grad", "uhr", "haus", "licht", "heiz",
+    # Verben (haeufig in Notifications)
+    "wurde", "wird", "hat", "sind", "kann", "soll",
+    "sollte", "darf", "liegt", "steht", "scheint",
+    # Smart-Home Begriffe
+    "temperatur", "fenster", "wasser", "luft",
+    "befeuchter", "humidor", "sensor", "batterie",
+    # Allgemein
+    "bereits", "aktuell", "guten", "herr", "frau",
 ]
 
 


### PR DESCRIPTION
- activity.py: _check_guests() unterscheidet jetzt zwischen Haushaltsmitgliedern und echten Gaesten. Wenn household.members mit ha_entity konfiguriert sind, werden nur unbekannte person.*-Entities als Gaeste gezaehlt. Fallback: persons_home > guest_person_count (statt >=), damit 2 Bewohner nicht als "Gaeste" klassifiziert werden.

- ollama_client.py: _GERMAN_MARKERS um haeufige Verben (wurde, wird, hat, sind, kann, soll), Smart-Home-Begriffe (temperatur, fenster, befeuchter, humidor) und "ma'am" erweitert. Verhindert dass Humidor-Notifications als "nicht Deutsch" verworfen werden.

https://claude.ai/code/session_01Cd7Rj1YP8CjfeHxYNpvosG