### PR TITLE
Bump MindHome addon version to 1.5.7 (Build 98)

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.5.7 – Jarvis Voice (Error Logging & Bugfixes)
+
+### Bugfixes
+- **POST Error-Logging verbessert**: Exception-Typ wird jetzt angezeigt wenn `str(e)` leer ist (z.B. `ConnectionError` statt leere Meldung)
+
+---
+
 ## 1.5.6 – Jarvis Voice (Speech Service Fixes)
 
 ### Whisper Fix

--- a/addon/build.yaml
+++ b/addon/build.yaml
@@ -6,6 +6,6 @@ build_from:
 labels:
   org.opencontainers.image.title: "MindHome"
   org.opencontainers.image.description: "KI-basierte Smart Home Automatisierung"
-  org.opencontainers.image.version: "1.5.6"
+  org.opencontainers.image.version: "1.5.7"
   org.opencontainers.image.source: "https://github.com/Goifal/mindhome"
   org.opencontainers.image.licenses: "MIT"

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,6 +1,6 @@
 # MindHome - Home Assistant Add-on Configuration
 name: "MindHome"
-version: "1.5.6"
+version: "1.5.7"
 slug: "mindhome"
 description: "KI-basierte Smart Home Automatisierung — lernt deine Gewohnheiten und steuert dein Zuhause intelligent. 100% lokal."
 url: "https://github.com/Goifal/mindhome"

--- a/addon/rootfs/opt/mindhome/version.py
+++ b/addon/rootfs/opt/mindhome/version.py
@@ -4,12 +4,14 @@ MindHome Version Info
 Alle Dateien importieren von hier - Version nur an EINER Stelle ändern.
 """
 
-VERSION = "1.5.6"
-BUILD = 97
-BUILD_DATE = "2026-02-24"
+VERSION = "1.5.7"
+BUILD = 98
+BUILD_DATE = "2026-03-04"
 CODENAME = "Jarvis Voice"
 
 # Changelog
+# Build 98: v1.5.7 Jarvis Voice — Error Logging & Bugfixes
+#   - FIX: MindHome POST Error-Logging zeigt jetzt Exception-Typ (war leer bei leerer Message)
 # Build 97: v1.5.6 Jarvis Voice — Speech Service Fixes
 #   - FIX: Whisper crash — AsrModel/AsrProgram fehlender 'version' Parameter (wyoming 1.8.0)
 #   - FIX: Piper crash — --port durch --uri tcp://0.0.0.0:10200 ersetzt (wyoming-piper CLI)


### PR DESCRIPTION
Version bump for Home Assistant update mechanism.
Includes improved POST error logging from previous commit.

https://claude.ai/code/session_01X1uYXB69biM8CvpghiyPVC