### PR TITLE
Fix 500-Fehler auf /api/ui/lights bei brightness=null

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -3133,8 +3133,9 @@ async def ui_get_lights(token: str = ""):
                 continue
             attrs = s.get("attributes", {})
             brightness = None
-            if s.get("state") == "on" and "brightness" in attrs:
-                brightness = round(attrs["brightness"] / 255 * 100)
+            raw_br = attrs.get("brightness")
+            if s.get("state") == "on" and raw_br is not None:
+                brightness = round(raw_br / 255 * 100)
             lights.append({
                 "entity_id": eid,
                 "name": attrs.get("friendly_name", eid),


### PR DESCRIPTION
HA kann brightness: null zurueckgeben. Der alte Check "brightness" in attrs war True bei null-Wert, was zu TypeError bei der Division fuehrte.

https://claude.ai/code/session_019JhTiCTgEbYv5nmHrs6Kr1