### PR TITLE
Entity-Katalog: Freitext-Eingabe mit Autocomplete für Räume und Rollen

### DIFF
--- a/assistant/static/ui/app.js
+++ b/assistant/static/ui/app.js
@@ -4672,6 +4672,16 @@ function toggleBatchSelect(eid, checked) {
   _updateBatchBar();
 }
 
+function toggleSelectAll(checked) {
+  // Alle aktuell sichtbaren Entities (de)selektieren
+  document.querySelectorAll('.ann-check').forEach(el => {
+    const eid = el.dataset.eid;
+    el.checked = checked;
+    if (checked) _annBatchSelected.add(eid); else _annBatchSelected.delete(eid);
+  });
+  _updateBatchBar();
+}
+
 function _updateBatchBar() {
   const bar = document.getElementById('annBatchBar');
   const cnt = document.getElementById('annBatchCount');
@@ -4687,6 +4697,8 @@ function _updateBatchBar() {
 function clearBatchSelection() {
   _annBatchSelected.clear();
   document.querySelectorAll('.ann-check').forEach(el => el.checked = false);
+  const selectAll = document.getElementById('annSelectAll');
+  if (selectAll) selectAll.checked = false;
   _updateBatchBar();
 }
 

--- a/assistant/static/ui/index.html
+++ b/assistant/static/ui/index.html
@@ -1080,9 +1080,11 @@ input:focus,select:focus,textarea:focus { border-color:var(--accent); box-shadow
         <!-- Batch-Toolbar (nur sichtbar bei Auswahl) -->
         <div id="annBatchBar" class="ann-batch-bar" style="display:none;">
           <span id="annBatchCount">0 ausgewaehlt</span>
-          <select id="annBatchRole" style="font-size:12px;padding:2px 6px;"><option value="">Rolle zuweisen...</option></select>
+          <input type="text" id="annBatchRole" placeholder="Rolle eingeben..." list="dl-batch-role" autocomplete="off" style="font-size:12px;padding:2px 6px;width:160px;" oninput="_updateRoleDatalist(this,'dl-batch-role')">
+          <datalist id="dl-batch-role"></datalist>
           <button class="btn btn-secondary btn-sm" onclick="batchSetRole()">Rolle</button>
-          <select id="annBatchRoom" style="font-size:12px;padding:2px 6px;"><option value="">Raum zuweisen...</option></select>
+          <input type="text" id="annBatchRoom" placeholder="Raum eingeben..." list="dl-batch-room" autocomplete="off" style="font-size:12px;padding:2px 6px;width:140px;" oninput="_updateRoomDatalist(this,'dl-batch-room')">
+          <datalist id="dl-batch-room"></datalist>
           <button class="btn btn-secondary btn-sm" onclick="batchSetRoom()">Raum</button>
           <button class="btn btn-secondary btn-sm" onclick="batchSetHidden(true)">Verstecken</button>
           <button class="btn btn-secondary btn-sm" onclick="batchSetHidden(false)">Einblenden</button>

--- a/assistant/static/ui/index.html
+++ b/assistant/static/ui/index.html
@@ -1075,6 +1075,11 @@ input:focus,select:focus,textarea:focus { border-color:var(--accent); box-shadow
           <div class="form-group mb-0">
             <input type="text" id="entitySearchInput" placeholder="Entity suchen... (Name, ID, Rolle)" oninput="filterEntities()" style="min-width:250px;font-size:14px;">
           </div>
+          <div class="form-group mb-0" style="display:flex;align-items:center;">
+            <label style="display:flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;margin:0;white-space:nowrap;">
+              <input type="checkbox" id="annSelectAll" onchange="toggleSelectAll(this.checked)"> Alle markieren
+            </label>
+          </div>
         </div>
 
         <!-- Batch-Toolbar (nur sichtbar bei Auswahl) -->


### PR DESCRIPTION
- Raum-Feld (pro Entity + Batch): Freitext-Input mit Datalist-Autocomplete statt starrem Dropdown — freie Eingabe, Vorschläge ab erstem Buchstaben
- Rollen-Feld (pro Entity + Batch): Freitext-Input mit Datalist-Autocomplete statt Select — Label wird automatisch zur Role-ID aufgelöst
- Rollen-Label-zu-ID-Lookup (_roleLabelToId) für korrekte Persistenz
- Batch-Toolbar: Inputs leeren sich nach Zuweisung

https://claude.ai/code/session_01LBfR3n36e8m8FQ3afJcsqK