### PR TITLE
Fix WebSocket rate-limit log spam and Anticipation NoneType crash

### DIFF
--- a/assistant/assistant/anticipation.py
+++ b/assistant/assistant/anticipation.py
@@ -41,9 +41,9 @@ class AnticipationEngine:
         # Konfiguration
         cfg = yaml_config.get("anticipation", {})
         self.enabled = cfg.get("enabled", True)
-        self.history_days = cfg.get("history_days", 30)
-        self.min_confidence = cfg.get("min_confidence", 0.6)
-        self.check_interval = cfg.get("check_interval_minutes", 15) * 60
+        self.history_days = cfg.get("history_days") or 30
+        self.min_confidence = cfg.get("min_confidence") or 0.6
+        self.check_interval = (cfg.get("check_interval_minutes") or 15) * 60
 
         thresholds = cfg.get("thresholds", {})
         self.threshold_ask = thresholds.get("ask", 0.6)
@@ -394,8 +394,8 @@ class AnticipationEngine:
         Min. 3 Wiederholungen der gleichen Kette.
         """
         causal_cfg = yaml_config.get("anticipation", {})
-        window_min = causal_cfg.get("causal_chain_window_min", 10)
-        min_occurrences = causal_cfg.get("causal_chain_min_occurrences", 3)
+        window_min = causal_cfg.get("causal_chain_window_min") or 10
+        min_occurrences = causal_cfg.get("causal_chain_min_occurrences") or 3
         window_sec = window_min * 60
 
         patterns = []

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -1500,6 +1500,7 @@ async def websocket_endpoint(websocket: WebSocket):
     _ws_msg_times: list[float] = []
     _WS_RATE_LIMIT = 30
     _WS_RATE_WINDOW = 10.0
+    _ws_rate_warned: float = 0.0  # Letzter Zeitpunkt der Rate-Limit-Warnung
     # Interrupt-Flag: wird vom Interrupt-Handler gesetzt, vom Stream-Callback geprueft
     _ws_interrupt_flag = False
     try:
@@ -1510,13 +1511,17 @@ async def websocket_endpoint(websocket: WebSocket):
             import time as _t
             now = _t.time()
             _ws_msg_times = [t for t in _ws_msg_times if now - t < _WS_RATE_WINDOW]
-            _ws_msg_times.append(now)
-            if len(_ws_msg_times) > _WS_RATE_LIMIT:
-                logger.warning("F-063: WebSocket Rate-Limit ueberschritten")
+            if len(_ws_msg_times) >= _WS_RATE_LIMIT:
+                # Nur alle 10 Sekunden loggen um Log-Spam zu vermeiden
+                if now - _ws_rate_warned > _WS_RATE_WINDOW:
+                    logger.warning("F-063: WebSocket Rate-Limit ueberschritten (%d msgs in %.0fs)",
+                                   len(_ws_msg_times), _WS_RATE_WINDOW)
+                    _ws_rate_warned = now
                 await ws_manager.send_personal(
                     websocket, "error", {"message": "Rate limit exceeded"}
                 )
                 continue
+            _ws_msg_times.append(now)
 
             try:
                 message = json.loads(data)


### PR DESCRIPTION
- Rate limiter: only count non-blocked messages (append after check, not before)
- Rate limiter: log warning max once per 10s window instead of every blocked message
- Anticipation: use `or` defaults for config values that may be null in YAML
  (fixes "unsupported operand type(s) for *: 'NoneType' and 'int'")

https://claude.ai/code/session_01X1uYXB69biM8CvpghiyPVC