### PR TITLE
Fix: Licht-Shortcut erkennt 'ein/aus' nicht bei Satzzeichen am Ende

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -5935,6 +5935,9 @@ class AssistantBrain(BrainCallbacksMixin):
         if "szene" in t:
             return None
 
+        # Satzzeichen am Ende entfernen (verhindert sonst Regex-Matches)
+        t = t.rstrip(".!,;:")
+
         words = [w for w in _re.split(r'[\s,.!?]+', t) if w]
         word_set = set(words)
 


### PR DESCRIPTION
"Schalte Manuel Büro Licht ein." wurde nicht als Licht-Befehl erkannt, weil der Punkt am Ende den Regex-Match auf 'ein$' verhinderte. Dadurch fiel der Befehl durch zum LLM, das fälschlicherweise set_vacuum statt set_light wählte.

Fix: Satzzeichen (.!,;:) werden nach dem Frage-Check entfernt, sodass die $-verankerten Regex-Patterns korrekt matchen.

https://claude.ai/code/session_01KsGMBMsHzPa3vDAkwmmYTe