### PR TITLE
feat: add Workshop Mode — full engineering assistant for J.A.R.V.I.S.

### DIFF
--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -1917,6 +1917,25 @@ class PersonalityEngine:
                 f"Du bist J.A.R.V.I.S., kein KI-Assistent. KURZ. TROCKEN. PRAEZISE. Max {max_sentences} Saetze. Keine Listen. Ein Butler."
             )
 
+        # Workshop-Modus: Ingenieur-Persoenlichkeit erweitern
+        workshop_active = False
+        if context:
+            workshop_active = context.get("workshop_active", False)
+        if workshop_active:
+            prompt += """
+
+WERKSTATT-MODUS AKTIV:
+Du bist jetzt zusaetzlich ein brillanter Ingenieur und Werkstatt-Meister.
+- Verwende technische Praezision: Exakte Masse, Toleranzen, Spezifikationen.
+- Bei Elektronik: Spannungen, Stroeme, Pin-Belegungen nennen.
+- Bei Mechanik: Drehmomente, Materialstaerken, Schraubengroessen.
+- Denke in Loesungen: "Das liesse sich mit einem MOSFET als Low-Side Switch realisieren."
+- Sicherheit hat Vorrang: Immer auf Gefahren hinweisen (Kurzschluss, Ueberhitzung, Verletzung).
+- Proaktiv: Schlage Verbesserungen vor wenn du Schwaechen siehst.
+- Nutze das manage_repair Tool fuer ALLE Werkstatt-Aktionen.
+- Wenn der User ein Projekt hat, beziehe dich immer darauf.
+"""
+
         return prompt
 
     @staticmethod

