### PR TITLE
fix: three light control bugs — status-query shortcut, entity-ID 404,…

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -5781,6 +5781,9 @@ class AssistantBrain(BrainCallbacksMixin):
         "Welche Lichter sind noch an?", "Rollladenstatus?", "Steckdosen Status?"
         ab, die _is_device_command nicht erkennt weil sie keine Aktionswörter
         enthalten.
+
+        WICHTIG: Steuerungsbefehle ("stell auf 10%", "einstellen", "dimmen")
+        werden NICHT als Status-Query erkannt, auch wenn sie "ist" enthalten.
         """
         t = text.lower()
         _NOUNS = [
@@ -5795,6 +5798,19 @@ class AssistantBrain(BrainCallbacksMixin):
         ]
         has_noun = any(n in t for n in _NOUNS)
         if not has_noun:
+            return False
+        # Ausschluss: Wenn Aktionswoerter vorhanden → Steuerbefehl, keine Query
+        _ACTION_EXCLUSIONS = [
+            "einstellen", "stellen", "stell ", "setzen", "setz ",
+            "dimmen", "dimm ", "heller", "dunkler",
+            "mach ", "schalte ", "dreh ", "aufdrehen", "andrehen",
+            "ausschalten", "einschalten", "anschalten", "abschalten",
+            "auf ", "runter", "hoch", "rauf",
+        ]
+        # Prozent-Angabe mit Aktionskontext: "auf 10%" ist ein Befehl
+        if re.search(r'auf\s+\d+\s*%', t):
+            return False
+        if any(a in t for a in _ACTION_EXCLUSIONS):
             return False
         _QUERY_MARKERS = [
             "welche", "sind ", "ist ", "status", "zeig", "liste",

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -399,7 +399,7 @@ _ASSISTANT_TOOLS_STATIC = [
                     },
                     "brightness": {
                         "type": "integer",
-                        "description": "Helligkeit 0-100 Prozent (optional, nur bei state='on'). Ohne Angabe wird adaptive Helligkeit nach Tageszeit berechnet.",
+                        "description": "Helligkeit 0-100 Prozent (optional, nur bei state='on'). WICHTIG: Wenn der User einen konkreten Wert nennt (z.B. 'auf 10%'), diesen EXAKT uebernehmen — NICHT den aktuellen Kontextwert verwenden. Ohne Angabe wird adaptive Helligkeit nach Tageszeit berechnet.",
                     },
                     "transition": {
                         "type": "integer",
@@ -2043,7 +2043,7 @@ class FunctionExecutor:
         if "transition" in args:
             extras.append(f"Transition: {args['transition']}s")
         extra_str = f" ({', '.join(extras)})" if extras else ""
-        return {"success": success, "message": f"Licht {room} {state}{extra_str}"}
+        return {"success": success, "message": f"Licht {room} {state}{extra_str}", "entity_id": entity_id}
 
     async def _exec_set_light_all(self, args: dict, state: str) -> dict:
         """Alle Lichter ein- oder ausschalten."""

--- a/assistant/assistant/outcome_tracker.py
+++ b/assistant/assistant/outcome_tracker.py
@@ -80,8 +80,13 @@ class OutcomeTracker:
             logger.debug("OutcomeTracker: Max pending erreicht (%d)", self._max_pending)
             return
 
-        # Entity-ID bestimmen
-        entity_id = args.get("entity_id", "")
+        # Entity-ID bestimmen: bevorzuge aufgeloeste ID aus result (von _find_entity),
+        # dann args, dann konstruierte ID als Fallback
+        entity_id = ""
+        if isinstance(result, dict) and result.get("entity_id"):
+            entity_id = result["entity_id"]
+        if not entity_id:
+            entity_id = args.get("entity_id", "")
         if not entity_id:
             r = args.get("room", room or "")
             if r and action_type in ("set_light", "set_cover", "set_climate", "set_switch"):

--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -2196,7 +2196,7 @@ class PersonalityEngine:
             if "lights" in house:
                 lights_on = house.get("lights") or []
                 if lights_on:
-                    lines.append(f"- Lichter an: {', '.join(lights_on)}")
+                    lines.append(f"- Lichter an (nur Info, NICHT als Zielwert verwenden): {', '.join(lights_on)}")
 
             # Anwesenheit kompakt
             if "presence" in house:


### PR DESCRIPTION
… LLM brightness confusion

1. Status-Query-Shortcut: "auf 10% einstellen" was incorrectly classified as a status query (matched "ist " in "ist mir zu hell"). Added action word exclusions so commands with "einstellen", "auf X%", etc. bypass the shortcut.

2. Entity-ID 404: OutcomeTracker used LLM-generated entity_id (light.manuel_büro) instead of the resolved entity_id (light.hmipw_drd3_a3_licht_fitnessraum). Now prefers entity_id from action result, and _exec_set_light includes it.

3. LLM Brightness Confusion: The LLM saw current brightness (29%) in context and used it instead of the user's requested value (10%). Fixed by:
   - Making tool description explicit: "EXAKT übernehmen, NICHT Kontextwert"
   - Adding hint to context line: "nur Info, NICHT als Zielwert verwenden"

https://claude.ai/code/session_01MPRSoh2eRkt2Skm3TXYN6P