### PR TITLE
Fix: Piper TTS liest SSML-Tags als Text vor ('5% speak prosody...')

### DIFF
--- a/assistant/assistant/tts_enhancer.py
+++ b/assistant/assistant/tts_enhancer.py
@@ -69,7 +69,7 @@ class TTSEnhancer:
     def __init__(self):
         # TTS Konfiguration
         tts_cfg = yaml_config.get("tts", {})
-        self.ssml_enabled = tts_cfg.get("ssml_enabled", True)
+        self.ssml_enabled = tts_cfg.get("ssml_enabled", False)
         self.prosody_variation = tts_cfg.get("prosody_variation", False)
 
         # Sprechgeschwindigkeit pro Typ
@@ -298,7 +298,10 @@ class TTSEnhancer:
         if pitch and pitch != "0%":
             prosody_attrs += f' pitch="{pitch}"'
 
-        parts.append(f'<speak><prosody{prosody_attrs}>')
+        if prosody_attrs:
+            parts.append(f'<speak><prosody{prosody_attrs}>')
+        else:
+            parts.append('<speak>')
 
         # F-059: User-Text XML-escapen um SSML-Injection zu verhindern
         # P-2: xml_escape jetzt auf Modul-Ebene importiert
@@ -334,7 +337,10 @@ class TTSEnhancer:
             if i < len(sentences) - 1:
                 parts.append(f'<break time="{self.pause_sentence}ms"/>')
 
-        parts.append('</prosody></speak>')
+        if prosody_attrs:
+            parts.append('</prosody></speak>')
+        else:
+            parts.append('</speak>')
 
         return "".join(parts)
 

--- a/assistant/config/settings.yaml
+++ b/assistant/config/settings.yaml
@@ -1183,7 +1183,7 @@ seasonal_actions:
     manual_override_hours: 2
 tts:
   entity: tts.piper
-  ssml_enabled: true
+  ssml_enabled: false
   speed:
     confirmation: 105
     warning: 85


### PR DESCRIPTION
Problem: Piper TTS unterstuetzt kein SSML. Wenn ssml_enabled=true (Default war true), generierte der TTS Enhancer SSML wie <speak><prosody pitch="+5%">Sehr wohl.</prosody></speak> und Piper las die Tags woertlich vor: 'speak prosody pitch plus 5 percent Sehr wohl prosody speak'.

Fix:
1. Default fuer ssml_enabled von true auf false geaendert
2. settings.yaml: ssml_enabled explizit auf false gesetzt
3. _generate_ssml(): Leere prosody-Tags vermieden — wenn weder speed noch pitch gesetzt sind, wird nur <speak>Text</speak> generiert statt <speak><prosody>Text</prosody></speak>

https://claude.ai/code/session_01AVNR6S3Y6PGSUAsnETwtdk