--- a/assistant/assistant/repair_planner.py
+++ b/assistant/assistant/repair_planner.py
@@ -1,0 +1,1470 @@
+"""
+MindHome Workshop-Modus — Werkstatt-Ingenieur-Assistent.
+
+Features:
+- Projekt-Management (CRUD, Multi-Projekt, Templates)
+- LLM-Diagnose, Simulation, Troubleshooting
+- Schritt-basierte Navigation per Sprache
+- Werkstatt-Inventar, Budget, Journal, Snippets
+- 3D-Drucker Steuerung (via HA)
+- Roboterarm Steuerung (Stub)
+- Werkzeug-Verleih, Wartungs-Tracking
+- Geraete-Management via Home Assistant
+"""
+
+import asyncio
+import json
+import logging
+import re
+import time
+import uuid as uuid_mod
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from .config import yaml_config
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================
+# Dataclasses
+# ============================================================
+
+@dataclass
+class RepairStep:
+    """Ein einzelner Reparatur-/Bau-Schritt."""
+    number: int
+    title: str
+    description: str
+    tools: list[str] = field(default_factory=list)
+    parts: list[str] = field(default_factory=list)
+    estimated_minutes: int = 0
+    completed: bool = False
+    photos: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RepairSession:
+    """Eine aktive Werkstatt-Session mit Projekt und Schritten."""
+    project_id: str
+    title: str
+    category: str
+    steps: list[RepairStep] = field(default_factory=list)
+    current_step: int = 0
+    started_at: str = ""
+    timer_start: float = 0
+    timer_total: float = 0
+
+    @property
+    def total_steps(self) -> int:
+        return len(self.steps)
+
+    @property
+    def is_finished(self) -> bool:
+        return self.current_step >= self.total_steps
+
+    def get_current_step(self) -> Optional[RepairStep]:
+        if 0 <= self.current_step < self.total_steps:
+            return self.steps[self.current_step]
+        return None
+
+
+# ============================================================
+# Navigation-Keywords (Pattern: cooking_assistant.py)
+# ============================================================
+
+NAV_NEXT = {"weiter", "naechster schritt", "nächster schritt", "next",
+            "und dann", "weiter gehts"}
+NAV_PREV = {"zurueck", "zurück", "vorheriger schritt", "back",
+            "einen zurueck", "einen zurück"}
+NAV_REPEAT = {"nochmal", "wiederhole", "repeat", "wie war das"}
+NAV_STATUS = {"status", "wo bin ich", "uebersicht", "übersicht",
+              "wo stehe ich"}
+NAV_PARTS = {"was brauche ich", "teile", "teileliste", "material"}
+NAV_TOOLS = {"welches werkzeug", "werkzeugliste",
+             "was brauch ich an werkzeug"}
+NAV_SHOP = {"bestell das", "einkaufsliste", "kaufen", "shopping"}
+NAV_SAVE = {"merk dir das", "speicher das", "merken"}
+NAV_CODE = {"zeig den code", "programmier", "code generieren", "firmware"}
+NAV_3D = {"3d modell", "gehaeuse", "openscad"}
+NAV_CALC = {"berechne", "welcher widerstand", "rechne", "umrechnen",
+            "konvertiere"}
+NAV_SCAN = {"scan das", "schau dir an", "was ist das",
+            "analysiere das teil"}
+NAV_SIM = {"simuliere", "teste das design", "haelt das", "hält das"}
+NAV_PRINT = {"druck", "drucke", "print", "3d druck starten"}
+NAV_ARM = {"gib mir", "halt das", "greif", "arm", "robot"}
+NAV_TIMER = {"erinnere mich", "timer", "wecker"}
+NAV_JOURNAL = {"was hab ich heute", "journal", "tagebuch"}
+NAV_STOP = {"pause", "fertig", "stop", "beenden"}
+EMERGENCY_STOP = {"stopp"}  # Hoechste Prioritaet fuer Arm
+
+# Intent-Erkennung
+REPAIR_KEYWORDS = {
+    "reparieren", "kaputt", "defekt", "tropft", "leckt", "klemmt",
+    "bauen", "basteln", "konstruieren", "erfinden",
+    "esp32", "arduino", "esp8266", "raspberry", "3d druck", "3d-druck",
+    "loeten", "loet", "werkstatt", "werkzeug",
+    "simuliere", "diagnostik", "scan", "schaltplan", "schaltung",
+    "programmier", "code", "firmware", "website", "webseite",
+    "gehaeuse", "modell", "openscad",
+    "online", "mqtt", "strom", "sensor",
+}
+
+ACTIVATION_ON = {"werkstatt modus an", "werkstatt aktivieren",
+                 "workshop an", "werkstattmodus an"}
+ACTIVATION_OFF = {"werkstatt modus aus", "werkstatt deaktivieren",
+                  "workshop aus", "werkstattmodus aus"}
+
+# Templates
+TEMPLATES = {
+    "esp_sensor": {
+        "title": "ESP32 Sensor-Projekt", "category": "maker",
+        "parts": [{"name": "ESP32 DevKit", "quantity": 1}],
+        "tools": ["Loetkolben", "Multimeter"],
+    },
+    "led_strip": {
+        "title": "LED-Strip Steuerung", "category": "maker",
+        "parts": [
+            {"name": "ESP32", "quantity": 1},
+            {"name": "WS2812 Strip", "quantity": 1},
+        ],
+    },
+    "3d_enclosure": {"title": "3D-Druck Gehaeuse", "category": "maker"},
+    "furniture": {"title": "Moebelbau Projekt", "category": "bau"},
+    "repair_standard": {"title": "Standard-Reparatur", "category": "reparatur"},
+}
+
+
+# ============================================================
+# LLM-Prompts
+# ============================================================
+
+DIAGNOSIS_PROMPT = """Du bist ein Werkstatt-Ingenieur. Analysiere das Problem und antworte NUR als JSON:
+{{
+  "diagnosis": "Was ist das Problem",
+  "difficulty": 3,
+  "tools": ["Werkzeug1", "Werkzeug2"],
+  "parts": [{{"name": "Teil", "quantity": 1, "estimated_cost": 5.0}}],
+  "safety_warnings": ["Warnung1"],
+  "steps": [{{"title": "Schritt", "description": "Beschreibung", "tools": [], "estimated_minutes": 10}}],
+  "estimated_time": "1-2 Stunden",
+  "estimated_cost": "10-20 Euro"
+}}
+Kontext: {context}
+Werkstatt-Sensoren: {environment}"""
+
+
+# ============================================================
+# Hauptklasse
+# ============================================================
+
+class RepairPlanner:
+    """Werkstatt-Assistent: Projekte, Diagnose, Navigation, Hardware."""
+
+    REDIS_SESSION_KEY = "mha:repair:session"
+    REDIS_SESSION_TTL = 24 * 3600  # 24h
+
+    def __init__(self, ollama_client, ha_client):
+        self.ollama = ollama_client
+        self.ha = ha_client
+        self.redis = None
+        self.semantic_memory = None
+        self.generator = None       # WorkshopGenerator (Phase 2)
+        self.model_router = None    # ModelRouter
+        self._session: Optional[RepairSession] = None
+        self._notify_callback = None
+
+        # Config
+        ws_cfg = yaml_config.get("workshop", {})
+        self.enabled = ws_cfg.get("enabled", False)
+        self.workshop_room = ws_cfg.get("workshop_room", "werkstatt")
+        self.auto_safety_check = ws_cfg.get("auto_safety_check", True)
+        self.proactive_suggestions = ws_cfg.get("proactive_suggestions", True)
+
+    async def initialize(self, redis_client):
+        """Initialisiert mit Redis und laedt ggf. eine gespeicherte Session."""
+        self.redis = redis_client
+        if self.redis:
+            await self._restore_session()
+        logger.info("RepairPlanner initialisiert (enabled=%s)", self.enabled)
+
+    def set_generator(self, generator):
+        """Verknuepft den WorkshopGenerator."""
+        self.generator = generator
+
+    def set_model_router(self, router):
+        """Setzt den ModelRouter fuer LLM-Tier-Auswahl."""
+        self.model_router = router
+
+    def set_notify_callback(self, callback):
+        """Setzt den Callback fuer Timer-Benachrichtigungen."""
+        self._notify_callback = callback
+
+    # ── Session Persistence ──────────────────────────────────
+
+    async def _save_session(self):
+        """Speichert die aktive Session in Redis."""
+        if not self.redis or not self._session:
+            return
+        data = {
+            "project_id": self._session.project_id,
+            "title": self._session.title,
+            "category": self._session.category,
+            "steps": [asdict(s) for s in self._session.steps],
+            "current_step": self._session.current_step,
+            "started_at": self._session.started_at,
+            "timer_start": self._session.timer_start,
+            "timer_total": self._session.timer_total,
+        }
+        await self.redis.setex(
+            self.REDIS_SESSION_KEY,
+            self.REDIS_SESSION_TTL,
+            json.dumps(data),
+        )
+
+    async def _restore_session(self):
+        """Laedt eine gespeicherte Session aus Redis."""
+        if not self.redis:
+            return
+        raw = await self.redis.get(self.REDIS_SESSION_KEY)
+        if not raw:
+            return
+        try:
+            data = json.loads(raw)
+            steps = [RepairStep(**s) for s in data.get("steps", [])]
+            self._session = RepairSession(
+                project_id=data["project_id"],
+                title=data["title"],
+                category=data.get("category", "maker"),
+                steps=steps,
+                current_step=data.get("current_step", 0),
+                started_at=data.get("started_at", ""),
+                timer_start=data.get("timer_start", 0),
+                timer_total=data.get("timer_total", 0),
+            )
+            logger.info("Workshop-Session wiederhergestellt: %s (Schritt %d/%d)",
+                        self._session.title, self._session.current_step + 1,
+                        self._session.total_steps)
+        except Exception as e:
+            logger.warning("Workshop-Session Restore fehlgeschlagen: %s", e)
+            self._session = None
+
+    async def _clear_session(self):
+        """Loescht die aktive Session."""
+        self._session = None
+        if self.redis:
+            await self.redis.delete(self.REDIS_SESSION_KEY)
+
+    # ── Projekt-CRUD (Redis Pattern: inventory.py) ───────────
+
+    async def create_project(self, title, description="", category="maker",
+                             priority="normal") -> dict:
+        """Erstellt ein neues Werkstatt-Projekt."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        project_id = str(uuid_mod.uuid4())[:8]
+        slug = (title.lower().replace(" ", "-")
+                .replace("ä", "ae").replace("ö", "oe").replace("ü", "ue"))
+        project = {
+            "id": project_id,
+            "title": title,
+            "description": description,
+            "category": category,   # reparatur|bau|maker|erfindung|renovierung
+            "priority": priority,   # niedrig|normal|hoch|dringend
+            "status": "erstellt",   # erstellt|diagnose|teile_bestellt|in_arbeit|pausiert|fertig
+            "slug": slug,
+            "created": datetime.now().isoformat(),
+            "parts": "[]",
+            "tools": "[]",
+            "notes": "[]",
+            "budget": "0",
+            "expenses": "[]",
+            "device_entity": "",
+        }
+        await self.redis.hset(f"mha:repair:project:{project_id}", mapping=project)
+        await self.redis.sadd("mha:repair:projects:all", project_id)
+        await self.redis.sadd("mha:repair:projects:status:erstellt", project_id)
+        logger.info("Workshop-Projekt erstellt: %s (%s)", title, project_id)
+        return project
+
+    async def get_project(self, project_id) -> Optional[dict]:
+        """Holt ein Projekt aus Redis."""
+        if not self.redis:
+            return None
+        data = await self.redis.hgetall(f"mha:repair:project:{project_id}")
+        if not data:
+            return None
+        # JSON-Felder parsen
+        for key in ("parts", "tools", "notes", "expenses"):
+            if key in data and isinstance(data[key], str):
+                try:
+                    data[key] = json.loads(data[key])
+                except (json.JSONDecodeError, TypeError):
+                    data[key] = []
+        return data
+
+    async def list_projects(self, status_filter=None,
+                            category_filter=None) -> list:
+        """Listet alle Projekte, optional gefiltert."""
+        if not self.redis:
+            return []
+        if status_filter:
+            ids = await self.redis.smembers(
+                f"mha:repair:projects:status:{status_filter}")
+        else:
+            ids = await self.redis.smembers("mha:repair:projects:all")
+        projects = []
+        for pid in ids:
+            p = await self.get_project(pid)
+            if p and (not category_filter or p.get("category") == category_filter):
+                projects.append(p)
+        return projects
+
+    async def update_project(self, project_id, **kwargs) -> Optional[dict]:
+        """Aktualisiert ein Projekt."""
+        if not self.redis:
+            return None
+        # Status-Change: alte Status-Set entfernen, neue hinzufuegen
+        if "status" in kwargs:
+            old = await self.redis.hget(
+                f"mha:repair:project:{project_id}", "status")
+            if old:
+                await self.redis.srem(
+                    f"mha:repair:projects:status:{old}", project_id)
+            await self.redis.sadd(
+                f"mha:repair:projects:status:{kwargs['status']}", project_id)
+        for k, v in kwargs.items():
+            if isinstance(v, (list, dict)):
+                v = json.dumps(v)
+            await self.redis.hset(
+                f"mha:repair:project:{project_id}", k, str(v))
+        return await self.get_project(project_id)
+
+    async def complete_project(self, project_id, notes="") -> Optional[dict]:
+        """Schliesst ein Projekt ab."""
+        await self.update_project(
+            project_id, status="fertig",
+            completed=datetime.now().isoformat())
+        if notes:
+            await self.add_project_note(project_id, notes)
+        # Auto-Dokumentation generieren
+        if self.generator:
+            try:
+                model = (self.model_router.model_smart
+                         if self.model_router else None)
+                await self.generator.generate_documentation(
+                    project_id, model=model)
+            except Exception as e:
+                logger.warning("Auto-Doku fehlgeschlagen: %s", e)
+        return await self.get_project(project_id)
+
+    async def add_project_note(self, project_id, note) -> dict:
+        """Fuegt eine Notiz zum Projekt hinzu."""
+        project = await self.get_project(project_id)
+        if not project:
+            return {"status": "error", "message": "Projekt nicht gefunden"}
+        notes = project.get("notes", [])
+        notes.append({"text": note, "timestamp": datetime.now().isoformat()})
+        await self.redis.hset(
+            f"mha:repair:project:{project_id}", "notes", json.dumps(notes))
+        return {"status": "ok", "note_count": len(notes)}
+
+    async def add_part(self, project_id, name, quantity=1,
+                       estimated_cost=0, source="") -> dict:
+        """Fuegt ein Bauteil zum Projekt hinzu."""
+        project = await self.get_project(project_id)
+        if not project:
+            return {"status": "error", "message": "Projekt nicht gefunden"}
+        parts = project.get("parts", [])
+        parts.append({
+            "name": name, "quantity": quantity,
+            "cost": estimated_cost, "source": source,
+            "available": False,
+        })
+        await self.redis.hset(
+            f"mha:repair:project:{project_id}", "parts", json.dumps(parts))
+        return {"status": "ok", "part": name}
+
+    async def add_missing_to_shopping(self, project_id) -> dict:
+        """Gibt fehlende Teile zurueck — User muss bestaetigen."""
+        project = await self.get_project(project_id)
+        if not project:
+            return {"status": "error", "message": "Projekt nicht gefunden"}
+        missing = [p for p in project.get("parts", [])
+                   if not p.get("available")]
+        if not missing:
+            return {"status": "ok", "message": "Alle Teile vorhanden"}
+        return {
+            "status": "confirm_needed", "missing_parts": missing,
+            "message": (f"{len(missing)} Teile fehlen. "
+                        "Soll ich sie auf die Einkaufsliste setzen?"),
+        }
+
+    # ── LLM-Diagnose ────────────────────────────────────────
+
+    async def diagnose_problem(self, text, person="",
+                               model=None) -> str:
+        """Analysiert ein Problem und erstellt Diagnose + Projekt."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return "Kein LLM-Modell verfuegbar fuer Diagnose."
+
+        # Semantic Memory durchsuchen
+        context = ""
+        if self.semantic_memory:
+            try:
+                results = await self.semantic_memory.search(text, limit=3)
+                if results:
+                    context = "\n".join(
+                        r.get("content", "") for r in results)
+            except Exception:
+                pass
+
+        # Werkstatt-Umgebung holen
+        environment = await self.get_workshop_environment()
+
+        prompt = DIAGNOSIS_PROMPT.format(
+            context=context or "Kein Vorwissen",
+            environment=json.dumps(environment) if environment else "Keine Sensoren")
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": text},
+        ]
+
+        try:
+            response = await self.ollama.chat(
+                model=model, messages=messages,
+                temperature=0.3, max_tokens=2048)
+        except Exception as e:
+            logger.error("Diagnose LLM-Fehler: %s", e)
+            return f"Diagnose fehlgeschlagen: {e}"
+
+        # JSON parsen und Projekt erstellen
+        try:
+            data = json.loads(response)
+            project = await self.create_project(
+                title=data.get("diagnosis", text)[:60],
+                description=text, category="reparatur",
+                priority="hoch" if data.get("difficulty", 3) >= 4 else "normal",
+            )
+            # Session starten
+            steps = []
+            for i, s in enumerate(data.get("steps", [])):
+                steps.append(RepairStep(
+                    number=i + 1,
+                    title=s.get("title", f"Schritt {i + 1}"),
+                    description=s.get("description", ""),
+                    tools=s.get("tools", []),
+                    estimated_minutes=s.get("estimated_minutes", 0),
+                ))
+            self._session = RepairSession(
+                project_id=project["id"],
+                title=project["title"],
+                category="reparatur",
+                steps=steps,
+                started_at=datetime.now().isoformat(),
+            )
+            await self._save_session()
+
+            # WebSocket Event
+            try:
+                from .websocket import emit_workshop
+                await emit_workshop("diagnosis", {
+                    "project": project, "diagnosis": data,
+                })
+            except Exception:
+                pass
+
+            return self._format_diagnosis(data)
+        except json.JSONDecodeError:
+            return response  # LLM hat kein JSON generiert
+
+    def _format_diagnosis(self, data: dict) -> str:
+        """Formatiert eine Diagnose fuer die Sprachausgabe."""
+        parts = [f"Diagnose: {data.get('diagnosis', 'Unbekannt')}"]
+        if data.get("difficulty"):
+            parts.append(f"Schwierigkeit: {data['difficulty']}/5")
+        if data.get("estimated_time"):
+            parts.append(f"Geschaetzte Zeit: {data['estimated_time']}")
+        if data.get("estimated_cost"):
+            parts.append(f"Geschaetzte Kosten: {data['estimated_cost']}")
+        if data.get("safety_warnings"):
+            parts.append("Sicherheit: " + ", ".join(data["safety_warnings"]))
+        steps = data.get("steps", [])
+        if steps:
+            parts.append(f"\n{len(steps)} Schritte erstellt. "
+                         "Sage 'weiter' um zu beginnen.")
+        return "\n".join(parts)
+
+    # ── Simulation ───────────────────────────────────────────
+
+    async def simulate_design(self, project_id, question,
+                              model=None) -> str:
+        """Simuliert ein Design und beantwortet Fragen dazu."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return "Kein LLM-Modell verfuegbar."
+        project = await self.get_project(project_id)
+        if not project:
+            return "Projekt nicht gefunden."
+
+        files = []
+        file_contents = {}
+        if self.generator:
+            files = await self.generator.list_files(project_id)
+            for f in files[:5]:
+                content = await self.generator.read_file(
+                    project_id, f["name"])
+                if content:
+                    file_contents[f["name"]] = content[:2000]
+
+        prompt = f"""Analysiere dieses Projekt und beantworte die Frage.
+Projekt: {project['title']} ({project['category']})
+Teile: {json.dumps(project.get('parts', []))}
+Dateien: {json.dumps(file_contents)}
+Frage: {question}
+
+Analysiere: Machbarkeit, Schwachstellen, Belastungsgrenzen, Batterie-Laufzeit,
+thermische Aspekte, Verbesserungsvorschlaege. Gib Konfidenz-Level an."""
+        messages = [{"role": "system", "content": prompt}]
+        return await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.4, max_tokens=2048)
+
+    # ── Troubleshooting ──────────────────────────────────────
+
+    async def troubleshoot(self, project_id, symptom,
+                           model=None) -> str:
+        """Systematisches Troubleshooting."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return "Kein LLM-Modell verfuegbar."
+        project = await self.get_project(project_id)
+        if not project:
+            return "Projekt nicht gefunden."
+
+        prompt = f"""Systematischer Debug-Workflow fuer: {symptom}
+Projekt: {project['title']}
+Teile: {json.dumps(project.get('parts', []))}
+1. Symptom analysieren
+2. Wahrscheinlichste Ursachen (sortiert nach Wahrscheinlichkeit)
+3. Pruefschritte mit konkreten Anweisungen ("Miss Spannung an Pin X")
+4. Erwartete Ergebnisse pro Pruefschritt
+Antworte strukturiert als Diagnosebaum."""
+        messages = [
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": symptom},
+        ]
+        return await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.3, max_tokens=2048)
+
+    # ── Proaktive Verbesserungen ─────────────────────────────
+
+    async def suggest_improvements(self, project_id,
+                                   model=None) -> str:
+        """Schlaegt Verbesserungen fuer ein Projekt vor."""
+        model = model or (self.model_router.model_smart
+                          if self.model_router else None)
+        if not model:
+            return "Kein LLM-Modell verfuegbar."
+        project = await self.get_project(project_id)
+        if not project:
+            return "Projekt nicht gefunden."
+
+        prompt = f"""Analysiere das Projekt und schlage Verbesserungen vor.
+Projekt: {project['title']} ({project['category']})
+Teile: {json.dumps(project.get('parts', []))}
+Schlage konkrete Optimierungen vor (Effizienz, Kosten, Sicherheit, Zuverlaessigkeit)."""
+        messages = [{"role": "system", "content": prompt}]
+        return await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.5, max_tokens=1024)
+
+    # ── Komponenten-Vergleich ────────────────────────────────
+
+    async def compare_components(self, comp_a, comp_b,
+                                 use_case="", model=None) -> str:
+        """Vergleicht zwei Komponenten."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return "Kein LLM-Modell verfuegbar."
+
+        prompt = f"""Vergleiche {comp_a} vs {comp_b} fuer: {use_case or 'allgemein'}
+Vergleiche: Features, Preis, Stromverbrauch, Pins, Verfuegbarkeit.
+Gib eine klare Empfehlung mit Begruendung."""
+        messages = [{"role": "system", "content": prompt}]
+        return await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.3, max_tokens=1024)
+
+    # ── Error-Log Analyse ────────────────────────────────────
+
+    async def analyze_error_log(self, project_id, log_text,
+                                model=None) -> str:
+        """Analysiert einen Error-Log/Serial-Output."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return "Kein LLM-Modell verfuegbar."
+        project = await self.get_project(project_id)
+        if not project:
+            return "Projekt nicht gefunden."
+
+        files = []
+        if self.generator:
+            files = await self.generator.list_files(project_id)
+
+        prompt = f"""Analysiere diesen Error-Log/Serial-Output.
+Projekt: {project['title']}
+Projekt-Dateien: {[f['name'] for f in files]}
+Error-Log:
+{log_text[:3000]}
+Erklaere den Fehler und schlage einen konkreten Fix vor."""
+        messages = [{"role": "system", "content": prompt}]
+        return await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.2, max_tokens=1024)
+
+    # ── Mess-Assistent ───────────────────────────────────────
+
+    async def evaluate_measurement(self, project_id, measurement_text,
+                                   model=None) -> str:
+        """Bewertet einen Messwert im Projekt-Kontext."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return "Kein LLM-Modell verfuegbar."
+        project = await self.get_project(project_id)
+        if not project:
+            return "Projekt nicht gefunden."
+
+        current_step = "unbekannt"
+        if self._session:
+            current_step = str(self._session.current_step + 1)
+
+        prompt = f"""Der User hat einen Messwert diktiert. Bewerte ihn im Projekt-Kontext.
+Projekt: {project['title']}
+Schritt: {current_step}
+Messwert: {measurement_text}
+Bewerte: Ist der Wert im erwarteten Bereich? Was bedeutet er? Naechster Schritt?"""
+        messages = [{"role": "system", "content": prompt}]
+        return await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.3, max_tokens=512)
+
+    # ── Kalibrierung ─────────────────────────────────────────
+
+    async def calibration_guide(self, device_type, model=None) -> str:
+        """Erstellt eine Kalibrierungsanleitung."""
+        model = model or (self.model_router.model_smart
+                          if self.model_router else None)
+        if not model:
+            return "Kein LLM-Modell verfuegbar."
+
+        prompt = f"""Erstelle eine Schritt-fuer-Schritt Kalibrierungsanleitung fuer: {device_type}
+Gib konkrete Werte, Pruefschritte und erwartete Ergebnisse an."""
+        messages = [{"role": "system", "content": prompt}]
+        return await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.3, max_tokens=1024)
+
+    # ── Werkstatt-Umgebung ───────────────────────────────────
+
+    async def get_workshop_environment(self) -> dict:
+        """Holt Werkstatt-Sensordaten von Home Assistant."""
+        room = self.workshop_room
+        try:
+            states = await self.ha.get_states()
+            env = {}
+            for state in states:
+                eid = state.get("entity_id", "")
+                if room.lower() in eid.lower():
+                    if "temperature" in eid:
+                        env["temperatur"] = state.get("state")
+                    elif "humidity" in eid:
+                        env["feuchtigkeit"] = state.get("state")
+                    elif "co2" in eid:
+                        env["co2"] = state.get("state")
+                    elif "illuminance" in eid:
+                        env["licht"] = state.get("state")
+            return env
+        except Exception:
+            return {}
+
+    # ── Sicherheits-Checkliste ───────────────────────────────
+
+    async def generate_safety_checklist(self, project_id) -> str:
+        """Generiert eine Sicherheits-Checkliste (kein LLM)."""
+        project = await self.get_project(project_id)
+        if not project:
+            return "Projekt nicht gefunden."
+        tools = project.get("tools", [])
+        category = project.get("category", "")
+
+        checklist = ["Arbeitsflaeche frei und sauber"]
+        if any(t in str(tools) for t in ["loetkolben", "loeten", "loet"]):
+            checklist.extend([
+                "Lueftung einschalten",
+                "Loetkolben-Ablage pruefen",
+                "Loetzinn bereit",
+            ])
+        if any(t in str(tools) for t in ["bohr", "saeg", "flex", "schlei"]):
+            checklist.extend([
+                "Schutzbrille aufsetzen",
+                "Gehoerschutz bei Bedarf",
+            ])
+        if category == "reparatur":
+            checklist.append("Strom/Wasser abstellen wenn noetig")
+        checklist.append("Erste-Hilfe-Kasten in Reichweite")
+
+        return ("Sicherheits-Checkliste:\n"
+                + "\n".join(f"- {c}" for c in checklist))
+
+    # ── Navigation (Pattern: cooking_assistant.py) ───────────
+
+    def is_repair_navigation(self, text: str) -> bool:
+        """Erkennt ob der User durch eine aktive Session navigiert."""
+        if not self._session:
+            return False
+        text_lower = text.lower().strip()
+        all_nav = (NAV_NEXT | NAV_PREV | NAV_REPEAT | NAV_STATUS | NAV_PARTS
+                   | NAV_TOOLS | NAV_SHOP | NAV_SAVE | NAV_CODE | NAV_3D
+                   | NAV_CALC | NAV_SCAN | NAV_SIM | NAV_PRINT | NAV_ARM
+                   | NAV_TIMER | NAV_JOURNAL | NAV_STOP | EMERGENCY_STOP)
+        return any(kw in text_lower for kw in all_nav)
+
+    async def handle_navigation(self, text: str) -> str:
+        """Verarbeitet einen Navigations-Befehl."""
+        text_lower = text.lower().strip()
+
+        # Emergency Stop hat IMMER Vorrang
+        if any(kw in text_lower for kw in EMERGENCY_STOP):
+            return await self._emergency_stop()
+        if any(kw in text_lower for kw in NAV_NEXT):
+            return await self._next_step()
+        if any(kw in text_lower for kw in NAV_PREV):
+            return await self._prev_step()
+        if any(kw in text_lower for kw in NAV_REPEAT):
+            return await self._repeat_step()
+        if any(kw in text_lower for kw in NAV_STATUS):
+            return self._get_status()
+        if any(kw in text_lower for kw in NAV_PARTS):
+            return self._get_parts()
+        if any(kw in text_lower for kw in NAV_TOOLS):
+            return self._get_tools()
+        if any(kw in text_lower for kw in NAV_STOP):
+            return await self._stop_session()
+
+        return "Ich habe das nicht verstanden. Sage 'status' fuer eine Uebersicht."
+
+    async def _next_step(self) -> str:
+        """Geht zum naechsten Schritt."""
+        if not self._session:
+            return "Keine aktive Session."
+        if self._session.current_step >= self._session.total_steps - 1:
+            return ("Das war der letzte Schritt! "
+                    "Sage 'fertig' um das Projekt abzuschliessen.")
+        self._session.current_step += 1
+        await self._save_session()
+
+        step = self._session.get_current_step()
+        try:
+            from .websocket import emit_workshop
+            await emit_workshop("step", {
+                "step_number": step.number,
+                "total": self._session.total_steps,
+                "title": step.title,
+            })
+        except Exception:
+            pass
+
+        return self._format_step(step)
+
+    async def _prev_step(self) -> str:
+        """Geht zum vorherigen Schritt."""
+        if not self._session:
+            return "Keine aktive Session."
+        if self._session.current_step <= 0:
+            return "Du bist bereits beim ersten Schritt."
+        self._session.current_step -= 1
+        await self._save_session()
+        step = self._session.get_current_step()
+        return self._format_step(step)
+
+    async def _repeat_step(self) -> str:
+        """Wiederholt den aktuellen Schritt."""
+        if not self._session:
+            return "Keine aktive Session."
+        step = self._session.get_current_step()
+        if not step:
+            return "Kein aktueller Schritt."
+        return self._format_step(step)
+
+    def _get_status(self) -> str:
+        """Gibt den aktuellen Status zurueck."""
+        if not self._session:
+            return "Keine aktive Session."
+        s = self._session
+        step = s.get_current_step()
+        return (f"Projekt: {s.title}\n"
+                f"Schritt {s.current_step + 1} von {s.total_steps}: "
+                f"{step.title if step else 'Fertig'}\n"
+                f"Sage 'weiter' oder 'zurueck' zum Navigieren.")
+
+    def _get_parts(self) -> str:
+        """Listet die benoetigten Teile."""
+        if not self._session:
+            return "Keine aktive Session."
+        step = self._session.get_current_step()
+        if not step or not step.parts:
+            return "Fuer diesen Schritt werden keine speziellen Teile benoetigt."
+        return "Benoetigte Teile:\n" + "\n".join(
+            f"- {p}" for p in step.parts)
+
+    def _get_tools(self) -> str:
+        """Listet das benoetigte Werkzeug."""
+        if not self._session:
+            return "Keine aktive Session."
+        step = self._session.get_current_step()
+        if not step or not step.tools:
+            return "Fuer diesen Schritt wird kein spezielles Werkzeug benoetigt."
+        return "Benoetigtes Werkzeug:\n" + "\n".join(
+            f"- {t}" for t in step.tools)
+
+    async def _stop_session(self) -> str:
+        """Beendet die aktive Session."""
+        if not self._session:
+            return "Keine aktive Session."
+        project_id = self._session.project_id
+        title = self._session.title
+        await self._clear_session()
+        return f"Session fuer '{title}' beendet. Projekt bleibt gespeichert."
+
+    def _format_step(self, step: RepairStep) -> str:
+        """Formatiert einen Schritt fuer die Sprachausgabe."""
+        parts = [
+            f"Schritt {step.number} von {self._session.total_steps}: "
+            f"{step.title}",
+        ]
+        parts.append(step.description)
+        if step.tools:
+            parts.append("Werkzeug: " + ", ".join(step.tools))
+        if step.estimated_minutes:
+            parts.append(f"Geschaetzte Dauer: {step.estimated_minutes} Minuten")
+        return "\n".join(parts)
+
+    # ── Objekt-Scanner ───────────────────────────────────────
+
+    async def scan_object(self, image_data=None, camera_name="",
+                          description="") -> dict:
+        """Nutzt bestehende Camera/OCR-Infrastruktur."""
+        try:
+            from .camera_manager import get_camera_view
+            from .ocr import analyze_image
+        except ImportError:
+            return {"status": "error",
+                    "message": "Kamera/OCR Module nicht verfuegbar"}
+
+        if image_data:
+            img = image_data
+        elif camera_name:
+            img = await get_camera_view(camera_name)
+        else:
+            return {"status": "error",
+                    "message": "Kein Bild oder Kamera angegeben"}
+
+        prompt = """Analysiere dieses Bild aus einer Werkstatt-Perspektive:
+1. Was ist das fuer ein Objekt/Bauteil?
+2. Erkennbare Beschaedigungen oder Verschleiss?
+3. Geschaetzte Abmessungen?
+4. Teilenummern/Beschriftungen?
+5. Reparierbar oder Ersatz noetig?"""
+        result = await analyze_image(img, prompt)
+        return {"status": "ok", "analysis": result}
+
+    # ── Werkstatt-Inventar (Redis) ───────────────────────────
+
+    async def add_workshop_item(self, name, quantity=1,
+                                category="werkzeug",
+                                location="") -> dict:
+        """Fuegt ein Werkstatt-Item hinzu."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        item_id = name.lower().replace(" ", "_")
+        item = {
+            "name": name, "quantity": str(quantity),
+            "category": category, "location": location,
+            "added": datetime.now().isoformat(),
+        }
+        await self.redis.hset(
+            f"mha:repair:workshop:{item_id}", mapping=item)
+        await self.redis.sadd("mha:repair:workshop:all", item_id)
+        await self.redis.sadd(
+            f"mha:repair:workshop:cat:{category}", item_id)
+        return {"status": "ok", "item": name}
+
+    async def list_workshop(self, category=None) -> list:
+        """Listet Werkstatt-Items."""
+        if not self.redis:
+            return []
+        if category:
+            ids = await self.redis.smembers(
+                f"mha:repair:workshop:cat:{category}")
+        else:
+            ids = await self.redis.smembers("mha:repair:workshop:all")
+        items = []
+        for iid in ids:
+            data = await self.redis.hgetall(
+                f"mha:repair:workshop:{iid}")
+            if data:
+                items.append(data)
+        return items
+
+    async def add_maintenance_schedule(self, tool_name,
+                                       interval_days,
+                                       last_done="") -> dict:
+        """Fuegt einen Wartungsplan hinzu."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        key = f"mha:repair:maintenance:{tool_name.lower().replace(' ', '_')}"
+        await self.redis.hset(key, mapping={
+            "tool": tool_name,
+            "interval_days": str(interval_days),
+            "last_done": last_done or datetime.now().isoformat(),
+        })
+        return {"status": "ok"}
+
+    async def check_maintenance_due(self) -> list:
+        """Prueft welche Werkzeuge gewartet werden muessen."""
+        if not self.redis:
+            return []
+        keys = [k async for k in self.redis.scan_iter(
+            "mha:repair:maintenance:*")]
+        due = []
+        for key in keys:
+            data = await self.redis.hgetall(key)
+            try:
+                last = datetime.fromisoformat(
+                    data.get("last_done", datetime.now().isoformat()))
+                interval = int(data.get("interval_days", 90))
+                if (datetime.now() - last).days >= interval:
+                    due.append(data)
+            except (ValueError, TypeError):
+                pass
+        return due
+
+    # ── Budget ───────────────────────────────────────────────
+
+    async def set_project_budget(self, project_id, budget) -> dict:
+        """Setzt das Budget eines Projekts."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        await self.redis.hset(
+            f"mha:repair:project:{project_id}", "budget", str(budget))
+        return {"status": "ok"}
+
+    async def add_expense(self, project_id, item, cost) -> dict:
+        """Fuegt eine Ausgabe hinzu."""
+        project = await self.get_project(project_id)
+        if not project:
+            return {"status": "error", "message": "Projekt nicht gefunden"}
+        expenses = project.get("expenses", [])
+        expenses.append({
+            "item": item, "cost": float(cost),
+            "date": datetime.now().isoformat(),
+        })
+        await self.redis.hset(
+            f"mha:repair:project:{project_id}",
+            "expenses", json.dumps(expenses))
+        total = sum(e["cost"] for e in expenses)
+        return {"status": "ok", "total": total}
+
+    # ── Skills ───────────────────────────────────────────────
+
+    async def record_skill(self, person, skill,
+                           level="beginner") -> dict:
+        """Speichert ein Skill-Level."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        key = f"mha:repair:skills:{person.lower()}"
+        await self.redis.hset(key, skill, level)
+        return {"status": "ok"}
+
+    # ── Statistiken ──────────────────────────────────────────
+
+    async def get_workshop_stats(self, period="month") -> dict:
+        """Holt Werkstatt-Statistiken."""
+        all_projects = await self.list_projects()
+        completed = [p for p in all_projects
+                     if p.get("status") == "fertig"]
+        categories = {}
+        for cat in ["reparatur", "bau", "maker", "erfindung", "renovierung"]:
+            categories[cat] = len(
+                [p for p in all_projects if p.get("category") == cat])
+        return {
+            "total_projects": len(all_projects),
+            "completed": len(completed),
+            "in_progress": len(all_projects) - len(completed),
+            "categories": categories,
+        }
+
+    # ── Templates ────────────────────────────────────────────
+
+    async def create_from_template(self, template_name,
+                                   title="") -> dict:
+        """Erstellt ein Projekt aus einem Template."""
+        tmpl = TEMPLATES.get(template_name)
+        if not tmpl:
+            return {"status": "error",
+                    "message": f"Template '{template_name}' nicht gefunden. "
+                    f"Verfuegbar: {', '.join(TEMPLATES.keys())}"}
+        project = await self.create_project(
+            title=title or tmpl["title"],
+            description=f"Aus Template: {template_name}",
+            category=tmpl.get("category", "maker"),
+        )
+        for part in tmpl.get("parts", []):
+            await self.add_part(project["id"], **part)
+        return project
+
+    # ── Werkzeug-Verleih ─────────────────────────────────────
+
+    async def lend_tool(self, tool_name, person) -> dict:
+        """Vermerkt ein verliehenes Werkzeug."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        key = f"mha:repair:lent:{tool_name.lower().replace(' ', '_')}"
+        await self.redis.hset(key, mapping={
+            "tool": tool_name, "person": person,
+            "since": datetime.now().isoformat(),
+        })
+        return {"status": "ok",
+                "message": f"{tool_name} an {person} verliehen"}
+
+    async def return_tool(self, tool_name) -> dict:
+        """Vermerkt ein zurueckgegebenes Werkzeug."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        key = f"mha:repair:lent:{tool_name.lower().replace(' ', '_')}"
+        await self.redis.delete(key)
+        return {"status": "ok",
+                "message": f"{tool_name} zurueckgegeben"}
+
+    async def list_lent_tools(self) -> list:
+        """Listet alle verliehenen Werkzeuge."""
+        if not self.redis:
+            return []
+        keys = [k async for k in self.redis.scan_iter(
+            "mha:repair:lent:*")]
+        return [await self.redis.hgetall(k) for k in keys]
+
+    # ── 3D-Drucker Steuerung (via HA) ────────────────────────
+
+    async def get_printer_status(self) -> dict:
+        """Liest 3D-Drucker Status via HA-Entities."""
+        ws_cfg = yaml_config.get("workshop", {})
+        printer_cfg = ws_cfg.get("printer_3d", {})
+        if not printer_cfg.get("enabled"):
+            return {"status": "disabled",
+                    "message": "3D-Drucker nicht aktiviert"}
+        prefix = printer_cfg.get("entity_prefix", "octoprint")
+        try:
+            states = await self.ha.get_states()
+        except Exception:
+            return {"status": "error",
+                    "message": "Home Assistant nicht erreichbar"}
+
+        printer = {}
+        for s in states:
+            eid = s.get("entity_id", "")
+            if prefix in eid:
+                if "progress" in eid:
+                    printer["progress"] = s.get("state")
+                elif "bed_temp" in eid:
+                    printer["bed_temp"] = s.get("state")
+                elif "tool_temp" in eid or "hotend" in eid:
+                    printer["hotend_temp"] = s.get("state")
+                elif "state" in eid or "status" in eid:
+                    printer["state"] = s.get("state")
+                elif "time_remaining" in eid:
+                    printer["eta"] = s.get("state")
+        return printer if printer else {
+            "status": "not_found",
+            "message": "Kein 3D-Drucker in HA gefunden",
+        }
+
+    async def start_print(self, project_id="", filename="") -> dict:
+        """Startet einen 3D-Druck."""
+        status = await self.get_printer_status()
+        if status.get("status") in ("disabled", "not_found", "error"):
+            return status
+        if status.get("state") not in (
+            "idle", "ready", "operational", None
+        ):
+            return {"status": "error",
+                    "message": f"Drucker nicht bereit: {status.get('state')}"}
+        ws_cfg = yaml_config.get("workshop", {})
+        prefix = ws_cfg.get("printer_3d", {}).get(
+            "entity_prefix", "octoprint")
+        try:
+            await self.ha.call_service(
+                "button", "press",
+                {"entity_id": f"button.{prefix}_resume_job"})
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+        return {"status": "ok", "message": "Druck gestartet"}
+
+    async def pause_print(self) -> dict:
+        """Pausiert den 3D-Druck."""
+        ws_cfg = yaml_config.get("workshop", {})
+        printer_cfg = ws_cfg.get("printer_3d", {})
+        if not printer_cfg.get("enabled"):
+            return {"status": "disabled"}
+        prefix = printer_cfg.get("entity_prefix", "octoprint")
+        try:
+            await self.ha.call_service(
+                "button", "press",
+                {"entity_id": f"button.{prefix}_pause_job"})
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+        return {"status": "ok", "message": "Druck pausiert"}
+
+    async def cancel_print(self) -> dict:
+        """Bricht den 3D-Druck ab."""
+        ws_cfg = yaml_config.get("workshop", {})
+        printer_cfg = ws_cfg.get("printer_3d", {})
+        if not printer_cfg.get("enabled"):
+            return {"status": "disabled"}
+        prefix = printer_cfg.get("entity_prefix", "octoprint")
+        try:
+            await self.ha.call_service(
+                "button", "press",
+                {"entity_id": f"button.{prefix}_cancel_job"})
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+        return {"status": "ok", "message": "Druck abgebrochen"}
+
+    # ── Roboterarm-Steuerung (Stub) ──────────────────────────
+
+    async def _arm_command(self, cmd: dict) -> dict:
+        """Sendet JSON-Kommando an den Arm via HTTP."""
+        arm_cfg = yaml_config.get("workshop", {}).get("robot_arm", {})
+        if not arm_cfg.get("enabled"):
+            return {"status": "disabled",
+                    "message": "Roboterarm nicht aktiviert"}
+        url = arm_cfg.get("url", "")
+        if not url:
+            return {"status": "error",
+                    "message": "Arm-URL nicht konfiguriert"}
+        try:
+            import aiohttp
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=5)
+            ) as session:
+                async with session.post(
+                    f"{url}/js?json={json.dumps(cmd)}"
+                ) as resp:
+                    return await resp.json()
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    async def arm_move(self, x, y, z, speed=50) -> dict:
+        """Bewegt den Arm zu einer Position."""
+        arm_cfg = yaml_config.get("workshop", {}).get("robot_arm", {})
+        max_speed = arm_cfg.get("max_speed", 80)
+        speed = min(speed, max_speed)
+        return await self._arm_command({
+            "T": 104, "x": x, "y": y, "z": z,
+            "t": int(2000 / (speed / 100)),
+        })
+
+    async def arm_gripper(self, action="open") -> dict:
+        """Oeffnet oder schliesst den Greifer."""
+        cmd = 1 if action == "open" else 0
+        return await self._arm_command({"T": 106, "cmd": cmd})
+
+    async def arm_home(self) -> dict:
+        """Faehrt den Arm in die Home-Position."""
+        return await self._arm_command({"T": 100})
+
+    async def arm_save_position(self, name, position=None) -> dict:
+        """Speichert eine Arm-Position."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        if position is None:
+            result = await self._arm_command({"T": 100})
+            position = result
+        key = f"mha:repair:arm:positions:{name.lower()}"
+        await self.redis.hset(
+            key, mapping={k: str(v) for k, v in position.items()})
+        return {"status": "ok",
+                "message": f"Position '{name}' gespeichert"}
+
+    async def arm_pick_tool(self, tool_name) -> dict:
+        """Greift ein Werkzeug an einer gespeicherten Position."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        key = f"mha:repair:arm:positions:{tool_name.lower()}"
+        pos = await self.redis.hgetall(key)
+        if not pos:
+            return {"status": "error",
+                    "message": f"Position '{tool_name}' nicht gespeichert"}
+        await self.arm_gripper("open")
+        await self.arm_move(
+            float(pos.get("x", 0)),
+            float(pos.get("y", 0)),
+            float(pos.get("z", 0)),
+        )
+        await self.arm_gripper("close")
+        return {"status": "ok", "message": f"Greife {tool_name}"}
+
+    async def _emergency_stop(self) -> str:
+        """NOTFALL-STOPP fuer den Arm."""
+        await self._arm_command({"T": 0})
+        return "NOTFALL-STOPP! Arm angehalten."
+
+    # ── Timer ────────────────────────────────────────────────
+
+    async def start_timer(self, project_id) -> dict:
+        """Startet den Projekt-Timer."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        await self.redis.hset(
+            f"mha:repair:project:{project_id}",
+            "timer_start", str(time.time()))
+        return {"status": "ok", "message": "Timer gestartet"}
+
+    async def pause_timer(self, project_id) -> dict:
+        """Pausiert den Projekt-Timer und gibt Gesamtzeit zurueck."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        start = float(await self.redis.hget(
+            f"mha:repair:project:{project_id}", "timer_start") or 0)
+        total = float(await self.redis.hget(
+            f"mha:repair:project:{project_id}", "timer_total") or 0)
+        if start > 0:
+            total += time.time() - start
+            await self.redis.hset(
+                f"mha:repair:project:{project_id}",
+                "timer_total", str(total))
+            await self.redis.hset(
+                f"mha:repair:project:{project_id}",
+                "timer_start", "0")
+        hours, remainder = divmod(int(total), 3600)
+        minutes = remainder // 60
+        return {"status": "ok", "total_seconds": total,
+                "display": f"{hours}h {minutes}min"}
+
+    async def set_workshop_timer(self, minutes, reason="") -> dict:
+        """Setzt einen Countdown-Timer mit Callback."""
+        timer_id = str(uuid_mod.uuid4())[:6]
+
+        async def _timer_callback():
+            await asyncio.sleep(minutes * 60)
+            msg = f"Sir, {minutes} Minuten sind um"
+            if reason:
+                msg += f" — {reason}"
+            if self._notify_callback:
+                await self._notify_callback(msg)
+
+        asyncio.create_task(_timer_callback())
+        return {"status": "ok", "timer_id": timer_id,
+                "minutes": minutes, "reason": reason}
+
+    # ── Journal ──────────────────────────────────────────────
+
+    async def get_journal(self, period="today") -> dict:
+        """Holt Journal-Eintraege."""
+        if not self.redis:
+            return {"date": "", "entries": []}
+        key = f"mha:repair:journal:{datetime.now().strftime('%Y-%m-%d')}"
+        entries = await self.redis.lrange(key, 0, -1)
+        return {
+            "date": datetime.now().strftime('%Y-%m-%d'),
+            "entries": [json.loads(e) for e in entries],
+        }
+
+    async def add_journal_entry(self, note) -> dict:
+        """Fuegt einen Journal-Eintrag hinzu."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        key = f"mha:repair:journal:{datetime.now().strftime('%Y-%m-%d')}"
+        entry = {"text": note, "time": datetime.now().strftime('%H:%M')}
+        await self.redis.rpush(key, json.dumps(entry))
+        await self.redis.expire(key, 90 * 86400)  # 90 Tage
+        return {"status": "ok"}
+
+    # ── Snippets ─────────────────────────────────────────────
+
+    async def save_snippet(self, name, code, language="",
+                           tags=None) -> dict:
+        """Speichert ein Code-Snippet."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        key = f"mha:repair:snippet:{name.lower().replace(' ', '_')}"
+        await self.redis.hset(key, mapping={
+            "name": name, "code": code, "language": language,
+            "tags": json.dumps(tags or []),
+            "created": datetime.now().isoformat(),
+        })
+        return {"status": "ok"}
+
+    async def get_snippet(self, name) -> dict:
+        """Holt ein Code-Snippet."""
+        if not self.redis:
+            return {}
+        key = f"mha:repair:snippet:{name.lower().replace(' ', '_')}"
+        return await self.redis.hgetall(key)
+
+    # ── Multi-Projekt ────────────────────────────────────────
+
+    async def switch_project(self, project_id) -> dict:
+        """Wechselt zum angegebenen Projekt."""
+        project = await self.get_project(project_id)
+        if not project:
+            return {"status": "error", "message": "Projekt nicht gefunden"}
+        # Alte Session pausieren
+        if self._session:
+            await self.pause_timer(self._session.project_id)
+        # Neue Session (ohne Schritte, die kommen bei Diagnose)
+        self._session = RepairSession(
+            project_id=project_id,
+            title=project.get("title", ""),
+            category=project.get("category", "maker"),
+            started_at=datetime.now().isoformat(),
+        )
+        await self._save_session()
+        return {"status": "ok",
+                "message": f"Gewechselt zu: {project['title']}"}
+
+    async def get_active_project(self) -> Optional[dict]:
+        """Gibt das aktive Projekt zurueck."""
+        if not self._session:
+            return None
+        return await self.get_project(self._session.project_id)
+
+    async def search_projects(self, query,
+                              include_completed=True) -> list:
+        """Sucht in Projekten."""
+        all_projects = await self.list_projects()
+        if not include_completed:
+            all_projects = [p for p in all_projects
+                           if p.get("status") != "fertig"]
+        results = [p for p in all_projects
+                   if query.lower() in json.dumps(p).lower()]
+        return results
+
+    # ── Geraete-Management ───────────────────────────────────
+
+    async def check_device_online(self, entity_id) -> dict:
+        """Prueft ob ein HA-Geraet online ist."""
+        try:
+            states = await self.ha.get_states()
+        except Exception:
+            return {"entity": entity_id, "state": "ha_unavailable"}
+        for s in states:
+            if s.get("entity_id") == entity_id:
+                return {
+                    "entity": entity_id,
+                    "state": s.get("state", "unknown"),
+                    "last_updated": s.get("last_updated", ""),
+                }
+        return {"entity": entity_id, "state": "not_found"}
+
+    async def get_power_consumption(self, entity_id) -> dict:
+        """Liest den Stromverbrauch eines Geraets."""
+        try:
+            states = await self.ha.get_states()
+        except Exception:
+            return {"status": "error",
+                    "message": "Home Assistant nicht erreichbar"}
+        for s in states:
+            if s.get("entity_id") == entity_id:
+                return {
+                    "entity": entity_id,
+                    "power_w": s.get("state", "0"),
+                    "unit": s.get("attributes", {}).get(
+                        "unit_of_measurement", "W"),
+                }
+        return {"status": "not_found"}
+
+    async def link_device_to_project(self, project_id,
+                                     entity_id) -> dict:
+        """Verknuepft ein HA-Geraet mit einem Projekt."""
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+        await self.redis.hset(
+            f"mha:repair:project:{project_id}",
+            "device_entity", entity_id)
+        return {"status": "ok"}
+
+    async def check_all_devices(self) -> list:
+        """Prueft alle verknuepften Geraete."""
+        projects = await self.list_projects()
+        devices = []
+        for p in projects:
+            entity = p.get("device_entity")
+            if entity:
+                status = await self.check_device_online(entity)
+                status["project"] = p.get("title")
+                devices.append(status)
+        return devices
+
+    # ── Push-Benachrichtigung ────────────────────────────────
+
+    async def notify_user(self, message,
+                          title="Werkstatt") -> dict:
+        """Push-Benachrichtigung via HA Notify."""
+        try:
+            await self.ha.call_service(
+                "notify", "notify",
+                {"title": title, "message": message})
+            return {"status": "ok"}
+        except Exception:
+            return {"status": "error"}
+
+    # ── Intent-Erkennung ─────────────────────────────────────
+
+    def is_repair_intent(self, text: str) -> bool:
+        """Erkennt ob der User etwas Werkstatt-bezogenes will."""
+        if not self.enabled:
+            return False
+        text_lower = text.lower()
+        return any(kw in text_lower for kw in REPAIR_KEYWORDS)
+
+    def is_activation_command(self, text: str) -> bool:
+        """Erkennt Werkstatt-Modus An/Aus Befehle."""
+        text_lower = text.lower().strip()
+        return text_lower in (ACTIVATION_ON | ACTIVATION_OFF)
+
+    async def toggle_activation(self, text: str) -> str:
+        """Schaltet den Werkstatt-Modus an/aus."""
+        text_lower = text.lower().strip()
+        if text_lower in ACTIVATION_ON:
+            if self.redis:
+                await self.redis.setex(
+                    "mha:repair:manual_active",
+                    self.REDIS_SESSION_TTL, "1")
+            return "Werkstatt-Modus aktiviert, Sir. Wie kann ich helfen?"
+        else:
+            if self.redis:
+                await self.redis.delete("mha:repair:manual_active")
+            return "Werkstatt-Modus deaktiviert. Bis zum naechsten Mal, Sir."
+
+    def has_active_session(self) -> bool:
+        """Prueft ob eine aktive Session existiert."""
+        return self._session is not None
+
+    async def is_manually_activated(self) -> bool:
+        """Prueft ob der Werkstatt-Modus manuell aktiviert ist."""
+        if not self.redis:
+            return False
+        return bool(await self.redis.exists("mha:repair:manual_active"))

--- a/assistant/assistant/websocket.py
+++ b/assistant/assistant/websocket.py
@@ -165,6 +165,25 @@ async def emit_proactive(
     })
 
 
+async def emit_workshop(
+    sub_event: str,
+    data: dict | None = None,
+) -> None:
+    """Workshop-Event an alle Clients.
+
+    Sub-Events:
+      - workshop.step       — Schritt gewechselt (step_number, total, title)
+      - workshop.diagnosis  — Diagnose abgeschlossen (project, diagnosis)
+      - workshop.file_created — Neue Datei erstellt (project_id, filename)
+      - workshop.printer    — Drucker-Status Update (progress, state, temps)
+      - workshop.environment — Werkstatt-Sensordaten (temperatur, feuchtigkeit, co2)
+      - workshop.timer      — Timer abgelaufen (message)
+      - workshop.arm        — Arm-Status (position, gripper)
+      - workshop.project    — Projekt-Update (project_id, status)
+    """
+    await ws_manager.broadcast(f"workshop.{sub_event}", data or {})
+
+
 async def emit_interrupt(
     text: str,
     event_type: str,

--- a/assistant/assistant/workshop_generator.py
+++ b/assistant/assistant/workshop_generator.py
@@ -1,0 +1,566 @@
+"""
+MindHome Workshop-Generator — Code/3D/SVG/Website/BOM/Doku/Tests/Berechnungen.
+
+Generiert Artefakte fuer Werkstatt-Projekte:
+- Code-Generation (Arduino, Python, C++, HTML, JS, YAML, MicroPython)
+- OpenSCAD 3D-Modelle
+- SVG-Schaltplaene
+- Responsive Websites
+- BOM (Bill of Materials)
+- Projekt-Dokumentation
+- Test-Generation
+- Deterministische Berechnungen (Ohm, LED, Widerstand, Draht, etc.)
+- File-Management mit Versionierung
+- Projekt-Export als ZIP
+"""
+
+import json
+import logging
+import math
+import re
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================
+# Physik-Referenz-Datenbanken (kein LLM noetig)
+# ============================================================
+
+RESISTOR_E24 = [
+    1.0, 1.1, 1.2, 1.3, 1.5, 1.6, 1.8, 2.0,
+    2.2, 2.4, 2.7, 3.0, 3.3, 3.6, 3.9, 4.3,
+    4.7, 5.1, 5.6, 6.2, 6.8, 7.5, 8.2, 9.1,
+]
+
+WIRE_GAUGE_MM2 = {
+    0.5: 3, 0.75: 5, 1.0: 7.5, 1.5: 10,
+    2.5: 16, 4.0: 25, 6.0: 32, 10.0: 50,
+}
+
+SCREW_TORQUES_NM = {
+    "M3": 1.2, "M4": 2.5, "M5": 5.0, "M6": 8.5,
+    "M8": 22, "M10": 44, "M12": 77,
+}
+
+MATERIAL_PROPERTIES = {
+    "pla": {"temp_max": 60, "strength_mpa": 50, "density_g_cm3": 1.24},
+    "petg": {"temp_max": 80, "strength_mpa": 55, "density_g_cm3": 1.27},
+    "abs": {"temp_max": 100, "strength_mpa": 40, "density_g_cm3": 1.04},
+    "tpu": {"temp_max": 80, "strength_mpa": 30, "density_g_cm3": 1.21},
+    "asa": {"temp_max": 95, "strength_mpa": 55, "density_g_cm3": 1.07},
+}
+
+ESP32_PINOUT = {
+    "adc": [32, 33, 34, 35, 36, 39],
+    "dac": [25, 26],
+    "i2c_sda": 21, "i2c_scl": 22,
+    "spi_mosi": 23, "spi_miso": 19, "spi_clk": 18,
+    "pwm": list(range(2, 34)),
+    "touch": [4, 2, 15, 13, 12, 14, 27, 33, 32],
+}
+
+UNIT_CONVERSIONS = {
+    ("mm", "inch"): lambda x: x / 25.4,
+    ("inch", "mm"): lambda x: x * 25.4,
+    ("celsius", "fahrenheit"): lambda x: x * 9 / 5 + 32,
+    ("fahrenheit", "celsius"): lambda x: (x - 32) * 5 / 9,
+    ("bar", "psi"): lambda x: x * 14.5038,
+    ("psi", "bar"): lambda x: x / 14.5038,
+    ("kg", "lbs"): lambda x: x * 2.20462,
+    ("lbs", "kg"): lambda x: x / 2.20462,
+}
+
+
+# ============================================================
+# LLM-Prompts
+# ============================================================
+
+CODE_GEN_PROMPT = """Du bist ein erfahrener Embedded-/Software-Entwickler.
+Generiere VOLLSTAENDIGEN, KOMPILIERBAREN Code. Keine Platzhalter. Keine "...".
+Sprache: {language}
+Projekt: {project_title}
+Bestehender Code: {existing_code}
+Anforderung: {requirement}
+
+REGELN:
+- Vollstaendig: Alle Imports, alle Funktionen, main() wenn noetig
+- Kommentare auf Deutsch
+- Bei Arduino/ESP32: setup() + loop() + alle Variablen
+- Bei Python: if __name__ == "__main__" wenn standalone
+- Bei HTML: Vollstaendiges Dokument mit DOCTYPE"""
+
+OPENSCAD_PROMPT = """Du bist ein CAD-Ingenieur. Generiere VOLLSTAENDIGEN OpenSCAD Code.
+Masse in mm. Verwende Module fuer Wiederholungen.
+Projekt: {project_title}
+Anforderung: {requirement}
+
+REGELN:
+- Immer $fn=60 fuer runde Formen
+- Toleranzen: Steckverbindungen +0.2mm, Pressfit -0.1mm
+- Wandstaerke min. 1.2mm fuer FDM-Druck
+- Kommentare auf Deutsch"""
+
+SVG_PROMPT = """Du bist ein Elektrotechnik-Ingenieur. Generiere einen SVG-Schaltplan.
+REGELN:
+- Sauberes SVG mit viewBox
+- Bauteile als Symbole (Rechteck=Widerstand, Kreis mit Pfeil=LED, etc.)
+- Verbindungslinien als <line> oder <path>
+- Beschriftungen mit <text>
+- Farbschema: Hintergrund=#1a1a2e, Linien=#00d4ff, Text=#e0e0e0
+Anforderung: {requirement}"""
+
+WEBSITE_PROMPT = """Du bist ein Fullstack-Webentwickler. Generiere eine VOLLSTAENDIGE,
+FUNKTIONALE Single-Page HTML/CSS/JS Datei.
+DESIGN: Modern, responsive, CSS Grid/Flexbox. Dunkles Theme (#040810, #00d4ff).
+Anforderung: {requirement}
+Kontext: {context}
+REGELN: Alles in EINER Datei. Kein Framework noetig. Vanilla JS."""
+
+
+# ============================================================
+# Hauptklasse
+# ============================================================
+
+class WorkshopGenerator:
+    """Code-/3D-/Schaltplan-Generator fuer die Werkstatt."""
+
+    FILES_DIR = Path("/app/data/workshop/files")
+
+    def __init__(self, ollama_client):
+        self.ollama = ollama_client
+        self.redis = None
+        self.model_router = None
+
+    async def initialize(self, redis_client):
+        """Initialisiert mit Redis und erstellt Verzeichnisse."""
+        self.redis = redis_client
+        self.FILES_DIR.mkdir(parents=True, exist_ok=True)
+        logger.info("WorkshopGenerator initialisiert (FILES_DIR=%s)", self.FILES_DIR)
+
+    def set_model_router(self, router):
+        """Setzt den ModelRouter."""
+        self.model_router = router
+
+    # ── Code-Generation ──────────────────────────────────────
+
+    async def generate_code(self, project_id, requirement,
+                            language="arduino", existing_code="",
+                            model=None) -> dict:
+        """Generiert Code in der angegebenen Sprache."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return {"status": "error", "message": "Kein LLM-Modell verfuegbar"}
+
+        project_title = ""
+        if project_id and self.redis:
+            proj = await self.redis.hgetall(
+                f"mha:repair:project:{project_id}")
+            project_title = proj.get("title", "")
+
+        prompt = CODE_GEN_PROMPT.format(
+            language=language, project_title=project_title or "Unbenannt",
+            existing_code=(existing_code[:3000]
+                           if existing_code else "Kein bestehender Code"),
+            requirement=requirement,
+        )
+        messages = [{"role": "system", "content": prompt}]
+        code = await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.2, max_tokens=4096)
+
+        # Datei speichern
+        ext = {
+            "arduino": ".ino", "python": ".py", "cpp": ".cpp",
+            "html": ".html", "javascript": ".js", "yaml": ".yaml",
+            "micropython": ".py",
+        }.get(language, ".txt")
+        filename = f"code_{language}_{datetime.now().strftime('%H%M%S')}{ext}"
+        if project_id:
+            await self._save_file(project_id, filename, code)
+
+        return {"status": "ok", "code": code,
+                "filename": filename, "language": language}
+
+    # ── 3D-Modell (OpenSCAD) ─────────────────────────────────
+
+    async def generate_3d_model(self, project_id, requirement,
+                                model=None) -> dict:
+        """Generiert ein OpenSCAD 3D-Modell."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return {"status": "error", "message": "Kein LLM-Modell verfuegbar"}
+
+        project_title = ""
+        if project_id and self.redis:
+            proj = await self.redis.hgetall(
+                f"mha:repair:project:{project_id}")
+            project_title = proj.get("title", "")
+
+        prompt = OPENSCAD_PROMPT.format(
+            project_title=project_title or "Unbenannt",
+            requirement=requirement,
+        )
+        messages = [{"role": "system", "content": prompt}]
+        scad_code = await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.2, max_tokens=4096)
+
+        filename = f"model_{datetime.now().strftime('%H%M%S')}.scad"
+        if project_id:
+            await self._save_file(project_id, filename, scad_code)
+        return {"status": "ok", "code": scad_code, "filename": filename}
+
+    # ── SVG-Schaltplan ───────────────────────────────────────
+
+    async def generate_schematic(self, project_id, requirement,
+                                 model=None) -> dict:
+        """Generiert einen SVG-Schaltplan."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return {"status": "error", "message": "Kein LLM-Modell verfuegbar"}
+
+        prompt = SVG_PROMPT.format(requirement=requirement)
+        messages = [{"role": "system", "content": prompt}]
+        svg = await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.2, max_tokens=4096)
+
+        # SVG extrahieren (falls in Markdown-Block)
+        svg_match = re.search(r'<svg[\s\S]*?</svg>', svg)
+        if svg_match:
+            svg = svg_match.group(0)
+
+        filename = f"schematic_{datetime.now().strftime('%H%M%S')}.svg"
+        if project_id:
+            await self._save_file(project_id, filename, svg)
+        return {"status": "ok", "svg": svg, "filename": filename}
+
+    # ── Website-Generation ───────────────────────────────────
+
+    async def generate_website(self, project_id, requirement,
+                               context="", model=None) -> dict:
+        """Generiert eine Single-Page Website."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return {"status": "error", "message": "Kein LLM-Modell verfuegbar"}
+
+        prompt = WEBSITE_PROMPT.format(
+            requirement=requirement, context=context or "Werkstatt-Projekt")
+        messages = [{"role": "system", "content": prompt}]
+        html = await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.3, max_tokens=8192)
+
+        filename = f"site_{datetime.now().strftime('%H%M%S')}.html"
+        if project_id:
+            await self._save_file(project_id, filename, html)
+        return {"status": "ok", "html": html, "filename": filename}
+
+    # ── BOM-Generator ────────────────────────────────────────
+
+    async def generate_bom(self, project_id, model=None) -> dict:
+        """Generiert eine Bill of Materials."""
+        model = model or (self.model_router.model_smart
+                          if self.model_router else None)
+        if not model:
+            return {"status": "error", "message": "Kein LLM-Modell verfuegbar"}
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+
+        project = await self.redis.hgetall(
+            f"mha:repair:project:{project_id}")
+        if not project:
+            return {"status": "error", "message": "Projekt nicht gefunden"}
+
+        parts = json.loads(project.get("parts", "[]"))
+        files = await self.list_files(project_id)
+        file_contents = {}
+        for f in files[:5]:
+            content = await self.read_file(project_id, f["name"])
+            if content:
+                file_contents[f["name"]] = content[:1500]
+
+        prompt = f"""Erstelle eine vollstaendige BOM (Bill of Materials) fuer dieses Projekt.
+Projekt: {project.get('title', '')}
+Bekannte Teile: {json.dumps(parts, ensure_ascii=False)}
+Projekt-Dateien: {json.dumps(file_contents, ensure_ascii=False)}
+
+Format als Markdown-Tabelle:
+| # | Bauteil | Menge | Spezifikation | Geschaetzter Preis | Bezugsquelle |
+Ergaenze fehlende Teile die aus dem Code/Schaltplan ersichtlich sind."""
+        messages = [{"role": "system", "content": prompt}]
+        bom = await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.3, max_tokens=2048)
+        return {"status": "ok", "bom": bom}
+
+    # ── Dokumentation ────────────────────────────────────────
+
+    async def generate_documentation(self, project_id,
+                                     model=None) -> dict:
+        """Generiert Projekt-Dokumentation."""
+        model = model or (self.model_router.model_smart
+                          if self.model_router else None)
+        if not model:
+            return {"status": "error", "message": "Kein LLM-Modell verfuegbar"}
+        if not self.redis:
+            return {"status": "error", "message": "Redis nicht verfuegbar"}
+
+        project = await self.redis.hgetall(
+            f"mha:repair:project:{project_id}")
+        if not project:
+            return {"status": "error", "message": "Projekt nicht gefunden"}
+
+        files = await self.list_files(project_id)
+
+        prompt = f"""Erstelle eine Projekt-Dokumentation (Markdown).
+Projekt: {project.get('title', '')} ({project.get('category', '')})
+Beschreibung: {project.get('description', '')}
+Teile: {project.get('parts', '[]')}
+Dateien: {[f['name'] for f in files]}
+Status: {project.get('status', '')}
+
+Struktur: Uebersicht, Materialien, Schaltung/Aufbau, Software, Montage, Tests, Fazit."""
+        messages = [{"role": "system", "content": prompt}]
+        doc = await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.4, max_tokens=4096)
+
+        title_slug = project.get("title", "projekt").replace(" ", "_")
+        filename = f"DOKU_{title_slug}.md"
+        await self._save_file(project_id, filename, doc)
+        return {"status": "ok", "documentation": doc, "filename": filename}
+
+    # ── Test-Generation ──────────────────────────────────────
+
+    async def generate_tests(self, project_id, filename,
+                             model=None) -> dict:
+        """Generiert Tests fuer eine Projekt-Datei."""
+        model = model or (self.model_router.model_deep
+                          if self.model_router else None)
+        if not model:
+            return {"status": "error", "message": "Kein LLM-Modell verfuegbar"}
+
+        code = await self.read_file(project_id, filename)
+        if not code:
+            return {"status": "error", "message": "Datei nicht gefunden"}
+
+        ext = Path(filename).suffix
+        test_frameworks = {
+            ".py": "pytest", ".ino": "Arduino Serial Test",
+            ".js": "Jest", ".cpp": "Google Test",
+            ".html": "Browser Console Test",
+        }
+        framework = test_frameworks.get(ext, "generic")
+
+        prompt = f"""Generiere Tests fuer diesen Code.
+Framework: {framework}
+Code:
+{code[:4000]}
+REGELN: Vollstaendige, ausfuehrbare Tests. Edge Cases abdecken."""
+        messages = [{"role": "system", "content": prompt}]
+        tests = await self.ollama.chat(
+            model=model, messages=messages,
+            temperature=0.2, max_tokens=4096)
+
+        test_filename = f"test_{filename}"
+        await self._save_file(project_id, test_filename, tests)
+        return {"status": "ok", "tests": tests, "filename": test_filename}
+
+    # ── Berechnungen (KEIN LLM) ──────────────────────────────
+
+    def calculate(self, calc_type, **params) -> dict:
+        """Deterministische Berechnungen ohne LLM."""
+        try:
+            if calc_type == "resistor_divider":
+                v_in = params["v_in"]
+                v_out = params["v_out"]
+                r2 = params.get("r2", 10000)
+                r1 = r2 * (v_in / v_out - 1)
+                r1_e24 = self._nearest_e24(r1)
+                v_out_real = v_in * r2 / (r1_e24 + r2)
+                return {
+                    "r1": r1_e24, "r2": r2,
+                    "v_out_real": round(v_out_real, 3),
+                    "error_pct": round(
+                        abs(v_out - v_out_real) / v_out * 100, 2),
+                }
+
+            elif calc_type == "led_resistor":
+                v_supply = params["v_supply"]
+                v_led = params.get("v_led", 2.0)
+                i_ma = params.get("i_ma", 20)
+                r = (v_supply - v_led) / (i_ma / 1000)
+                r_e24 = self._nearest_e24(r)
+                power_mw = (v_supply - v_led) ** 2 / r_e24 * 1000
+                return {"resistor_ohm": r_e24,
+                        "power_mw": round(power_mw, 1)}
+
+            elif calc_type == "wire_gauge":
+                current_a = params["current_a"]
+                for mm2, max_a in sorted(WIRE_GAUGE_MM2.items()):
+                    if max_a >= current_a:
+                        return {"recommended_mm2": mm2,
+                                "max_current_a": max_a}
+                return {"error": "Strom zu hoch fuer Standard-Kabelquerschnitte"}
+
+            elif calc_type == "ohms_law":
+                v = params.get("v")
+                i = params.get("i")
+                r = params.get("r")
+                if v and i:
+                    return {"r": round(v / i, 3), "p": round(v * i, 3)}
+                if v and r:
+                    return {"i": round(v / r, 6), "p": round(v ** 2 / r, 3)}
+                if i and r:
+                    return {"v": round(i * r, 3), "p": round(i ** 2 * r, 3)}
+                return {"error": "Mindestens 2 von 3 Werten (v, i, r) noetig"}
+
+            elif calc_type == "3d_print_weight":
+                volume_cm3 = params["volume_cm3"]
+                material = params.get("material", "pla")
+                infill = params.get("infill_pct", 20) / 100
+                props = MATERIAL_PROPERTIES.get(
+                    material, MATERIAL_PROPERTIES["pla"])
+                weight = volume_cm3 * props["density_g_cm3"] * infill
+                return {"weight_g": round(weight, 1),
+                        "material": material,
+                        "infill_pct": infill * 100}
+
+            elif calc_type == "screw_torque":
+                screw = params["screw_size"].upper()
+                torque = SCREW_TORQUES_NM.get(screw)
+                if torque is None:
+                    return {"error": f"Schraubengroesse '{screw}' nicht bekannt. "
+                            f"Verfuegbar: {', '.join(SCREW_TORQUES_NM.keys())}"}
+                return {"torque_nm": torque}
+
+            elif calc_type == "convert":
+                value = params["value"]
+                from_unit = params["from_unit"].lower()
+                to_unit = params["to_unit"].lower()
+                converter = UNIT_CONVERSIONS.get((from_unit, to_unit))
+                if converter:
+                    return {"result": round(converter(value), 4),
+                            "from": from_unit, "to": to_unit}
+                return {"error": f"Konvertierung {from_unit} -> {to_unit} "
+                        "nicht unterstuetzt"}
+
+            elif calc_type == "power_supply":
+                components = params.get("components", [])
+                total_ma = sum(
+                    c.get("current_ma", 0) * c.get("quantity", 1)
+                    for c in components)
+                safety_factor = 1.25
+                recommended_ma = total_ma * safety_factor
+                voltage = params.get("voltage", 5)
+                return {
+                    "total_ma": total_ma,
+                    "recommended_ma": round(recommended_ma),
+                    "recommended_w": round(
+                        voltage * recommended_ma / 1000, 1),
+                }
+
+            return {"error": f"Unbekannter Berechnungstyp: {calc_type}"}
+        except Exception as e:
+            return {"error": str(e)}
+
+    def _nearest_e24(self, value) -> float:
+        """Findet den naechsten E24-Widerstandswert."""
+        if value <= 0:
+            return RESISTOR_E24[0]
+        decade = 10 ** int(math.log10(value))
+        normalized = value / decade
+        closest = min(RESISTOR_E24, key=lambda x: abs(x - normalized))
+        return closest * decade
+
+    # ── File-Management ──────────────────────────────────────
+
+    async def _save_file(self, project_id, filename, content) -> dict:
+        """Speichert Datei auf Disk + Referenz in Redis."""
+        project_dir = self.FILES_DIR / project_id
+        project_dir.mkdir(parents=True, exist_ok=True)
+        filepath = project_dir / filename
+        filepath.write_text(content, encoding="utf-8")
+
+        # Redis: Datei-Liste und Versionierung
+        if self.redis:
+            await self.redis.rpush(
+                f"mha:repair:files:{project_id}", filename)
+            await self.redis.rpush(
+                f"mha:repair:versions:{project_id}:{filename}",
+                json.dumps({
+                    "timestamp": datetime.now().isoformat(),
+                    "size": len(content),
+                }))
+
+        # WebSocket Event
+        try:
+            from .websocket import emit_workshop
+            await emit_workshop("file_created", {
+                "project_id": project_id, "filename": filename,
+            })
+        except Exception:
+            pass
+
+        return {"status": "ok", "path": str(filepath)}
+
+    async def read_file(self, project_id, filename) -> str:
+        """Liest eine Projekt-Datei."""
+        filepath = self.FILES_DIR / project_id / filename
+        if (filepath.exists()
+                and filepath.resolve().is_relative_to(
+                    self.FILES_DIR.resolve())):
+            return filepath.read_text(encoding="utf-8")
+        return ""
+
+    async def list_files(self, project_id) -> list:
+        """Listet Dateien eines Projekts."""
+        if not self.redis:
+            return []
+        filenames = await self.redis.lrange(
+            f"mha:repair:files:{project_id}", 0, -1)
+        result = []
+        for fn in filenames:
+            filepath = self.FILES_DIR / project_id / fn
+            if filepath.exists():
+                result.append({
+                    "name": fn,
+                    "size": filepath.stat().st_size,
+                    "modified": datetime.fromtimestamp(
+                        filepath.stat().st_mtime).isoformat(),
+                })
+        return result
+
+    async def delete_file(self, project_id, filename) -> dict:
+        """Loescht eine Projekt-Datei."""
+        filepath = self.FILES_DIR / project_id / filename
+        if (filepath.exists()
+                and filepath.resolve().is_relative_to(
+                    self.FILES_DIR.resolve())):
+            filepath.unlink()
+            if self.redis:
+                await self.redis.lrem(
+                    f"mha:repair:files:{project_id}", 0, filename)
+            return {"status": "ok"}
+        return {"status": "error", "message": "Datei nicht gefunden"}
+
+    async def export_project(self, project_id) -> str:
+        """Exportiert alle Projekt-Dateien als ZIP."""
+        project_dir = self.FILES_DIR / project_id
+        if not project_dir.exists():
+            return ""
+        zip_path = self.FILES_DIR / f"{project_id}_export.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in project_dir.iterdir():
+                if f.is_file():
+                    zf.write(f, f.name)
+        return str(zip_path)

--- a/assistant/assistant/workshop_library.py
+++ b/assistant/assistant/workshop_library.py
@@ -1,0 +1,228 @@
+"""
+Workshop Library — RAG fuer technische Fachbuecher und Referenzen.
+
+Eigene ChromaDB-Collection (workshop_library) fuer Werkstatt-Dokumente
+wie Datenblaetter, Reparaturanleitungen und Referenzhandbuecher.
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Pfade
+WORKSHOP_DOCS_DIR = Path("/app/data/workshop/library")
+SUPPORTED_EXTENSIONS = {".pdf", ".txt", ".md"}
+
+
+class WorkshopLibrary:
+    """Workshop-RAG: Eigene ChromaDB-Collection fuer technische Fachbuecher."""
+
+    COLLECTION_NAME = "workshop_library"
+    CHUNK_SIZE = 1500      # Zeichen pro Chunk
+    CHUNK_OVERLAP = 200    # Ueberlappung
+
+    def __init__(self):
+        self.chroma_client = None
+        self.collection = None
+        self.embedding_fn = None
+
+    async def initialize(self, chroma_client, embedding_fn) -> None:
+        """Initialisiert mit ChromaDB Client + Embedding-Funktion.
+
+        Nutzt die gleiche ChromaDB-Instanz wie knowledge_base.py,
+        aber eine EIGENE Collection (workshop_library statt mha_knowledge_base).
+        """
+        self.chroma_client = chroma_client
+        self.embedding_fn = embedding_fn
+        WORKSHOP_DOCS_DIR.mkdir(parents=True, exist_ok=True)
+        self.collection = self.chroma_client.get_or_create_collection(
+            name=self.COLLECTION_NAME,
+            metadata={"description": "Workshop technical reference library"},
+        )
+        logger.info(
+            "WorkshopLibrary: Collection '%s' mit %d Dokumenten",
+            self.COLLECTION_NAME,
+            self.collection.count(),
+        )
+
+    async def ingest_document(self, filepath: str) -> dict:
+        """Importiert ein Dokument in die Workshop-Library.
+
+        Unterstuetzt PDF (via PyMuPDF), TXT, MD.
+        """
+        if not self.collection:
+            return {"status": "error", "message": "Library nicht initialisiert"}
+
+        path = Path(filepath)
+        if not path.exists():
+            return {"status": "error", "message": f"Datei nicht gefunden: {path}"}
+        if path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            return {
+                "status": "error",
+                "message": f"Nicht unterstuetzt: {path.suffix}. Erlaubt: {SUPPORTED_EXTENSIONS}",
+            }
+
+        # Text extrahieren
+        if path.suffix.lower() == ".pdf":
+            text = await self._extract_pdf(path)
+        else:
+            text = path.read_text(encoding="utf-8", errors="replace")
+
+        if not text.strip():
+            return {"status": "error", "message": "Dokument ist leer"}
+
+        # Chunken
+        chunks = self._chunk_text(text)
+
+        # In ChromaDB speichern
+        ids = [f"{path.stem}_{i}" for i in range(len(chunks))]
+        metadatas = [
+            {"source": path.name, "chunk": i, "total_chunks": len(chunks)}
+            for i in range(len(chunks))
+        ]
+
+        if self.embedding_fn:
+            embeddings = [self.embedding_fn(chunk) for chunk in chunks]
+            self.collection.upsert(
+                ids=ids, documents=chunks, metadatas=metadatas, embeddings=embeddings,
+            )
+        else:
+            self.collection.upsert(ids=ids, documents=chunks, metadatas=metadatas)
+
+        return {
+            "status": "ok",
+            "document": path.name,
+            "chunks": len(chunks),
+            "total_docs": self.collection.count(),
+        }
+
+    async def search(self, query: str, n_results: int = 5) -> list:
+        """Sucht in der Workshop-Library."""
+        if not self.collection or self.collection.count() == 0:
+            return []
+
+        if self.embedding_fn:
+            query_embedding = self.embedding_fn(query)
+            results = self.collection.query(
+                query_embeddings=[query_embedding],
+                n_results=min(n_results, self.collection.count()),
+            )
+        else:
+            results = self.collection.query(
+                query_texts=[query],
+                n_results=min(n_results, self.collection.count()),
+            )
+
+        formatted = []
+        docs = results.get("documents", [[]])[0]
+        metas = results.get("metadatas", [[]])[0]
+        dists = results.get("distances", [[]])[0]
+        for i, doc in enumerate(docs):
+            meta = metas[i] if i < len(metas) else {}
+            dist = dists[i] if i < len(dists) else 0
+            formatted.append({
+                "content": doc,
+                "source": meta.get("source", ""),
+                "chunk": meta.get("chunk", 0),
+                "relevance": round(1 - dist, 3),
+            })
+        return formatted
+
+    async def list_documents(self) -> list:
+        """Listet alle Dokumente in der Library."""
+        files = []
+        if not WORKSHOP_DOCS_DIR.exists():
+            return files
+        for f in WORKSHOP_DOCS_DIR.iterdir():
+            if f.is_file() and f.suffix.lower() in SUPPORTED_EXTENSIONS:
+                files.append({
+                    "name": f.name,
+                    "size_mb": round(f.stat().st_size / 1024 / 1024, 2),
+                })
+        return files
+
+    async def get_stats(self) -> dict:
+        """Gibt Statistiken der Workshop-Library zurueck."""
+        count = self.collection.count() if self.collection else 0
+        docs = await self.list_documents()
+        return {
+            "total_chunks": count,
+            "total_documents": len(docs),
+            "total_size_mb": round(sum(d["size_mb"] for d in docs), 2),
+        }
+
+    def _chunk_text(self, text: str) -> list[str]:
+        """Teilt Text in ueberlappende Chunks."""
+        chunks = []
+        start = 0
+        while start < len(text):
+            end = start + self.CHUNK_SIZE
+            chunk = text[start:end]
+            if chunk.strip():
+                chunks.append(chunk)
+            start = end - self.CHUNK_OVERLAP
+        return chunks
+
+    async def _extract_pdf(self, path: Path) -> str:
+        """Extrahiert Text aus PDF (Pattern: knowledge_base.py)."""
+        # 1. PyMuPDF (fitz)
+        try:
+            import fitz  # PyMuPDF
+            doc = fitz.open(str(path))
+            pages = []
+            for page in doc:
+                pages.append(page.get_text())
+            doc.close()
+            text = "\n\n".join(pages)
+            if text.strip():
+                logger.info("PDF gelesen via PyMuPDF: %s (%d Seiten)", path.name, len(pages))
+                return text
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.debug("PyMuPDF Fehler bei %s: %s", path.name, e)
+
+        # 2. pdfplumber
+        try:
+            import pdfplumber
+            pages = []
+            with pdfplumber.open(path) as pdf:
+                for page in pdf.pages:
+                    page_text = page.extract_text()
+                    if page_text:
+                        pages.append(page_text)
+            text = "\n\n".join(pages)
+            if text.strip():
+                logger.info("PDF gelesen via pdfplumber: %s (%d Seiten)", path.name, len(pages))
+                return text
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.debug("pdfplumber Fehler bei %s: %s", path.name, e)
+
+        # 3. PyPDF2
+        try:
+            from PyPDF2 import PdfReader
+            reader = PdfReader(str(path))
+            pages = []
+            for page in reader.pages:
+                page_text = page.extract_text()
+                if page_text:
+                    pages.append(page_text)
+            text = "\n\n".join(pages)
+            if text.strip():
+                logger.info("PDF gelesen via PyPDF2: %s (%d Seiten)", path.name, len(pages))
+                return text
+        except ImportError:
+            pass
+        except Exception as e:
+            logger.debug("PyPDF2 Fehler bei %s: %s", path.name, e)
+
+        logger.warning(
+            "PDF %s konnte nicht gelesen werden. "
+            "Installiere: pip install PyMuPDF oder pdfplumber oder PyPDF2",
+            path.name,
+        )
+        return ""

