### PR TITLE
Fix: Startup-Crash durch torchaudio AttributeError in health_check

### DIFF
--- a/assistant/assistant/embedding_extractor.py
+++ b/assistant/assistant/embedding_extractor.py
@@ -107,5 +107,5 @@ def is_available() -> bool:
         import speechbrain  # noqa: F401
         import torchaudio  # noqa: F401
         return True
-    except ImportError:
+    except (ImportError, AttributeError, Exception):
         return False

--- a/assistant/assistant/speaker_recognition.py
+++ b/assistant/assistant/speaker_recognition.py
@@ -955,5 +955,8 @@ class SpeakerRecognition:
         """Gibt den Status zurueck."""
         if not self.enabled:
             return "disabled"
-        embeds = "embeddings:on" if embeddings_available() else "embeddings:off"
+        try:
+            embeds = "embeddings:on" if embeddings_available() else "embeddings:off"
+        except Exception:
+            embeds = "embeddings:error"
         return f"active ({len(self._profiles)} profiles, {len(self._device_mapping)} devices, {embeds})"


### PR DESCRIPTION
speechbrain-Import loest AttributeError aus weil torchaudio.list_audio_backends() in der installierten Version nicht existiert. Das crasht health_check() beim Startup und killt den ganzen Container (exit code 3, restart-loop).

Fix: embedding_extractor.is_available() faengt jetzt alle Exceptions ab, nicht nur ImportError. speaker_recognition.health_status() zusaetzlich mit try/except gesichert als Defense-in-Depth.

https://claude.ai/code/session_01AVNR6S3Y6PGSUAsnETwtdk