### PR TITLE
fix: remove duplicate ambientIdleTimer declaration causing boot crash

### DIFF
--- a/assistant/static/workshop/index.html
+++ b/assistant/static/workshop/index.html
@@ -4996,7 +4996,6 @@ function restoreSidebarOrder() {
 }
 
 // ===== Schritt 8: Ambient Auto-Start =====
-let ambientIdleTimer = null;
 function resetAmbientIdle() {
     if (ambientIdleTimer) clearTimeout(ambientIdleTimer);
     if (localStorage.getItem('ws-ambient-auto') === 'on') {


### PR DESCRIPTION
The variable was declared in both the Phase 2 ambient mode section and the Phase 3 ambient auto-start section, causing a SyntaxError that prevented the entire script from loading.

https://claude.ai/code/session_01VPc2NKLeKV4F5RvDxR9EQr