--- a/assistant/config/settings.yaml
+++ b/assistant/config/settings.yaml
@@ -197,6 +197,17 @@ models:
   - pro und contra
   - bewerte
   - bewertung
+  - programmier
+  - code
+  - website
+  - schaltplan
+  - schaltung
+  - firmware
+  - gehaeuse
+  - 3d modell
+  - simuliere
+  - diagnostik
+  - troubleshoot
   cooking_keywords:
   - kochen
   - backen
@@ -1172,3 +1183,37 @@ error_patterns:
   enabled: true
   min_occurrences_for_mitigation: 3
   mitigation_ttl_hours: 1
+# Workshop-Modus: Werkstatt-Ingenieur-Assistent
+workshop:
+  enabled: false
+  workshop_room: werkstatt
+  auto_safety_check: true
+  proactive_suggestions: true
+  default_category: maker
+  file_storage_path: /app/data/workshop/files
+  library_path: /app/data/workshop/library
+  max_file_size_mb: 50
+  printer_3d:
+    enabled: false
+    entity_prefix: octoprint
+    auto_monitor: true
+    monitor_interval_seconds: 30
+  robot_arm:
+    enabled: false
+    url: ''
+    max_speed: 80
+    home_on_idle: true
+    idle_timeout_minutes: 5
+  mqtt:
+    enabled: false
+    broker: ''
+    port: 1883
+    topic_prefix: workshop/
+    username: ''
+    password: ''
+  templates:
+    - esp_sensor
+    - led_strip
+    - 3d_enclosure
+    - furniture
+    - repair_standard

