### PR TITLE
Fix: TimeAwareness NoneType crash bei room_motion_sensors: null

### DIFF
--- a/assistant/assistant/time_awareness.py
+++ b/assistant/assistant/time_awareness.py
@@ -250,7 +250,7 @@ class TimeAwareness:
         # Welche Raeume haben Bewegung?
         active_rooms = set()
         # Konfigurierte Motion-Sensoren aus multi_room nutzen
-        room_motion = yaml_config.get("multi_room", {}).get("room_motion_sensors", {})
+        room_motion = yaml_config.get("multi_room", {}).get("room_motion_sensors", {}) or {}
         motion_to_room = {}
         for room_name, sensor_id in room_motion.items():
             if sensor_id:


### PR DESCRIPTION
Error: 'NoneType' object has no attribute 'items'
Ursache: yaml_config multi_room.room_motion_sensors ist null/None, .get() Default {} greift nur bei fehlendem Key, nicht bei null-Value. Fix: 'or {}' fuer null-safety.

https://claude.ai/code/session_01AVNR6S3Y6PGSUAsnETwtdk