### PR TITLE
Fix: 'str' object has no attribute 'get' in _format_context

### DIFF
--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -2227,7 +2227,10 @@ class PersonalityEngine:
             # Termine: Nur naechste 2
             if "calendar" in house:
                 for event in (house["calendar"] or [])[:2]:
-                    lines.append(f"- Termin: {event.get('time', '?')} {event.get('title', '?')}")
+                    if isinstance(event, dict):
+                        lines.append(f"- Termin: {event.get('time', '?')} {event.get('title', '?')}")
+                    elif isinstance(event, str):
+                        lines.append(f"- Termin: {event}")
 
             if "active_scenes" in house and house["active_scenes"]:
                 lines.append(f"- Szenen: {', '.join(house['active_scenes'])}")


### PR DESCRIPTION
Calendar events from context_builder are stored as plain strings, but _format_context assumed they were dicts. Now handles both string and dict calendar entries gracefully.

https://claude.ai/code/session_01KsGMBMsHzPa3vDAkwmmYTe