### PR TITLE
feat: add consolidated light configuration tab to Jarvis UI

### DIFF
--- a/assistant/config/room_profiles.yaml
+++ b/assistant/config/room_profiles.yaml
@@ -28,6 +28,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 50
     night_brightness: 10
+    light_entities: []
+    light_type: "standard"
     alerts: []
     scenes: []
 
@@ -39,6 +41,8 @@ rooms:
     default_light: "tageslicht"
     default_brightness: 80
     night_brightness: 40
+    light_entities: []
+    light_type: "standard"
     alerts:
       - "keine_pause_3h"
     scenes:
@@ -53,6 +57,8 @@ rooms:
     default_light: "tageslicht"
     default_brightness: 80
     night_brightness: 40
+    light_entities: []
+    light_type: "standard"
     alerts:
       - "keine_pause_3h"
     scenes:
@@ -68,6 +74,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 50
     night_brightness: 10
+    light_entities: []
+    light_type: "standard"
     alerts: []
     scenes: []
 
@@ -79,6 +87,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 70
     night_brightness: 20
+    light_entities: []
+    light_type: "dim2warm"
     alerts: []
     scenes:
       - "gemuetlich"
@@ -93,6 +103,8 @@ rooms:
     default_light: "neutralweiss"
     default_brightness: 100
     night_brightness: 30
+    light_entities: []
+    light_type: "standard"
     alerts:
       - "ofen_lange_an"
       - "herd_an"
@@ -108,6 +120,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 30
     night_brightness: 5
+    light_entities: []
+    light_type: "dim2warm"
     alerts:
       - "co2_hoch"
     scenes:
@@ -123,6 +137,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 60
     night_brightness: 5
+    light_entities: []
+    light_type: "standard"
     alerts: []
     scenes:
       - "schlafen"
@@ -136,6 +152,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 60
     night_brightness: 5
+    light_entities: []
+    light_type: "standard"
     alerts: []
     scenes:
       - "schlafen"
@@ -149,6 +167,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 60
     night_brightness: 10
+    light_entities: []
+    light_type: "standard"
     alerts: []
     scenes:
       - "morgens"
@@ -162,6 +182,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 50
     night_brightness: 10
+    light_entities: []
+    light_type: "standard"
     alerts: []
     scenes: []
 
@@ -173,6 +195,8 @@ rooms:
     default_light: "warmweiss"
     default_brightness: 70
     night_brightness: 15
+    light_entities: []
+    light_type: "standard"
     alerts: []
     scenes: []
 

--- a/assistant/config/settings.yaml
+++ b/assistant/config/settings.yaml
@@ -382,6 +382,18 @@ context:
   recent_conversations: 5
   api_timeout: 10
   llm_timeout: 60
+lighting:
+  enabled: true
+  auto_on_dusk: true
+  auto_off_away: true
+  auto_off_empty_room_minutes: 30
+  night_dimming: true
+  daylight_off: true
+  default_transition: 2
+  circadian:
+    enabled: false
+    mode: mindhome
+    transition_seconds: 3
 heating:
   mode: room_thermostat
   curve_entity: ''

--- a/assistant/static/ui/index.html
+++ b/assistant/static/ui/index.html
@@ -845,6 +845,7 @@ input:focus,select:focus,textarea:focus { border-color:var(--accent); box-shadow
         <div class="nav-group-items">
           <div class="nav-item" data-page="presence"><span class="nav-icon">&#128205;</span>Anwesenheit</div>
           <div class="nav-item" data-page="settings" data-tab="tab-rooms"><span class="nav-icon">&#127968;</span>Raeume & Speaker</div>
+          <div class="nav-item" data-page="settings" data-tab="tab-lights"><span class="nav-icon">&#128161;</span>Licht</div>
           <div class="nav-item" data-page="settings" data-tab="tab-devices"><span class="nav-icon">&#128268;</span>Geraete</div>
           <div class="nav-item" data-page="settings" data-tab="tab-covers"><span class="nav-icon">&#129695;</span>Rolllaeden</div>
           <div class="nav-item" data-page="settings" data-tab="tab-vacuum"><span class="nav-icon">&#129529;</span>Saugroboter</div>


### PR DESCRIPTION
Add new "Licht" settings tab that consolidates all light-related configuration in one place:

- Room light entity assignment (light.* entities per room)
- Light type per room (dim2warm, tunable_white, standard)
- Day/night brightness per room (moved from Raeume tab)
- Automation rules (auto-on at dusk, auto-off when away, empty room timeout, night dimming, daylight hint)
- Circadian lighting with interpolated brightness curve
- Scene transition times
- Default transition time applied to all light commands
- New /api/ui/lights endpoint for fetching HA light entities

https://claude.ai/code/session_01MPRSoh2eRkt2Skm3TXYN6P