### PR TITLE
Qwen 3.5 Upgrade: Modelle aktualisiert + dynamische UI-Modellauswahl

### DIFF
--- a/assistant/assistant/config.py
+++ b/assistant/assistant/config.py
@@ -25,10 +25,10 @@ class Settings(BaseSettings):
 
     # Ollama
     ollama_url: str = "http://localhost:11434"
-    model_fast: str = "qwen3:4b"
-    model_notify: str = "qwen3:8b"
-    model_smart: str = "qwen3:14b"
-    model_deep: str = "qwen3:32b"
+    model_fast: str = "qwen3.5:4b"
+    model_notify: str = "qwen3.5:4b"
+    model_smart: str = "qwen3.5:9b"
+    model_deep: str = "qwen3.5:27b"
 
     # MindHome Assistant Server
     assistant_host: str = "0.0.0.0"

--- a/assistant/assistant/conflict_resolver.py
+++ b/assistant/assistant/conflict_resolver.py
@@ -115,7 +115,7 @@ class ConflictResolver:
         # Mediations-Config
         med_cfg = cfg.get("mediation", {})
         self._mediation_enabled = med_cfg.get("enabled", True)
-        self._mediation_model = med_cfg.get("model", "qwen3:14b")
+        self._mediation_model = med_cfg.get("model", "qwen3.5:9b")
         self._mediation_max_tokens = int(med_cfg.get("max_tokens", 256))
         self._mediation_temperature = med_cfg.get("temperature", 0.7)
 

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -2544,7 +2544,7 @@ def _reload_all_modules(yaml_cfg: dict, changed_settings: dict):
             cr._resolution_cooldown = int(cfg.get("resolution_cooldown_seconds", 120))
             med_cfg = cfg.get("mediation", {})
             cr._mediation_enabled = med_cfg.get("enabled", True)
-            cr._mediation_model = med_cfg.get("model", "qwen3:14b")
+            cr._mediation_model = med_cfg.get("model", "qwen3.5:9b")
             cr._mediation_max_tokens = int(med_cfg.get("max_tokens", 256))
             cr._mediation_temperature = med_cfg.get("temperature", 0.7)
             cr._domain_configs = cfg.get("conflict_domains", {})
@@ -2668,7 +2668,7 @@ def _reload_all_modules(yaml_cfg: dict, changed_settings: dict):
             so._approval_mode = cfg.get("approval_mode", "manual")
             so._interval = cfg.get("analysis_interval", "weekly")
             so._max_proposals = cfg.get("max_proposals_per_cycle", 3)
-            so._model = cfg.get("model", "qwen3:14b")
+            so._model = cfg.get("model", "qwen3.5:9b")
             so._bounds = cfg.get("parameter_bounds", {})
             logger.info("SelfOptimization Settings aktualisiert (enabled=%s)", so._enabled)
         _try_reload("self_optimization", _reload_self_optimization)
@@ -6574,6 +6574,22 @@ async def ui_system_restart(token: str = ""):
     asyncio.ensure_future(_docker_restart())
 
     return {"success": True, "output": "Container wird neugestartet..."}
+
+
+@app.get("/api/ui/system/ollama-models")
+async def ui_system_ollama_models(token: str = ""):
+    """Gibt die Liste der installierten Ollama-Modelle zurueck (fuer UI-Dropdowns)."""
+    _check_token(token)
+    ok, data = await _ollama_api("/api/tags")
+    if not ok or not isinstance(data, dict):
+        return {"success": False, "models": []}
+    models = []
+    for m in data.get("models", []):
+        name = m.get("name", "")
+        if name:
+            size_gb = m.get("size", 0) / 1e9
+            models.append({"name": name, "size_gb": round(size_gb, 1)})
+    return {"success": True, "models": models}
 
 
 @app.post("/api/ui/system/update-models")

--- a/assistant/assistant/memory_extractor.py
+++ b/assistant/assistant/memory_extractor.py
@@ -87,7 +87,7 @@ class MemoryExtractor:
         # Config aus settings.yaml lesen
         mem_cfg = yaml_config.get("memory", {})
         self.enabled = mem_cfg.get("extraction_enabled", True)