--- a/assistant/static/ui/app.js
+++ b/assistant/static/ui/app.js
@@ -612,6 +612,7 @@ function renderCurrentTab() {
       case 'tab-routines': c.innerHTML = renderRoutines(); break;
       case 'tab-proactive': c.innerHTML = renderProactive(); break;
       case 'tab-cooking': c.innerHTML = renderCooking(); break;
+      case 'tab-workshop': c.innerHTML = renderWorkshop(); break;
       case 'tab-house-status': c.innerHTML = renderHouseStatus(); break;
       case 'tab-lights': c.innerHTML = renderLights(); loadLightEntities(); break;
       case 'tab-devices': c.innerHTML = renderDevices(); loadMindHomeEntities(); break;
@@ -2725,6 +2726,37 @@ function renderCooking() {
     fRange('cooking.max_tokens', 'Rezept-Detailgrad', 256, 4096, 256, {256:'Kurz',512:'Normal',1024:'Ausfuehrlich',2048:'Sehr ausfuehrlich',4096:'Maximum'}) +
     fToggle('cooking.timer_notify_tts', 'Timer-Erinnerungen per Sprache')
   );
+}
+
+// ---- Werkstatt-Modus ----
+function renderWorkshop() {
+  return sectionWrap('&#128295;', 'Werkstatt-Modus',
+    fInfo('J.A.R.V.I.S. als Werkstatt-Ingenieur: Reparaturen, Elektronik, 3D-Druck, Robotik.') +
+    fToggle('workshop.enabled', 'Werkstatt-Modus aktiv') +
+    fText('workshop.workshop_room', 'Werkstatt-Raum (HA)', 'Name des Raums in Home Assistant fuer Sensor-Daten') +
+    fToggle('workshop.auto_safety_check', 'Auto-Sicherheits-Check') +
+    fToggle('workshop.proactive_suggestions', 'Proaktive Vorschlaege')
+  ) +
+  sectionWrap('&#128424;', '3D-Drucker',
+    fToggle('workshop.printer_3d.enabled', '3D-Drucker aktiviert') +
+    fText('workshop.printer_3d.entity_prefix', 'Entity-Prefix', 'z.B. octoprint, bambu') +
+    fToggle('workshop.printer_3d.auto_monitor', 'Auto-Monitoring') +
+    fNum('workshop.printer_3d.monitor_interval_seconds', 'Monitor-Intervall (Sek.)', 10, 300, 10)
+  ) +
+  sectionWrap('&#129302;', 'Roboterarm',
+    fToggle('workshop.robot_arm.enabled', 'Arm aktiviert') +
+    fText('workshop.robot_arm.url', 'Arm URL', 'z.B. http://192.168.1.100') +
+    fRange('workshop.robot_arm.max_speed', 'Max. Geschwindigkeit (%)', 10, 100, 5) +
+    fToggle('workshop.robot_arm.home_on_idle', 'Home bei Idle') +
+    fNum('workshop.robot_arm.idle_timeout_minutes', 'Idle-Timeout (Min.)', 1, 30, 1)
+  ) +
+  sectionWrap('&#128225;', 'MQTT',
+    fToggle('workshop.mqtt.enabled', 'MQTT aktiviert') +
+    fText('workshop.mqtt.broker', 'Broker-Adresse', 'z.B. 192.168.1.1') +
+    fNum('workshop.mqtt.port', 'Port', 1, 65535, 1) +
+    fText('workshop.mqtt.topic_prefix', 'Topic-Prefix', 'z.B. workshop/')
+  ) +
+  '<div style="margin-top:16px;"><a href="/workshop/" target="_blank" style="color:var(--accent);text-decoration:none;font-size:13px;">Workshop-HUD oeffnen &#8599;</a></div>';
 }
 
 /// ---- Tab 8: Sicherheit & Erweitert ----

