### PR TITLE
Fix: Staubsauger setzt Reinigung nicht fort nach Heimkehr+Abfahrt

### DIFF
--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -3417,7 +3417,7 @@ class ProactiveManager:
                     for s in (states or []):
                         if s.get("entity_id") == eid:
                             vac_state = s.get("state", "")
-                            if vac_state in ("cleaning", "returning"):
+                            if vac_state == "cleaning":
                                 cleaning_robots.append((floor, eid, robot))
                                 all_docked = False
                             elif vac_state not in ("docked", "idle"):
@@ -3425,7 +3425,9 @@ class ProactiveManager:
                             break
 
                 # Fall 1: Jemand kommt heim + Vacuum saugt → Pausieren + Dock
-                if anyone_home and cleaning_robots and guard_cfg.get("pause_on_arrival"):
+                # Guard: Nur wenn nicht schon pausiert (verhindert doppelte Befehle)
+                already_interrupted = _redis and await _redis.get("mha:vacuum:interrupted")
+                if anyone_home and cleaning_robots and guard_cfg.get("pause_on_arrival") and not already_interrupted:
                     logger.info("Vacuum-PresenceMonitor: Jemand ist zuhause — %d Roboter pausieren",
                                 len(cleaning_robots))
                     interrupted = []


### PR DESCRIPTION
Zwei Ursachen:
1. Crash-Loop (vorangegangener Commit): App startet nicht, Presence-Monitor laeuft nie lang genug fuer den 5-Min Resume-Delay.

2. Fall 1 (pause_on_arrival) feuert wiederholt alle 30s weil "returning" als "saugt gerade" zaehlt. Der Roboter bekommt in einer Endlosschleife pause+return_to_base Befehle waehrend er schon zur Dock faehrt.

Fix:
- "returning" aus cleaning_robots entfernt — nur "cleaning" loest Fall 1 aus. "returning" setzt weiterhin all_docked=False.
- Guard: Fall 1 feuert nicht wenn mha:vacuum:interrupted Key schon in Redis existiert (verhindert doppelte Pause-Befehle bei langsamem State-Update des Roboters).

https://claude.ai/code/session_01AVNR6S3Y6PGSUAsnETwtdk