-        self._extraction_model = mem_cfg.get("extraction_model", "qwen3:14b")
+        self._extraction_model = mem_cfg.get("extraction_model", "qwen3.5:4b")
         self._extraction_temperature = float(mem_cfg.get("extraction_temperature", 0.1))
         self._extraction_max_tokens = int(mem_cfg.get("extraction_max_tokens", 512))
         self._min_words = int(mem_cfg.get("extraction_min_words", _DEFAULT_MIN_WORDS))

--- a/assistant/assistant/model_router.py
+++ b/assistant/assistant/model_router.py
@@ -2,9 +2,9 @@
 Model Router - 3-Stufen LLM Routing (fast / smart / deep)
 
 Waehlt das richtige lokale LLM basierend auf Komplexitaet der Anfrage:
-  - Fast (3B): Einfache Befehle ("Licht an", "Musik stopp")
-  - Smart (14B): Fragen, Konversation, Standard-Interaktion
-  - Deep (32B): Komplexe Planung, Multi-Step Reasoning, Simulationen
+  - Fast (4B): Einfache Befehle ("Licht an", "Musik stopp")
+  - Smart (9B): Fragen, Konversation, Standard-Interaktion
+  - Deep (27B): Komplexe Planung, Multi-Step Reasoning, Simulationen
 
 Auto-Capability: Erkennt beim Start welche Modelle verfuegbar sind.
 Wenn das 32B-Modell nicht installiert ist, wird automatisch auf

--- a/assistant/assistant/ollama_client.py
+++ b/assistant/assistant/ollama_client.py
@@ -1,7 +1,7 @@
 """
 Ollama API Client - Kommunikation mit dem lokalen LLM
 
-Qwen 3 Kompatibilitaet:
+Qwen 3 / 3.5 Kompatibilitaet:
 - Stripped automatisch <think>...</think> Bloecke aus Antworten
 - Thinking Mode wird fuer Fast-Tier deaktiviert (spart Latenz)
 """

--- a/assistant/assistant/protocol_engine.py
+++ b/assistant/assistant/protocol_engine.py
@@ -371,7 +371,7 @@ class ProtocolEngine:
         try:
             response = await self.ollama.chat(
                 messages=[{"role": "user", "content": prompt}],
-                model=yaml_config.get("models", {}).get("fast", "qwen3:4b"),
+                model=yaml_config.get("models", {}).get("fast", "qwen3.5:4b"),
                 temperature=0.1,
                 max_tokens=512,
             )

--- a/assistant/assistant/self_optimization.py
+++ b/assistant/assistant/self_optimization.py
@@ -56,7 +56,7 @@ class SelfOptimization:
         self._approval_mode = self._cfg.get("approval_mode", "manual")
         self._interval = self._cfg.get("analysis_interval", "weekly")
         self._max_proposals = self._cfg.get("max_proposals_per_cycle", 3)
-        self._model = self._cfg.get("model", "qwen3:14b")
+        self._model = self._cfg.get("model", "qwen3.5:9b")
         self._bounds = self._cfg.get("parameter_bounds", {})
         # SICHERHEIT: Mindestmenge an immutable Keys, die NICHT per Config ueberschrieben werden kann
         _HARDCODED_IMMUTABLE = {"trust_levels", "security", "autonomy", "dashboard", "models"}

--- a/assistant/assistant/self_report.py
+++ b/assistant/assistant/self_report.py
@@ -26,7 +26,7 @@ class SelfReport:
         self.ollama = None
         self.enabled = False
         self._cfg = yaml_config.get("self_report", {})
-        self._model = self._cfg.get("model", "qwen3:14b")
+        self._model = self._cfg.get("model", "qwen3.5:9b")
         self._last_report_day: str = ""
 
     async def initialize(self, redis_client, ollama_client):

--- a/assistant/config/settings.yaml
+++ b/assistant/config/settings.yaml
@@ -134,9 +134,9 @@ autonomy:
 ollama:
   num_ctx: 4096
 models:
-  fast: qwen3:4b
-  smart: qwen3:14b
-  deep: qwen3:14b
+  fast: qwen3.5:4b
+  smart: qwen3.5:9b
+  deep: qwen3.5:27b
   enabled:
     fast: true
     smart: true