--- a/assistant/static/ui/index.html
+++ b/assistant/static/ui/index.html
@@ -878,6 +878,7 @@ input:focus,select:focus,textarea:focus { border-color:var(--accent); box-shadow
           <div class="nav-item" data-page="settings" data-tab="tab-routines"><span class="nav-icon">&#127748;</span>Routinen</div>
           <div class="nav-item" data-page="settings" data-tab="tab-proactive"><span class="nav-icon">&#128276;</span>Proaktiv</div>
           <div class="nav-item" data-page="settings" data-tab="tab-cooking"><span class="nav-icon">&#127859;</span>Koch-Assistent</div>
+          <div class="nav-item" data-page="settings" data-tab="tab-workshop"><span class="nav-icon">&#128295;</span>Werkstatt</div>
           <div class="nav-item" data-page="settings" data-tab="tab-followme"><span class="nav-icon">&#128694;</span>Follow-Me</div>
           <div class="nav-item" data-page="settings" data-tab="tab-jarvis"><span class="nav-icon">&#129497;</span>Jarvis-Features</div>
           <div class="nav-item" data-page="settings" data-tab="tab-eastereggs"><span class="nav-icon">&#127881;</span>Easter Eggs</div>

--- a/assistant/static/workshop/index.html
+++ b/assistant/static/workshop/index.html
@@ -1,0 +1,1314 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>J.A.R.V.I.S. Workshop</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --accent: #00d4ff;
+            --accent-dim: #00d4ff33;
+            --bg-primary: #040810;
+            --bg-secondary: #0a1020;
+            --bg-card: #0d1528;
+            --text-primary: #e0e8f0;
+            --text-secondary: #7a8a9a;
+            --border: #1a2a3a;
+            --success: #00ff88;
+            --warning: #ffaa00;
+            --danger: #ff4444;
+            --glass: rgba(10, 16, 32, 0.85);
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            overflow: hidden;
+        }
+
+        /* ===== Boot Screen ===== */
+        #boot-screen {
+            position: fixed; inset: 0; z-index: 1000;
+            display: flex; flex-direction: column;
+            align-items: center; justify-content: center;
+            background: var(--bg-primary);
+            transition: opacity 0.8s ease;
+        }
+        #boot-screen.fade-out { opacity: 0; pointer-events: none; }
+        .boot-ring {
+            width: 120px; height: 120px;
+            border: 2px solid var(--accent-dim);
+            border-top: 2px solid var(--accent);
+            border-radius: 50%;
+            animation: spin 2s linear infinite;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        #boot-text {
+            margin-top: 24px; font-size: 14px;
+            color: var(--accent); min-height: 20px;
+        }
+        .boot-title {
+            font-size: 24px; font-weight: 600;
+            color: var(--accent); margin-bottom: 32px;
+            letter-spacing: 4px;
+        }
+
+        /* ===== Main Grid ===== */
+        #workshop-main {
+            display: none; height: 100vh;
+            grid-template: "header header" 60px
+                           "sidebar main" 1fr
+                           "footer footer" 36px
+                           / 260px 1fr;
+        }
+
+        /* ===== Header ===== */
+        .header {
+            grid-area: header;
+            display: flex; align-items: center;
+            padding: 0 20px; gap: 16px;
+            background: var(--bg-secondary);
+            border-bottom: 1px solid var(--border);
+        }
+        .header-logo { color: var(--accent); font-size: 18px; font-weight: 600; letter-spacing: 2px; }
+        .header-project {
+            flex: 1; font-size: 13px; color: var(--text-secondary);
+            white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+        }
+        .header-project .proj-name { color: var(--text-primary); font-weight: 500; }
+        .header-status {
+            padding: 3px 10px; border-radius: 12px;
+            font-size: 11px; font-weight: 500; text-transform: uppercase;
+        }
+        .status-active { background: var(--success); color: #000; }
+        .status-paused { background: var(--warning); color: #000; }
+        .status-none { background: var(--border); color: var(--text-secondary); }
+        .header-actions { display: flex; gap: 8px; }
+        .header-actions button {
+            background: transparent; border: 1px solid var(--border);
+            color: var(--text-secondary); padding: 6px 12px;
+            border-radius: 6px; cursor: pointer; font-size: 12px;
+            font-family: inherit; transition: all 0.2s;
+        }
+        .header-actions button:hover { border-color: var(--accent); color: var(--accent); }
+
+        /* ===== Sidebar ===== */
+        .sidebar {
+            grid-area: sidebar; overflow-y: auto;
+            background: var(--bg-secondary);
+            border-right: 1px solid var(--border);
+            padding: 12px;
+        }
+        .sidebar h3 {
+            font-size: 11px; color: var(--text-secondary);
+            text-transform: uppercase; letter-spacing: 1px;
+            margin: 16px 0 8px; padding: 0 8px;
+        }
+        .sidebar h3:first-child { margin-top: 0; }
+        .nav-btn {
+            display: flex; align-items: center; gap: 8px;
+            width: 100%; padding: 8px 12px;
+            background: transparent; border: none;
+            color: var(--text-secondary); font-size: 12px;
+            font-family: inherit; cursor: pointer;
+            border-radius: 6px; transition: all 0.2s;
+            text-align: left;
+        }
+        .nav-btn:hover { background: var(--accent-dim); color: var(--text-primary); }
+        .nav-btn.active { background: var(--accent-dim); color: var(--accent); }
+        .nav-btn .icon { font-size: 16px; width: 20px; text-align: center; }
+        .project-item {
+            display: flex; align-items: center; gap: 8px;
+            padding: 6px 12px; border-radius: 6px;
+            cursor: pointer; font-size: 11px;
+            color: var(--text-secondary); transition: all 0.2s;
+        }
+        .project-item:hover { background: var(--accent-dim); color: var(--text-primary); }
+        .project-item.active { color: var(--accent); }
+        .project-dot {
+            width: 6px; height: 6px; border-radius: 50%;
+            background: var(--text-secondary); flex-shrink: 0;
+        }
+        .project-item.active .project-dot { background: var(--accent); }
+
+        /* ===== Main Content ===== */
+        .main {
+            grid-area: main; overflow-y: auto;
+            padding: 16px; display: flex;
+            flex-direction: column; gap: 16px;
+        }
+
+        /* ===== Widget ===== */
+        .widget {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 10px; padding: 16px;
+        }
+        .widget-header {
+            display: flex; align-items: center; gap: 8px;
+            margin-bottom: 12px; font-size: 12px;
+            color: var(--text-secondary); text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .widget-header .icon { font-size: 16px; }
+        .widget-title { font-weight: 600; color: var(--text-primary); }
+
+        /* Widget Grid Layouts */
+        .widget-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+        .widget-row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+        @media (max-width: 1200px) {
+            .widget-row, .widget-row-3 { grid-template-columns: 1fr; }
+        }
+
+        /* ===== Projekt-Info Widget ===== */
+        .project-meta { display: flex; gap: 16px; flex-wrap: wrap; margin-top: 8px; }
+        .meta-item { font-size: 12px; color: var(--text-secondary); }
+        .meta-item span { color: var(--text-primary); }
+
+        /* ===== Step Navigator ===== */
+        .step-list { list-style: none; }
+        .step-item {
+            padding: 8px 12px; border-left: 2px solid var(--border);
+            margin-left: 8px; font-size: 12px;
+            color: var(--text-secondary); cursor: pointer;
+            transition: all 0.2s;
+        }
+        .step-item:hover { color: var(--text-primary); }
+        .step-item.active { border-color: var(--accent); color: var(--accent); }
+        .step-item.done { border-color: var(--success); color: var(--success); }
+        .step-nav-btns { display: flex; gap: 8px; margin-top: 12px; }
+        .step-btn {
+            padding: 6px 16px; border-radius: 6px;
+            border: 1px solid var(--border);
+            background: transparent; color: var(--text-primary);
+            font-family: inherit; font-size: 12px;
+            cursor: pointer; transition: all 0.2s;
+        }
+        .step-btn:hover { border-color: var(--accent); color: var(--accent); }
+        .progress-bar {
+            height: 4px; background: var(--border);
+            border-radius: 2px; margin-top: 8px; overflow: hidden;
+        }
+        .progress-fill {
+            height: 100%; background: var(--accent);
+            border-radius: 2px; transition: width 0.3s;
+        }
+
+        /* ===== Parts List ===== */
+        .parts-table { width: 100%; font-size: 12px; border-collapse: collapse; }
+        .parts-table th {
+            text-align: left; padding: 6px 8px;
+            color: var(--text-secondary); font-weight: 500;
+            border-bottom: 1px solid var(--border);
+        }
+        .parts-table td { padding: 6px 8px; border-bottom: 1px solid var(--border); }
+        .part-available { color: var(--success); }
+        .part-missing { color: var(--danger); }
+
+        /* ===== Code Editor ===== */
+        .code-container {
+            background: #1a1a2e; border-radius: 8px;
+            overflow: hidden; position: relative;
+        }
+        .code-header {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 8px 12px; background: #12122a;
+            font-size: 11px; color: var(--text-secondary);
+        }
+        .code-content {
+            padding: 12px; font-size: 12px;
+            line-height: 1.6; overflow-x: auto;
+            max-height: 400px; overflow-y: auto;
+        }
+        .code-content pre { margin: 0; }
+        .code-content code { font-family: 'JetBrains Mono', monospace; }
+        .btn-copy {
+            background: transparent; border: 1px solid var(--border);
+            color: var(--text-secondary); padding: 2px 8px;
+            border-radius: 4px; cursor: pointer; font-size: 10px;
+            font-family: inherit;
+        }
+        .btn-copy:hover { color: var(--accent); border-color: var(--accent); }
+
+        /* ===== Schematic Viewer ===== */
+        .schematic-container {
+            background: #0a0a1a; border-radius: 8px;
+            padding: 16px; text-align: center; min-height: 200px;
+            display: flex; align-items: center; justify-content: center;
+        }
+        .schematic-container svg { max-width: 100%; height: auto; }
+        .schematic-empty { color: var(--text-secondary); font-size: 13px; }
+
+        /* ===== Chat Panel ===== */
+        .chat-messages {
+            max-height: 300px; overflow-y: auto;
+            padding: 8px; display: flex;
+            flex-direction: column; gap: 8px;
+        }
+        .chat-msg {
+            padding: 8px 12px; border-radius: 8px;
+            font-size: 12px; line-height: 1.5;
+            max-width: 85%;
+        }
+        .chat-msg.user {
+            align-self: flex-end;
+            background: var(--accent-dim); color: var(--accent);
+        }
+        .chat-msg.jarvis {
+            align-self: flex-start;
+            background: var(--bg-secondary); color: var(--text-primary);
+        }
+        .chat-input-row {
+            display: flex; gap: 8px; margin-top: 8px;
+        }
+        .chat-input {
+            flex: 1; background: var(--bg-secondary);
+            border: 1px solid var(--border); border-radius: 8px;
+            padding: 8px 12px; color: var(--text-primary);
+            font-family: inherit; font-size: 12px;
+        }
+        .chat-input:focus { outline: none; border-color: var(--accent); }
+        .btn-send, .btn-voice {
+            background: var(--accent-dim); border: 1px solid var(--accent);
+            color: var(--accent); padding: 8px 14px;
+            border-radius: 8px; cursor: pointer;
+            font-family: inherit; font-size: 12px;
+            transition: all 0.2s;
+        }
+        .btn-send:hover, .btn-voice:hover { background: var(--accent); color: var(--bg-primary); }
+        .btn-voice.recording { background: var(--danger); border-color: var(--danger); color: #fff; }
+
+        /* ===== Environment Widget ===== */
+        .env-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+        .env-item { text-align: center; }
+        .env-value { font-size: 24px; font-weight: 600; color: var(--accent); }
+        .env-label { font-size: 10px; color: var(--text-secondary); margin-top: 4px; }
+        .env-unit { font-size: 12px; color: var(--text-secondary); }
+
+        /* ===== Printer Status ===== */
+        .printer-progress {
+            display: flex; align-items: center; gap: 12px; margin: 8px 0;
+        }
+        .printer-bar { flex: 1; }
+        .printer-percent { font-size: 20px; font-weight: 600; color: var(--accent); }
+        .printer-temps { display: flex; gap: 16px; font-size: 12px; margin-top: 8px; }
+        .printer-temps span { color: var(--text-secondary); }
+        .printer-temps .val { color: var(--warning); }
+
+        /* ===== Arm Control ===== */
+        .arm-btns { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+        .arm-btn {
+            padding: 10px; border-radius: 6px;
+            border: 1px solid var(--border); background: transparent;
+            color: var(--text-primary); font-family: inherit;
+            font-size: 11px; cursor: pointer; transition: all 0.2s;
+            text-align: center;
+        }
+        .arm-btn:hover { border-color: var(--accent); color: var(--accent); }
+        .arm-btn.emergency {
+            border-color: var(--danger); color: var(--danger);
+            grid-column: span 3;
+        }
+        .arm-btn.emergency:hover { background: var(--danger); color: #fff; }
+
+        /* ===== Budget Tracker ===== */
+        .budget-bar-container { position: relative; margin: 12px 0; }
+        .budget-bar {
+            height: 20px; background: var(--border);
+            border-radius: 10px; overflow: hidden;
+        }
+        .budget-fill {
+            height: 100%; border-radius: 10px;
+            background: linear-gradient(90deg, var(--success), var(--accent));
+            transition: width 0.3s;
+        }
+        .budget-fill.over { background: linear-gradient(90deg, var(--warning), var(--danger)); }
+        .budget-labels {
+            display: flex; justify-content: space-between;
+            font-size: 11px; color: var(--text-secondary); margin-top: 4px;
+        }
+        .budget-amount { font-size: 20px; font-weight: 600; }
+
+        /* ===== File Browser ===== */
+        .file-list { list-style: none; }
+        .file-item {
+            display: flex; align-items: center; gap: 8px;
+            padding: 6px 8px; border-radius: 4px;
+            font-size: 12px; cursor: pointer; transition: all 0.2s;
+        }
+        .file-item:hover { background: var(--accent-dim); }
+        .file-icon { width: 16px; text-align: center; }
+        .file-name { flex: 1; }
+        .file-actions { display: flex; gap: 4px; opacity: 0; transition: opacity 0.2s; }
+        .file-item:hover .file-actions { opacity: 1; }
+        .file-action-btn {
+            background: transparent; border: none;
+            color: var(--text-secondary); cursor: pointer;
+            font-size: 12px; padding: 2px;
+        }
+        .file-action-btn:hover { color: var(--accent); }
+
+        /* ===== Calculator ===== */
+        .calc-btns { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; }
+        .calc-btn {
+            padding: 6px 12px; border-radius: 6px;
+            border: 1px solid var(--border); background: transparent;
+            color: var(--text-secondary); font-family: inherit;
+            font-size: 11px; cursor: pointer; transition: all 0.2s;
+        }
+        .calc-btn:hover, .calc-btn.active { border-color: var(--accent); color: var(--accent); }
+        .calc-form { display: flex; flex-direction: column; gap: 8px; }
+        .calc-form label { font-size: 11px; color: var(--text-secondary); }
+        .calc-form input {
+            background: var(--bg-secondary); border: 1px solid var(--border);
+            border-radius: 6px; padding: 6px 10px;
+            color: var(--text-primary); font-family: inherit; font-size: 12px;
+        }
+        .calc-form input:focus { outline: none; border-color: var(--accent); }
+        .calc-result {
+            margin-top: 8px; padding: 10px;
+            background: var(--bg-secondary); border-radius: 6px;
+            font-size: 12px; line-height: 1.6;
+        }
+
+        /* ===== Journal ===== */
+        .journal-entries { display: flex; flex-direction: column; gap: 8px; }
+        .journal-entry {
+            padding: 8px 12px; border-left: 2px solid var(--accent);
+            font-size: 12px; line-height: 1.5;
+        }
+        .journal-time { font-size: 10px; color: var(--text-secondary); }
+
+        /* ===== Footer ===== */
+        .footer {
+            grid-area: footer;
+            display: flex; align-items: center;
+            padding: 0 16px; gap: 16px;
+            background: var(--bg-secondary);
+            border-top: 1px solid var(--border);
+            font-size: 10px; color: var(--text-secondary);
+        }
+        .footer-ws { display: flex; align-items: center; gap: 4px; }
+        .ws-dot {
+            width: 6px; height: 6px; border-radius: 50%;
+            background: var(--danger);
+        }
+        .ws-dot.connected { background: var(--success); }
+
+        /* ===== Scrollbar ===== */
+        ::-webkit-scrollbar { width: 6px; }
+        ::-webkit-scrollbar-track { background: transparent; }
+        ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+        ::-webkit-scrollbar-thumb:hover { background: var(--accent-dim); }
+
+        /* ===== Notification Toast ===== */
+        .toast {
+            position: fixed; top: 20px; right: 20px;
+            padding: 12px 20px; border-radius: 8px;
+            background: var(--glass); border: 1px solid var(--accent);
+            color: var(--text-primary); font-size: 12px;
+            z-index: 900; opacity: 0;
+            transform: translateY(-10px);
+            transition: all 0.3s;
+        }
+        .toast.show { opacity: 1; transform: translateY(0); }
+    </style>
+</head>
+<body>
+
+<!-- ===== Boot Screen ===== -->
+<div id="boot-screen">
+    <div class="boot-title">J.A.R.V.I.S. WORKSHOP</div>
+    <div class="boot-ring" id="boot-ring"></div>
+    <div id="boot-text"></div>
+</div>
+
+<!-- ===== Main Workshop Grid ===== -->
+<div id="workshop-main" class="workshop-grid" style="display:none">
+
+    <!-- Header -->
+    <div class="header">
+        <div class="header-logo">WORKSHOP</div>
+        <div class="header-project" id="header-project">
+            <span class="proj-name" id="header-proj-name">Kein Projekt</span>
+        </div>
+        <span class="header-status status-none" id="header-status">---</span>
+        <div class="header-actions">
+            <button onclick="showNewProject()">+ Projekt</button>
+            <button onclick="refreshAll()">&#8635;</button>
+            <button onclick="window.open('/ui/', '_blank')">Dashboard</button>
+        </div>
+    </div>
+
+    <!-- Sidebar -->
+    <div class="sidebar">
+        <h3>Navigation</h3>
+        <button class="nav-btn active" data-view="overview" onclick="switchView(this, 'overview')">
+            <span class="icon">&#128200;</span> Uebersicht
+        </button>
+        <button class="nav-btn" data-view="steps" onclick="switchView(this, 'steps')">
+            <span class="icon">&#128221;</span> Schritte
+        </button>
+        <button class="nav-btn" data-view="code" onclick="switchView(this, 'code')">
+            <span class="icon">&#128187;</span> Code & Dateien
+        </button>
+        <button class="nav-btn" data-view="hardware" onclick="switchView(this, 'hardware')">
+            <span class="icon">&#128268;</span> Hardware
+        </button>
+        <button class="nav-btn" data-view="chat" onclick="switchView(this, 'chat')">
+            <span class="icon">&#128172;</span> Chat
+        </button>
+        <button class="nav-btn" data-view="calc" onclick="switchView(this, 'calc')">
+            <span class="icon">&#129518;</span> Rechner
+        </button>
+        <button class="nav-btn" data-view="journal" onclick="switchView(this, 'journal')">
+            <span class="icon">&#128214;</span> Journal
+        </button>
+
+        <h3>Projekte</h3>
+        <div id="project-list"></div>
+    </div>
+
+    <!-- Main Content -->
+    <div class="main" id="main-content"></div>
+
+    <!-- Footer -->
+    <div class="footer">
+        <div class="footer-ws">
+            <div class="ws-dot" id="ws-dot"></div>
+            <span id="ws-status">Getrennt</span>
+        </div>
+        <span id="footer-timer"></span>
+        <span style="flex:1"></span>
+        <span id="footer-env"></span>
+    </div>
+</div>
+
+<!-- Toast Notification -->
+<div class="toast" id="toast"></div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-c.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-cpp.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-javascript.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
+<script>
+'use strict';
+
+// ===== State =====
+let ws = null;
+let currentProject = null;
+let projects = [];
+let currentView = 'overview';
+let isRecording = false;
+
+// ===== Boot Sequence =====
+async function bootWorkshop() {
+    const text = document.getElementById('boot-text');
+    const messages = [
+        'Werkstatt-Systeme initialisieren...',
+        'Sensor-Array verbunden.',
+        '3D-Drucker: Online.',
+        'Roboterarm: Bereit.',
+        'Workshop-Modus aktiv, Sir.'
+    ];
+    for (const msg of messages) {
+        await typewrite(text, msg, 40);
+        await sleep(600);
+    }
+    document.getElementById('boot-screen').classList.add('fade-out');
+    setTimeout(() => {
+        document.getElementById('boot-screen').style.display = 'none';
+        document.getElementById('workshop-main').style.display = 'grid';
+        connectWebSocket();
+        loadProjects();
+    }, 800);
+}
+
+function typewrite(el, text, speed) {
+    return new Promise(resolve => {
+        el.textContent = '';
+        let i = 0;
+        const iv = setInterval(() => {
+            el.textContent += text[i++];
+            if (i >= text.length) { clearInterval(iv); resolve(); }
+        }, speed);
+    });
+}
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+// ===== API Helper =====
+async function apiCall(endpoint, method = 'GET', body = null) {
+    const opts = { method, headers: { 'Content-Type': 'application/json' } };
+    if (body) opts.body = JSON.stringify(body);
+    const resp = await fetch('/api/workshop/' + endpoint, opts);
+    return await resp.json();
+}
+
+async function chatApi(text) {
+    const resp = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, room: 'werkstatt' })
+    });
+    return await resp.json();
+}
+
+// ===== WebSocket =====
+function connectWebSocket() {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(proto + '//' + location.host + '/ws');
+    ws.onopen = () => {
+        document.getElementById('ws-dot').classList.add('connected');
+        document.getElementById('ws-status').textContent = 'Verbunden';
+    };
+    ws.onclose = () => {
+        document.getElementById('ws-dot').classList.remove('connected');
+        document.getElementById('ws-status').textContent = 'Getrennt';
+        setTimeout(connectWebSocket, 3000);
+    };
+    ws.onmessage = (e) => {
+        const msg = JSON.parse(e.data);
+        handleWsEvent(msg);
+    };
+}
+
+function handleWsEvent(msg) {
+    switch (msg.event) {
+        case 'workshop.step':
+            updateStepNavigator(msg.data);
+            break;
+        case 'workshop.diagnosis':
+            showDiagnosis(msg.data);
+            break;
+        case 'workshop.file_created':
+            if (currentView === 'code') renderCodeView();
+            showToast('Neue Datei: ' + (msg.data.filename || ''));
+            break;
+        case 'workshop.printer':
+            updatePrinterWidget(msg.data);
+            break;
+        case 'workshop.environment':
+            updateEnvironment(msg.data);
+            break;
+        case 'workshop.timer':
+            showToast('Timer: ' + (msg.data.message || ''));
+            break;
+        case 'workshop.project':
+            loadProjects();
+            break;
+        case 'assistant.speaking':
+            addChatMessage('jarvis', msg.data.text);
+            break;
+        case 'assistant.stream_token':
+            appendStreamToken(msg.data.token);
+            break;
+        case 'assistant.stream_end':
+            finalizeStream(msg.data.text);
+            break;
+    }
+}
+
+// ===== Project Management =====
+async function loadProjects() {
+    try {
+        const res = await apiCall('projects');
+        projects = res.projects || [];
+        renderProjectList();
+        if (currentProject) {
+            const updated = projects.find(p => p.id === currentProject.id);
+            if (updated) { currentProject = updated; updateHeader(); }
+        }
+    } catch (e) { console.error('loadProjects:', e); }
+}
+
+function renderProjectList() {
+    const el = document.getElementById('project-list');
+    if (!projects.length) {
+        el.innerHTML = '<div style="font-size:11px;color:var(--text-secondary);padding:8px">Keine Projekte</div>';
+        return;
+    }
+    el.innerHTML = projects.map(p =>
+        '<div class="project-item' + (currentProject && currentProject.id === p.id ? ' active' : '') +
+        '" onclick="selectProject(\'' + p.id + '\')">' +
+        '<div class="project-dot"></div>' +
+        '<span>' + escHtml(p.title || p.id) + '</span></div>'
+    ).join('');
+}
+
+async function selectProject(id) {
+    try {
+        const p = await apiCall('project/' + id);
+        currentProject = p;
+        updateHeader();
+        renderProjectList();
+        renderView();
+    } catch (e) { showToast('Projekt nicht gefunden'); }
+}
+
+function updateHeader() {
+    if (!currentProject) {
+        document.getElementById('header-proj-name').textContent = 'Kein Projekt';
+        document.getElementById('header-status').textContent = '---';
+        document.getElementById('header-status').className = 'header-status status-none';
+        return;
+    }
+    document.getElementById('header-proj-name').textContent = currentProject.title || currentProject.id;
+    const st = currentProject.status || 'erstellt';
+    document.getElementById('header-status').textContent = st;
+    const cls = (st === 'in_arbeit' || st === 'diagnose') ? 'status-active' :
+                st === 'pausiert' ? 'status-paused' : 'status-none';
+    document.getElementById('header-status').className = 'header-status ' + cls;
+}
+
+async function showNewProject() {
+    const title = prompt('Projekt-Name:');
+    if (!title) return;
+    const desc = prompt('Beschreibung (optional):') || '';
+    try {
+        const res = await chatApi('Erstelle ein Werkstatt-Projekt: ' + title + (desc ? '. ' + desc : ''));
+        showToast('Projekt wird erstellt...');
+        setTimeout(loadProjects, 2000);
+    } catch (e) { showToast('Fehler beim Erstellen'); }
+}
+
+// ===== View Switching =====
+function switchView(btn, view) {
+    document.querySelectorAll('.nav-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    currentView = view;
+    renderView();
+}
+
+function renderView() {
+    const main = document.getElementById('main-content');
+    switch (currentView) {
+        case 'overview': renderOverview(main); break;
+        case 'steps': renderStepsView(main); break;
+        case 'code': renderCodeView(main); break;
+        case 'hardware': renderHardwareView(main); break;
+        case 'chat': renderChatView(main); break;
+        case 'calc': renderCalcView(main); break;
+        case 'journal': renderJournalView(main); break;
+        default: main.innerHTML = '';
+    }
+}
+
+// ===== Overview View =====
+function renderOverview(main) {
+    if (!main) main = document.getElementById('main-content');
+    let html = '';
+
+    // Project Info
+    html += '<div class="widget" id="w-project-info">';
+    html += '<div class="widget-header"><span class="icon">&#128204;</span><span class="widget-title">Projekt-Info</span></div>';
+    if (currentProject) {
+        html += '<div style="font-size:18px;font-weight:600;">' + escHtml(currentProject.title || '') + '</div>';
+        html += '<div style="font-size:12px;color:var(--text-secondary);margin-top:4px">' + escHtml(currentProject.description || '') + '</div>';
+        html += '<div class="project-meta">';
+        html += '<div class="meta-item">Kategorie: <span>' + escHtml(currentProject.category || '-') + '</span></div>';
+        html += '<div class="meta-item">Prioritaet: <span>' + escHtml(currentProject.priority || '-') + '</span></div>';
+        html += '<div class="meta-item">Status: <span>' + escHtml(currentProject.status || '-') + '</span></div>';
+        html += '</div>';
+    } else {
+        html += '<div style="color:var(--text-secondary);font-size:13px">Kein Projekt ausgewaehlt. Erstelle ein neues Projekt oder waehle eines aus der Sidebar.</div>';
+    }
+    html += '</div>';
+
+    // Stats + Environment Row
+    html += '<div class="widget-row">';
+
+    // Environment
+    html += '<div class="widget" id="w-environment">';
+    html += '<div class="widget-header"><span class="icon">&#127777;</span><span class="widget-title">Werkstatt-Umgebung</span></div>';
+    html += '<div class="env-grid">';
+    html += '<div class="env-item"><div class="env-value" id="env-temp">--</div><div class="env-label">Temperatur</div></div>';
+    html += '<div class="env-item"><div class="env-value" id="env-hum">--</div><div class="env-label">Feuchtigkeit</div></div>';
+    html += '<div class="env-item"><div class="env-value" id="env-co2">--</div><div class="env-label">CO2</div></div>';
+    html += '</div></div>';
+
+    // Budget
+    html += '<div class="widget" id="w-budget">';
+    html += '<div class="widget-header"><span class="icon">&#128176;</span><span class="widget-title">Budget</span></div>';
+    if (currentProject && currentProject.budget) {
+        const spent = currentProject.expenses_total || 0;
+        const budget = currentProject.budget || 0;
+        const pct = budget > 0 ? Math.min(100, (spent / budget) * 100) : 0;
+        html += '<div class="budget-amount">' + spent.toFixed(2) + ' / ' + budget.toFixed(2) + ' EUR</div>';
+        html += '<div class="budget-bar-container"><div class="budget-bar">';
+        html += '<div class="budget-fill' + (pct > 100 ? ' over' : '') + '" style="width:' + pct + '%"></div>';
+        html += '</div></div>';
+        html += '<div class="budget-labels"><span>0 EUR</span><span>' + budget.toFixed(0) + ' EUR</span></div>';
+    } else {
+        html += '<div style="color:var(--text-secondary);font-size:12px">Kein Budget gesetzt</div>';
+    }
+    html += '</div>';
+
+    html += '</div>'; // end widget-row
+
+    // Parts List
+    if (currentProject && currentProject.parts && currentProject.parts.length) {
+        html += '<div class="widget" id="w-parts">';
+        html += '<div class="widget-header"><span class="icon">&#128295;</span><span class="widget-title">Teile-Liste</span></div>';
+        html += '<table class="parts-table"><thead><tr><th>Teil</th><th>Menge</th><th>Kosten</th><th>Status</th></tr></thead><tbody>';
+        currentProject.parts.forEach(p => {
+            const cls = p.available ? 'part-available' : 'part-missing';
+            html += '<tr><td>' + escHtml(p.name || '') + '</td><td>' + (p.quantity || 1) + '</td>';
+            html += '<td>' + (p.cost ? p.cost.toFixed(2) + ' EUR' : '-') + '</td>';
+            html += '<td class="' + cls + '">' + (p.available ? 'Vorhanden' : 'Fehlt') + '</td></tr>';
+        });
+        html += '</tbody></table></div>';
+    }
+
+    main.innerHTML = html;
+}
+
+// ===== Steps View =====
+function renderStepsView(main) {
+    if (!main) main = document.getElementById('main-content');
+    let html = '<div class="widget" id="w-steps">';
+    html += '<div class="widget-header"><span class="icon">&#128221;</span><span class="widget-title">Reparatur-Schritte</span></div>';
+
+    if (currentProject && currentProject.steps && currentProject.steps.length) {
+        const steps = currentProject.steps;
+        const current = currentProject.current_step || 0;
+        const pct = steps.length > 0 ? ((current + 1) / steps.length) * 100 : 0;
+        html += '<div class="progress-bar"><div class="progress-fill" style="width:' + pct + '%"></div></div>';
+        html += '<div style="font-size:11px;color:var(--text-secondary);margin:4px 0 12px">Schritt ' + (current + 1) + ' von ' + steps.length + '</div>';
+        html += '<ul class="step-list">';
+        steps.forEach((s, i) => {
+            const cls = i === current ? 'active' : (i < current ? 'done' : '');
+            html += '<li class="step-item ' + cls + '">';
+            html += '<strong>' + (i + 1) + '.</strong> ' + escHtml(s.title || s.description || '');
+            if (s.details) html += '<div style="font-size:11px;color:var(--text-secondary);margin-top:2px">' + escHtml(s.details) + '</div>';
+            html += '</li>';
+        });
+        html += '</ul>';
+        html += '<div class="step-nav-btns">';
+        html += '<button class="step-btn" onclick="navStep(\'prev\')">&#9664; Zurueck</button>';
+        html += '<button class="step-btn" onclick="navStep(\'next\')">Weiter &#9654;</button>';
+        html += '</div>';
+    } else {
+        html += '<div style="color:var(--text-secondary);font-size:13px">Keine Schritte vorhanden. Starte eine Diagnose um Reparatur-Schritte zu generieren.</div>';
+    }
+    html += '</div>';
+    main.innerHTML = html;
+}
+
+async function navStep(dir) {
+    await chatApi(dir === 'next' ? 'naechster schritt' : 'vorheriger schritt');
+}
+
+function updateStepNavigator(data) {
+    if (currentView === 'steps' || currentView === 'overview') {
+        if (currentProject) selectProject(currentProject.id);
+    }
+    showToast('Schritt ' + (data.step_number || '?') + ': ' + (data.title || ''));
+}
+
+// ===== Code & Files View =====
+async function renderCodeView(main) {
+    if (!main) main = document.getElementById('main-content');
+    let html = '';
+
+    // File Browser
+    html += '<div class="widget" id="w-files">';
+    html += '<div class="widget-header"><span class="icon">&#128193;</span><span class="widget-title">Dateien</span></div>';
+    if (currentProject) {
+        try {
+            const res = await apiCall('files/' + currentProject.id);
+            const files = res.files || [];
+            if (files.length) {
+                html += '<ul class="file-list">';
+                files.forEach(f => {
+                    const ext = (f.filename || '').split('.').pop();
+                    const icon = { py: '&#128013;', ino: '&#9889;', scad: '&#128230;', svg: '&#127912;', html: '&#127760;', js: '&#9889;', yaml: '&#128196;' }[ext] || '&#128196;';
+                    html += '<li class="file-item" onclick="viewFile(\'' + escHtml(f.filename) + '\')">';
+                    html += '<span class="file-icon">' + icon + '</span>';
+                    html += '<span class="file-name">' + escHtml(f.filename) + '</span>';
+                    html += '<span style="font-size:10px;color:var(--text-secondary)">' + (f.version ? 'v' + f.version : '') + '</span>';
+                    html += '<div class="file-actions">';
+                    html += '<button class="file-action-btn" onclick="event.stopPropagation();downloadFile(\'' + escHtml(f.filename) + '\')">&#11015;</button>';
+                    html += '</div></li>';
+                });
+                html += '</ul>';
+            } else {
+                html += '<div style="color:var(--text-secondary);font-size:12px">Keine Dateien. Generiere Code, 3D-Modelle oder Schaltplaene ueber den Chat.</div>';
+            }
+        } catch (e) {
+            html += '<div style="color:var(--text-secondary);font-size:12px">Dateien konnten nicht geladen werden.</div>';
+        }
+    } else {
+        html += '<div style="color:var(--text-secondary);font-size:12px">Kein Projekt ausgewaehlt.</div>';
+    }
+    html += '</div>';
+
+    // Code Editor
+    html += '<div class="widget" id="w-code">';
+    html += '<div class="widget-header"><span class="icon">&#128187;</span><span class="widget-title">Code-Ansicht</span></div>';
+    html += '<div id="code-display">';
+    html += '<div style="color:var(--text-secondary);font-size:12px">Waehle eine Datei aus der Liste oben.</div>';
+    html += '</div></div>';
+
+    // Schematic Viewer
+    html += '<div class="widget" id="w-schematic">';
+    html += '<div class="widget-header"><span class="icon">&#128268;</span><span class="widget-title">Schaltplan</span></div>';
+    html += '<div class="schematic-container" id="schematic-display">';
+    html += '<div class="schematic-empty">Kein Schaltplan geladen</div>';
+    html += '</div></div>';
+
+    main.innerHTML = html;
+}
+
+async function viewFile(filename) {
+    if (!currentProject) return;
+    try {
+        const res = await apiCall('files/' + currentProject.id + '/' + filename);
+        const content = res.content || '';
+        const ext = filename.split('.').pop();
+        const display = document.getElementById('code-display');
+
+        if (ext === 'svg') {
+            document.getElementById('schematic-display').innerHTML = content;
+            return;
+        }
+
+        const langMap = { py: 'python', ino: 'cpp', cpp: 'cpp', c: 'c', js: 'javascript', yaml: 'yaml', html: 'markup' };
+        const lang = langMap[ext] || 'markup';
+        let highlighted = content;
+        try { highlighted = Prism.highlight(content, Prism.languages[lang] || Prism.languages.markup, lang); } catch(e) {}
+
+        display.innerHTML = '<div class="code-container">' +
+            '<div class="code-header"><span>' + escHtml(filename) + '</span>' +
+            '<button class="btn-copy" onclick="copyCode()">Kopieren</button></div>' +
+            '<div class="code-content"><pre><code id="code-block">' + highlighted + '</code></pre></div></div>';
+
+        document.getElementById('code-block').dataset.raw = content;
+    } catch (e) { showToast('Datei konnte nicht geladen werden'); }
+}
+
+function copyCode() {
+    const block = document.getElementById('code-block');
+    if (block && block.dataset.raw) {
+        navigator.clipboard.writeText(block.dataset.raw);
+        showToast('Kopiert!');
+    }
+}
+
+function downloadFile(filename) {
+    if (!currentProject) return;
+    window.open('/api/workshop/files/' + currentProject.id + '/' + filename, '_blank');
+}
+
+// ===== Hardware View =====
+function renderHardwareView(main) {
+    if (!main) main = document.getElementById('main-content');
+    let html = '';
+
+    // Printer Status
+    html += '<div class="widget" id="w-printer">';
+    html += '<div class="widget-header"><span class="icon">&#128424;</span><span class="widget-title">3D-Drucker</span></div>';
+    html += '<div id="printer-content">';
+    html += '<div style="color:var(--text-secondary);font-size:12px">Status wird geladen...</div>';
+    html += '</div></div>';
+
+    // Arm Control
+    html += '<div class="widget" id="w-arm">';
+    html += '<div class="widget-header"><span class="icon">&#129302;</span><span class="widget-title">Roboterarm</span></div>';
+    html += '<div class="arm-btns">';
+    html += '<button class="arm-btn" onclick="armCmd(\'home\')">&#127968; Home</button>';
+    html += '<button class="arm-btn" onclick="armCmd(\'open\')">&#9996; Oeffnen</button>';
+    html += '<button class="arm-btn" onclick="armCmd(\'close\')">&#9994; Greifen</button>';
+    html += '<button class="arm-btn" onclick="armPickTool()">&#128295; Werkzeug</button>';
+    html += '<button class="arm-btn" onclick="armPos(\'up\')">&#11014; Hoch</button>';
+    html += '<button class="arm-btn" onclick="armPos(\'down\')">&#11015; Runter</button>';
+    html += '<button class="arm-btn emergency" onclick="armCmd(\'stop\')">&#9888; NOTAUS</button>';
+    html += '</div>';
+    html += '<div style="margin-top:12px;font-size:11px;color:var(--text-secondary)" id="arm-status">Position: ---</div>';
+    html += '</div>';
+
+    // Environment (detailed)
+    html += '<div class="widget" id="w-env-detail">';
+    html += '<div class="widget-header"><span class="icon">&#127777;</span><span class="widget-title">Umgebungssensoren</span></div>';
+    html += '<div class="env-grid">';
+    html += '<div class="env-item"><div class="env-value" id="env-temp2">--</div><div class="env-label">Temperatur</div></div>';
+    html += '<div class="env-item"><div class="env-value" id="env-hum2">--</div><div class="env-label">Feuchtigkeit</div></div>';
+    html += '<div class="env-item"><div class="env-value" id="env-co22">--</div><div class="env-label">CO2</div></div>';
+    html += '</div></div>';
+
+    main.innerHTML = html;
+    loadPrinterStatus();
+}
+
+async function loadPrinterStatus() {
+    try {
+        const res = await chatApi('Drucker-Status');
+        document.getElementById('printer-content').innerHTML =
+            '<div style="font-size:12px;color:var(--text-secondary)">Status abgefragt. Warte auf Update...</div>';
+    } catch(e) {}
+}
+
+function updatePrinterWidget(data) {
+    const el = document.getElementById('printer-content');
+    if (!el) return;
+    const pct = data.progress || 0;
+    const state = data.state || 'idle';
+    let html = '<div class="printer-progress">';
+    html += '<div class="printer-bar"><div class="progress-bar"><div class="progress-fill" style="width:' + pct + '%"></div></div></div>';
+    html += '<div class="printer-percent">' + pct + '%</div></div>';
+    html += '<div style="font-size:12px;color:var(--text-secondary)">Status: ' + state + '</div>';
+    if (data.temps) {
+        html += '<div class="printer-temps">';
+        html += '<span>Nozzle: <span class="val">' + (data.temps.nozzle || '--') + '°C</span></span>';
+        html += '<span>Bed: <span class="val">' + (data.temps.bed || '--') + '°C</span></span>';
+        html += '</div>';
+    }
+    el.innerHTML = html;
+}
+
+async function armCmd(cmd) {
+    if (cmd === 'home') await chatApi('Arm Home');
+    else if (cmd === 'open') await chatApi('Greifer oeffnen');
+    else if (cmd === 'close') await chatApi('Greifer schliessen');
+    else if (cmd === 'stop') await chatApi('Notaus');
+}
+
+async function armPos(dir) {
+    const delta = dir === 'up' ? 50 : -50;
+    await chatApi('Arm bewegen z ' + delta);
+}
+
+async function armPickTool() {
+    const tool = prompt('Welches Werkzeug?');
+    if (tool) await chatApi('Arm hole ' + tool);
+}
+
+// ===== Chat View =====
+let chatMessages = [];
+let streamBuffer = '';
+
+function renderChatView(main) {
+    if (!main) main = document.getElementById('main-content');
+    let html = '<div class="widget" style="flex:1;display:flex;flex-direction:column">';
+    html += '<div class="widget-header"><span class="icon">&#128172;</span><span class="widget-title">Workshop-Chat</span></div>';
+    html += '<div class="chat-messages" id="chat-messages">';
+    chatMessages.forEach(m => {
+        html += '<div class="chat-msg ' + m.role + '">' + escHtml(m.text) + '</div>';
+    });
+    html += '</div>';
+    html += '<div class="chat-input-row">';
+    html += '<button class="btn-voice" id="btn-voice" onclick="toggleVoice()">&#127908;</button>';
+    html += '<input class="chat-input" id="chat-input" placeholder="Nachricht eingeben..." onkeydown="if(event.key===\'Enter\')sendChat()">';
+    html += '<button class="btn-send" onclick="sendChat()">&#10148;</button>';
+    html += '</div></div>';
+    main.innerHTML = html;
+    const msgs = document.getElementById('chat-messages');
+    if (msgs) msgs.scrollTop = msgs.scrollHeight;
+}
+
+function addChatMessage(role, text) {
+    chatMessages.push({ role, text });
+    if (chatMessages.length > 100) chatMessages.shift();
+    if (currentView === 'chat') {
+        const el = document.getElementById('chat-messages');
+        if (el) {
+            el.innerHTML += '<div class="chat-msg ' + role + '">' + escHtml(text) + '</div>';
+            el.scrollTop = el.scrollHeight;
+        }
+    }
+}
+
+function appendStreamToken(token) {
+    streamBuffer += token;
+    if (currentView === 'chat') {
+        const el = document.getElementById('chat-messages');
+        if (!el) return;
+        let streaming = el.querySelector('.chat-msg.streaming');
+        if (!streaming) {
+            streaming = document.createElement('div');
+            streaming.className = 'chat-msg jarvis streaming';
+            el.appendChild(streaming);
+        }
+        streaming.textContent = streamBuffer;
+        el.scrollTop = el.scrollHeight;
+    }
+}
+
+function finalizeStream(fullText) {
+    if (currentView === 'chat') {
+        const el = document.getElementById('chat-messages');
+        if (el) {
+            const streaming = el.querySelector('.chat-msg.streaming');
+            if (streaming) streaming.remove();
+        }
+    }
+    streamBuffer = '';
+    addChatMessage('jarvis', fullText);
+}
+
+async function sendChat() {
+    const input = document.getElementById('chat-input');
+    if (!input) return;
+    const text = input.value.trim();
+    if (!text) return;
+    input.value = '';
+    addChatMessage('user', text);
+    try {
+        const res = await chatApi(text);
+        if (res.response && !res._emitted) {
+            addChatMessage('jarvis', res.response);
+        }
+    } catch (e) {
+        addChatMessage('jarvis', 'Fehler bei der Kommunikation.');
+    }
+}
+
+// ===== Voice Input =====
+function toggleVoice() {
+    const btn = document.getElementById('btn-voice');
+    if (isRecording) {
+        isRecording = false;
+        btn.classList.remove('recording');
+        return;
+    }
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SR) { showToast('Spracherkennung nicht unterstuetzt'); return; }
+    const recognition = new SR();
+    recognition.lang = 'de-DE';
+    recognition.continuous = false;
+    recognition.onstart = () => { isRecording = true; btn.classList.add('recording'); };
+    recognition.onresult = async (event) => {
+        const text = event.results[0][0].transcript;
+        const input = document.getElementById('chat-input');
+        if (input) input.value = text;
+        await sendChat();
+    };
+    recognition.onend = () => { isRecording = false; btn.classList.remove('recording'); };
+    recognition.onerror = () => { isRecording = false; btn.classList.remove('recording'); };
+    recognition.start();
+}
+
+// ===== Calculator View =====
+let activeCalc = 'ohms_law';
+
+function renderCalcView(main) {
+    if (!main) main = document.getElementById('main-content');
+    let html = '<div class="widget">';
+    html += '<div class="widget-header"><span class="icon">&#129518;</span><span class="widget-title">Werkstatt-Rechner</span></div>';
+    html += '<div class="calc-btns">';
+    const calcs = [
+        { id: 'ohms_law', label: 'Ohm\'sches Gesetz' },
+        { id: 'led_resistor', label: 'LED Widerstand' },
+        { id: 'resistor_divider', label: 'Spannungsteiler' },
+        { id: 'wire_gauge', label: 'Kabelquerschnitt' },
+        { id: '3d_print_weight', label: '3D-Druck Gewicht' },
+        { id: 'power_supply', label: 'Netzteil' },
+        { id: 'convert', label: 'Umrechnung' },
+    ];
+    calcs.forEach(c => {
+        html += '<button class="calc-btn' + (c.id === activeCalc ? ' active' : '') +
+                '" onclick="setCalc(\'' + c.id + '\')">' + c.label + '</button>';
+    });
+    html += '</div>';
+    html += '<div id="calc-form">' + getCalcForm(activeCalc) + '</div>';
+    html += '<div class="calc-result" id="calc-result"></div>';
+    html += '</div>';
+    main.innerHTML = html;
+}
+
+function setCalc(type) {
+    activeCalc = type;
+    document.querySelectorAll('.calc-btn').forEach(b => b.classList.remove('active'));
+    document.querySelector('.calc-btn[onclick*="' + type + '"]').classList.add('active');
+    document.getElementById('calc-form').innerHTML = getCalcForm(type);
+    document.getElementById('calc-result').innerHTML = '';
+}
+
+function getCalcForm(type) {
+    const forms = {
+        ohms_law: '<div class="calc-form"><label>Spannung (V)</label><input id="cp-v" type="number" step="any" placeholder="z.B. 5">' +
+                  '<label>Widerstand (Ohm)</label><input id="cp-r" type="number" step="any" placeholder="z.B. 100">' +
+                  '<label>Strom (A) — optional</label><input id="cp-i" type="number" step="any" placeholder="Berechnet">' +
+                  '<button class="step-btn" style="margin-top:8px" onclick="doCalc()">Berechnen</button></div>',
+        led_resistor: '<div class="calc-form"><label>Versorgungsspannung (V)</label><input id="cp-vs" type="number" step="any" value="5">' +
+                      '<label>LED Vorwaertsspannung (V)</label><input id="cp-vf" type="number" step="any" value="2">' +
+                      '<label>LED Strom (mA)</label><input id="cp-if" type="number" step="any" value="20">' +
+                      '<button class="step-btn" style="margin-top:8px" onclick="doCalc()">Berechnen</button></div>',
+        resistor_divider: '<div class="calc-form"><label>Eingangsspannung (V)</label><input id="cp-vin" type="number" step="any" value="12">' +
+                          '<label>Ausgangsspannung (V)</label><input id="cp-vout" type="number" step="any" value="3.3">' +
+                          '<label>R2 (Ohm) — optional</label><input id="cp-r2" type="number" step="any" placeholder="10000">' +
+                          '<button class="step-btn" style="margin-top:8px" onclick="doCalc()">Berechnen</button></div>',
+        wire_gauge: '<div class="calc-form"><label>Strom (A)</label><input id="cp-amp" type="number" step="any" value="10">' +
+                    '<label>Laenge (m)</label><input id="cp-len" type="number" step="any" value="5">' +
+                    '<label>Max. Spannungsabfall (V)</label><input id="cp-drop" type="number" step="any" value="0.5">' +
+                    '<button class="step-btn" style="margin-top:8px" onclick="doCalc()">Berechnen</button></div>',
+        '3d_print_weight': '<div class="calc-form"><label>Volumen (cm³)</label><input id="cp-vol" type="number" step="any">' +
+                           '<label>Material</label><select id="cp-mat" class="chat-input" style="padding:6px"><option>PLA</option><option>ABS</option><option>PETG</option><option>TPU</option><option>Nylon</option></select>' +
+                           '<label>Infill (%)</label><input id="cp-infill" type="number" step="any" value="20">' +
+                           '<button class="step-btn" style="margin-top:8px" onclick="doCalc()">Berechnen</button></div>',
+        power_supply: '<div class="calc-form"><label>Gesamtstrom (A)</label><input id="cp-total-a" type="number" step="any">' +
+                      '<label>Spannung (V)</label><input id="cp-psu-v" type="number" step="any" value="12">' +
+                      '<label>Sicherheitsmarge (%)</label><input id="cp-margin" type="number" step="any" value="20">' +
+                      '<button class="step-btn" style="margin-top:8px" onclick="doCalc()">Berechnen</button></div>',
+        convert: '<div class="calc-form"><label>Wert</label><input id="cp-val" type="number" step="any">' +
+                 '<label>Von</label><input id="cp-from" type="text" placeholder="z.B. inch">' +
+                 '<label>Nach</label><input id="cp-to" type="text" placeholder="z.B. mm">' +
+                 '<button class="step-btn" style="margin-top:8px" onclick="doCalc()">Berechnen</button></div>',
+    };
+    return forms[type] || '';
+}
+
+async function doCalc() {
+    let params = {};
+    switch (activeCalc) {
+        case 'ohms_law':
+            params = {};
+            const v = document.getElementById('cp-v')?.value;
+            const r = document.getElementById('cp-r')?.value;
+            const i = document.getElementById('cp-i')?.value;
+            if (v) params.v = parseFloat(v);
+            if (r) params.r = parseFloat(r);
+            if (i) params.i = parseFloat(i);
+            break;
+        case 'led_resistor':
+            params = { v_supply: parseFloat(document.getElementById('cp-vs')?.value || 5),
+                       v_forward: parseFloat(document.getElementById('cp-vf')?.value || 2),
+                       i_ma: parseFloat(document.getElementById('cp-if')?.value || 20) };
+            break;
+        case 'resistor_divider':
+            params = { v_in: parseFloat(document.getElementById('cp-vin')?.value || 12),
+                       v_out: parseFloat(document.getElementById('cp-vout')?.value || 3.3) };
+            const r2v = document.getElementById('cp-r2')?.value;
+            if (r2v) params.r2 = parseFloat(r2v);
+            break;
+        case 'wire_gauge':
+            params = { current_a: parseFloat(document.getElementById('cp-amp')?.value || 10),
+                       length_m: parseFloat(document.getElementById('cp-len')?.value || 5),
+                       max_drop_v: parseFloat(document.getElementById('cp-drop')?.value || 0.5) };
+            break;
+        case '3d_print_weight':
+            params = { volume_cm3: parseFloat(document.getElementById('cp-vol')?.value || 0),
+                       material: document.getElementById('cp-mat')?.value || 'PLA',
+                       infill_pct: parseFloat(document.getElementById('cp-infill')?.value || 20) };
+            break;
+        case 'power_supply':
+            params = { total_current_a: parseFloat(document.getElementById('cp-total-a')?.value || 0),
+                       voltage: parseFloat(document.getElementById('cp-psu-v')?.value || 12),
+                       margin_pct: parseFloat(document.getElementById('cp-margin')?.value || 20) };
+            break;
+        case 'convert':
+            params = { value: parseFloat(document.getElementById('cp-val')?.value || 0),
+                       from_unit: document.getElementById('cp-from')?.value || '',
+                       to_unit: document.getElementById('cp-to')?.value || '' };
+            break;
+    }
+    try {
+        const res = await apiCall('calculate', 'POST', { type: activeCalc, params });
+        const el = document.getElementById('calc-result');
+        if (res.error) {
+            el.innerHTML = '<span style="color:var(--danger)">' + escHtml(res.error) + '</span>';
+        } else {
+            el.innerHTML = '<pre style="margin:0;white-space:pre-wrap">' + escHtml(JSON.stringify(res, null, 2)) + '</pre>';
+        }
+    } catch (e) {
+        document.getElementById('calc-result').innerHTML = '<span style="color:var(--danger)">Fehler</span>';
+    }
+}
+
+// ===== Journal View =====
+async function renderJournalView(main) {
+    if (!main) main = document.getElementById('main-content');
+    let html = '<div class="widget">';
+    html += '<div class="widget-header"><span class="icon">&#128214;</span><span class="widget-title">Workshop-Journal</span></div>';
+
+    try {
+        const res = await apiCall('journal');
+        const entries = res.entries || [];
+        if (entries.length) {
+            html += '<div class="journal-entries">';
+            entries.forEach(e => {
+                html += '<div class="journal-entry">';
+                html += '<div class="journal-time">' + escHtml(e.timestamp || '') + '</div>';
+                html += '<div>' + escHtml(e.text || '') + '</div>';
+                html += '</div>';
+            });
+            html += '</div>';
+        } else {
+            html += '<div style="color:var(--text-secondary);font-size:12px">Noch keine Journal-Eintraege.</div>';
+        }
+    } catch (e) {
+        html += '<div style="color:var(--text-secondary);font-size:12px">Journal konnte nicht geladen werden.</div>';
+    }
+
+    html += '<div style="margin-top:12px;display:flex;gap:8px">';
+    html += '<input class="chat-input" id="journal-input" placeholder="Neuer Eintrag...">';
+    html += '<button class="btn-send" onclick="addJournalEntry()">+</button>';
+    html += '</div></div>';
+    main.innerHTML = html;
+}
+
+async function addJournalEntry() {
+    const input = document.getElementById('journal-input');
+    if (!input) return;
+    const text = input.value.trim();
+    if (!text) return;
+    input.value = '';
+    await chatApi('Journal-Eintrag: ' + text);
+    setTimeout(() => renderJournalView(), 1000);
+}
+
+// ===== Environment Updates =====
+function updateEnvironment(data) {
+    const setVal = (id, val, unit) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = val !== undefined ? val + unit : '--';
+    };
+    setVal('env-temp', data.temperatur, '°C');
+    setVal('env-hum', data.feuchtigkeit, '%');
+    setVal('env-co2', data.co2, 'ppm');
+    setVal('env-temp2', data.temperatur, '°C');
+    setVal('env-hum2', data.feuchtigkeit, '%');
+    setVal('env-co22', data.co2, 'ppm');
+
+    const footer = document.getElementById('footer-env');
+    if (footer && data.temperatur !== undefined) {
+        footer.textContent = data.temperatur + '°C | ' + (data.feuchtigkeit || '--') + '% | ' + (data.co2 || '--') + 'ppm';
+    }
+}
+
+function showDiagnosis(data) {
+    showToast('Diagnose abgeschlossen');
+    if (currentProject) selectProject(currentProject.id);
+}
+
+// ===== Utilities =====
+function escHtml(s) {
+    if (!s) return '';
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function showToast(msg) {
+    const el = document.getElementById('toast');
+    el.textContent = msg;
+    el.classList.add('show');
+    setTimeout(() => el.classList.remove('show'), 3000);
+}
+
+async function refreshAll() {
+    await loadProjects();
+    renderView();
+    showToast('Aktualisiert');
+}
+
+// ===== Init =====
+window.addEventListener('DOMContentLoaded', bootWorkshop);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Implements the complete Workshop/Werkstatt mode with ~70 features:

Phase 1 - Core Backend:
- repair_planner.py: Project CRUD, LLM diagnostics, step navigation, workshop inventory, budget/skills, tool lending, 3D printer & robot arm stubs, timer, journal, snippets, device management
- function_calling.py: manage_repair tool with 45+ actions
- brain.py: Intent detection, activation, navigation interception
- personality.py: Workshop engineer personality extension
- websocket.py: emit_workshop() for real-time HUD updates
- settings.yaml: Workshop configuration section + deep_keywords

Phase 2 - Generation & Library:
- workshop_generator.py: Code/3D/SVG/website generation, BOM, docs, deterministic calculations (ohms law, LED resistor, wire gauge, etc.)
- workshop_library.py: ChromaDB RAG for technical reference documents

Phase 3 - UI:
- static/workshop/index.html: Full HUD with boot animation, 7 views (overview, steps, code, hardware, chat, calculator, journal), WebSocket integration, voice input, Prism.js syntax highlighting
- main.py: SPA route + 12 API endpoints for projects, files, calc, journal, stats, library, export
- ui/index.html: Workshop nav-item in settings
- app.js: renderWorkshop() settings tab with all config options

https://claude.ai/code/session_01T8NG1MqtpwXc35kxo4wTwW