### PR TITLE
Fix: Emotionales Gedaechtnis blockiert jetzt Aktionen + Pre-Classifie…

### DIFF
--- a/assistant/assistant/pre_classifier.py
+++ b/assistant/assistant/pre_classifier.py
@@ -115,7 +115,7 @@ PROFILE_GENERAL = RequestProfile(
 # -----------------------------------------------------------------
 
 _DEVICE_VERBS = re.compile(
-    r"^(mach|schalte|stell|setz|dreh|oeffne|schliess|aktivier|deaktivier"
+    r"^(mach|schalte|schalt|stell|setz|dreh|fahr|oeffne|schliess|aktivier|deaktivier"
     r"|spiel|stopp|pause|lauter|leiser)\b",
 )
 


### PR DESCRIPTION
…r erkennt 'schalt'

Problem 1: Wenn der User negativ auf set_vacuum reagiert hat, warnte das Emotionale Gedaechtnis zwar ("Frage lieber nach"), fuehrte die Aktion aber trotzdem aus (Level 1). Der rohe System-Text wurde dabei als Antwort an den User geleakt.

Fix: Emotionales Gedaechtnis wird jetzt wie Level 2 Pushback behandelt
- Aktion wird blockiert, Bestaetigung in Redis gespeichert, und eine benutzerfreundliche Rueckfrage generiert.

Problem 2: Pre-Classifier erkannte "schalt" (Imperativ ohne 'e') und "fahr" nicht als Device-Verben, obwohl der Device-Shortcut beide hat.

Fix: 'schalt' und 'fahr' zur _DEVICE_VERBS Regex hinzugefuegt.

https://claude.ai/code/session_01KsGMBMsHzPa3vDAkwmmYTe