@@ -262,7 +262,7 @@ proactive:
 memory:
   extraction_enabled: true
   extraction_min_words: 5
-  extraction_model: qwen3:4b
+  extraction_model: qwen3.5:4b
   extraction_temperature: 0.1
   extraction_max_tokens: 512
   max_person_facts_in_context: 5
@@ -273,7 +273,7 @@ memory:
   default_confidence: 0.7
 planner:
   max_iterations: 5
-  model: qwen3:14b
+  model: qwen3.5:9b
   max_tokens: 512
   complex_keywords:
   - alles
@@ -397,7 +397,7 @@ feedback:
 summarizer:
   run_hour: 3
   run_minute: 0
-  model: qwen3:14b
+  model: qwen3.5:9b
   max_tokens_daily: 512
   max_tokens_weekly: 384
   max_tokens_monthly: 512
@@ -835,7 +835,7 @@ response_filter:
   max_response_sentences: 0
 correction:
   confidence: 0.95
-  model: qwen3:4b
+  model: qwen3.5:4b
   temperature: 0.1
 dashboard:
   setup_complete: false
@@ -917,7 +917,7 @@ conflict_resolution:
   use_trust_priority: true
   mediation:
     enabled: true
-    model: qwen3:14b
+    model: qwen3.5:9b
     max_tokens: 256
     temperature: 0.7
   conflict_domains:
@@ -941,7 +941,7 @@ self_optimization:
   analysis_interval: weekly
   approval_mode: manual
   max_proposals_per_cycle: 3
-  model: qwen3:14b
+  model: qwen3.5:9b
   rollback:
     enabled: true
     max_snapshots: 20
@@ -985,7 +985,7 @@ self_optimization:
 self_automation:
   enabled: true
   max_per_day: 5
-  model: qwen3:14b
+  model: qwen3.5:9b
   templates_file: config/automation_templates.yaml
 # --- Kamera-Integration ---
 cameras:
@@ -1243,7 +1243,7 @@ correction_memory:
 # Woechentlicher Selbst-Report ueber alle Lernsysteme
 self_report:
   enabled: true
-  model: qwen3:14b
+  model: qwen3.5:9b
 # Lernende Schwellwerte: Passt Parameter automatisch an (enge Grenzen)
 adaptive_thresholds:
   enabled: false          # Default OFF bis genug Daten gesammelt

--- a/assistant/config/settings.yaml.example
+++ b/assistant/config/settings.yaml.example
@@ -96,9 +96,9 @@ persons:
 autonomy:
   level: 2
 models:
-  fast: qwen3:4b
-  smart: qwen3:14b
-  deep: qwen3:32b
+  fast: qwen3.5:4b
+  smart: qwen3.5:9b
+  deep: qwen3.5:27b
   enabled:
     fast: true
     smart: true
@@ -213,7 +213,7 @@ proactive:
 memory:
   extraction_enabled: true
   extraction_min_words: 5
-  extraction_model: qwen3:4b
+  extraction_model: qwen3.5:4b
   extraction_temperature: 0.1
   extraction_max_tokens: 512
   max_person_facts_in_context: 5
@@ -224,7 +224,7 @@ memory:
   default_confidence: 0.7
 planner:
   max_iterations: 5
-  model: qwen3:14b
+  model: qwen3.5:9b
   max_tokens: 512
   complex_keywords:
   - alles
@@ -335,7 +335,7 @@ feedback:
 summarizer:
   run_hour: 3
   run_minute: 0
-  model: qwen3:14b
+  model: qwen3.5:9b
   max_tokens_daily: 512
   max_tokens_weekly: 384
   max_tokens_monthly: 512
@@ -658,7 +658,7 @@ response_filter:
   max_response_sentences: 0
 correction:
   confidence: 0.95
-  model: qwen3:4b
+  model: qwen3.5:4b
   temperature: 0.1
 dashboard:
   setup_complete: false
@@ -734,7 +734,7 @@ conflict_resolution:
   use_trust_priority: true
   mediation:
     enabled: true
-    model: qwen3:14b
+    model: qwen3.5:9b
     max_tokens: 256
     temperature: 0.7
   conflict_domains:
