### PR TITLE
Entity-Katalog: Such-zuerst UX, Annotation entfernen, kein 150er Limit

### DIFF
--- a/assistant/static/ui/index.html
+++ b/assistant/static/ui/index.html
@@ -1073,7 +1073,7 @@ input:focus,select:focus,textarea:focus { border-color:var(--accent); box-shadow
             </select>
           </div>
           <div class="form-group mb-0">
-            <input type="text" id="entitySearchInput" placeholder="Entity suchen..." oninput="filterEntities()">
+            <input type="text" id="entitySearchInput" placeholder="Entity suchen... (Name, ID, Rolle)" oninput="filterEntities()" style="min-width:250px;font-size:14px;">
           </div>
         </div>
 
@@ -1086,6 +1086,7 @@ input:focus,select:focus,textarea:focus { border-color:var(--accent); box-shadow
           <button class="btn btn-secondary btn-sm" onclick="batchSetRoom()">Raum</button>
           <button class="btn btn-secondary btn-sm" onclick="batchSetHidden(true)">Verstecken</button>
           <button class="btn btn-secondary btn-sm" onclick="batchSetHidden(false)">Einblenden</button>
+          <button class="btn btn-danger btn-sm" onclick="batchClearAnnotations()">Annotation entfernen</button>
           <button class="btn btn-secondary btn-sm" onclick="clearBatchSelection()">Aufheben</button>
         </div>
 


### PR DESCRIPTION
- Ohne Suchbegriff: nur annotierte Entities + Hinweis "Suchbegriff eingeben"
- Mit Suche: Relevanz-Scoring (exakt > Anfang > enthält), alle Treffer
- Lazy-Load statt hartem 150er Limit ("50 weitere laden" Button)
- "Annotation entfernen" Button pro Entity-Detail
- "Annotation entfernen" Batch-Button in der Toolbar
- Suchfeld größer und mit besserem Placeholder

https://claude.ai/code/session_01LBfR3n36e8m8FQ3afJcsqK