### PR TITLE
fix: false-positive Warnung bei Settings-Update durch Roundtrip gesch…

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -2687,7 +2687,7 @@ async def ui_update_settings(req: SettingsUpdateFull, token: str = ""):
             req.settings if isinstance(req.settings, dict) else {}
         )
         if stripped:
-            logger.warning("Settings-Update: Geschuetzte Keys herausgefiltert: %s", stripped)
+            logger.info("Settings-Update: Geschuetzte Keys herausgefiltert: %s", stripped)
 
         if not safe_settings:
             return {"success": True, "message": "Keine aenderbaren Settings vorhanden"}

--- a/assistant/static/ui/app.js
+++ b/assistant/static/ui/app.js
@@ -3682,7 +3682,19 @@ async function saveAllSettings() {
     const tabUpdates = collectSettings();
     deepMerge(S, tabUpdates);
     // Vollstaendiges Settings-Objekt senden (nicht nur aktiven Tab)
+    // Geschuetzte Keys entfernen die vom GET mitkommen aber per PUT
+    // nicht gesendet werden duerfen (sonst False-Positive Warnung im Log)
     const updates = JSON.parse(JSON.stringify(S));
+    delete updates.dashboard;
+    if (updates.security) {
+      delete updates.security.api_key;
+      delete updates.security.api_key_required;
+      if (Object.keys(updates.security).length === 0) delete updates.security;
+    }
+    if (updates.self_optimization) {
+      delete updates.self_optimization.immutable_keys;
+      if (Object.keys(updates.self_optimization).length === 0) delete updates.self_optimization;
+    }
     const result = await api('/api/ui/settings', 'PUT', {settings: updates});
 
     if (result && result.success === false) {


### PR DESCRIPTION
…uetzter Keys

Die UI laedt via GET /api/ui/settings ALLE Keys (inkl. dashboard, security.api_key, etc.) und schickt sie beim Speichern komplett zurueck. Der PUT-Endpoint filtert sie korrekt raus, loggt aber eine irrefuehrende Warnung. Fix: UI entfernt geschuetzte Keys vor dem Senden, Backend stuft Log von warning auf info herab.

https://claude.ai/code/session_01Cd7Rj1YP8CjfeHxYNpvosG