@@ -758,7 +758,7 @@ self_optimization:
   analysis_interval: weekly
   approval_mode: manual
   max_proposals_per_cycle: 3
-  model: qwen3:14b
+  model: qwen3.5:9b
   rollback:
     enabled: true
     max_snapshots: 20
@@ -790,7 +790,7 @@ self_optimization:
 self_automation:
   enabled: true
   max_per_day: 5
-  model: qwen3:14b
+  model: qwen3.5:9b
   templates_file: config/automation_templates.yaml
 # --- Kamera-Integration ---
 cameras:

--- a/assistant/static/ui/app.js
+++ b/assistant/static/ui/app.js
@@ -591,8 +591,11 @@ function mergeCurrentTabIntoS() {
 async function loadSettings() {
   try {
     S = await api('/api/ui/settings');
-    // Room-Profiles parallel laden
-    try { RP = await api('/api/ui/room-profiles'); } catch(e) { RP = {}; }
+    // Room-Profiles und Ollama-Modelle parallel laden
+    await Promise.all([
+      (async () => { try { RP = await api('/api/ui/room-profiles'); } catch(e) { RP = {}; } })(),
+      loadOllamaModels(),
+    ]);
     _rpDirty = false;
     renderCurrentTab();
     _initAutoSave();
@@ -1214,24 +1217,27 @@ function toggleChip(path, value) {
   scheduleAutoSave();
 }
 
-// Modell-Auswahl als Dropdown
+// Installierte Ollama-Modelle (wird beim Start geladen)
+let _ollamaModels = [];
+
+async function loadOllamaModels() {
+  try {
+    const data = await api('/api/ui/system/ollama-models');
+    if (data.success && data.models) {
+      _ollamaModels = data.models.map(m => ({
+        v: m.name,
+        l: `${m.name} (${m.size_gb} GB)`
+      }));
+    }
+  } catch(e) {
+    console.warn('Ollama-Modelle konnten nicht geladen werden:', e);
+  }
+}
+
+// Modell-Auswahl als Dropdown (zeigt nur installierte Modelle)
 function fModelSelect(path, label, hint='') {
   const v = getPath(S, path) ?? '';
-  const models = [
-    {v:'qwen3:4b', l:'Qwen3 4B (Schnell)'},
-    {v:'qwen3:8b', l:'Qwen3 8B (Ausgewogen)'},
-    {v:'qwen3:14b', l:'Qwen3 14B (Smart)'},
-    {v:'qwen3:32b', l:'Qwen3 32B (Deep)'},
-    {v:'llama3.2:3b', l:'Llama 3.2 3B'},
-    {v:'llama3.1:8b', l:'Llama 3.1 8B'},
-    {v:'gemma3:4b', l:'Gemma3 4B'},
-    {v:'gemma3:12b', l:'Gemma3 12B'},
-    {v:'gemma3:27b', l:'Gemma3 27B'},
-    {v:'phi4:14b', l:'Phi4 14B'},
-    {v:'mistral:7b', l:'Mistral 7B'},
-    {v:'deepseek-r1:14b', l:'DeepSeek-R1 14B'},
-    {v:'deepseek-r1:32b', l:'DeepSeek-R1 32B'},
-  ];
+  const models = _ollamaModels.length > 0 ? _ollamaModels : [{v, l: v || 'Kein Modell'}];
   // Aktuellen Wert in Liste sicherstellen
   const hasVal = models.some(m => m.v === v);
   let h = `<div class="form-group"><label>${label}${helpBtn(path)}</label><select data-path="${path}">`;


### PR DESCRIPTION
- Alle Modell-Referenzen von Qwen 3 auf Qwen 3.5 migriert (fast: 4b, smart: 9b, deep: 27b)
- UI-Modell-Dropdown zeigt jetzt nur noch installierte Ollama-Modelle (dynamisch via API)
- Neuer Endpoint /api/ui/system/ollama-models fuer Live-Modellliste
- Defaults in config.py, settings.yaml, settings.yaml.example und allen Modulen aktualisiert

https://claude.ai/code/session_019QDmPc4EXqXnXkSiAqQ2gi