### PR TITLE
Fix 3 runtime errors: action-log timeout, NoneType strip, weather for…

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -5695,7 +5695,7 @@ class AssistantBrain(BrainCallbacksMixin):
                     temperature=0.1,
                     max_tokens=80,
                 )
-                topic_text = topic_summary.strip()
+                topic_text = topic_summary.strip() if topic_summary else ""
                 if topic_text and len(topic_text) > 10:
                     fact = SemanticFact(
                         content=topic_text,

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -7483,6 +7483,9 @@ class FunctionExecutor:
                     "weather", "get_forecasts",
                     {"entity_id": entity_id, "type": "daily"},
                 )
+                # HA gibt ggf. {"service_response": {entity: {forecast: [...]}}} zurueck
+                if isinstance(result, dict) and "service_response" in result:
+                    result = result["service_response"]
                 if isinstance(result, list):
                     # Format 1: [{entity_id: {forecast: [...]}}]
                     for item in result:

--- a/assistant/assistant/ha_client.py
+++ b/assistant/assistant/ha_client.py
@@ -255,12 +255,13 @@ class HomeAssistantClient:
         """Oeffentlicher GET auf die MindHome Add-on API (z.B. /api/covers/configs)."""
         return await self._get_mindhome(path)
 
-    async def mindhome_post(self, path: str, data: dict, retries: int = 0) -> Any:
+    async def mindhome_post(self, path: str, data: dict, retries: int = 0, timeout: float | None = None) -> Any:
         """POST auf die MindHome Add-on API mit Circuit Breaker."""
         if not mindhome_breaker.is_available:
             logger.debug("MindHome Circuit Breaker OPEN — POST %s uebersprungen", path)
             return None
 
+        req_timeout = aiohttp.ClientTimeout(total=timeout) if timeout else None
         last_err = None
         for attempt in range(1 + retries):
             session = await self._get_session()
@@ -268,6 +269,7 @@ class HomeAssistantClient:
                 async with session.post(
                     f"{self.mindhome_url}{path}",
                     json=data,
+                    timeout=req_timeout,
                 ) as resp:
                     if resp.status == 200:
                         mindhome_breaker.record_success()
@@ -317,7 +319,7 @@ class HomeAssistantClient:
         logger.info("log_actions: %d Aktionen melden (%s)",
                      len(safe_actions),
                      [a["function"] for a in safe_actions])
-        result = await self.mindhome_post("/api/action-log", payload, retries=1)
+        result = await self.mindhome_post("/api/action-log", payload, retries=1, timeout=45)
         if result is None:
             logger.warning("log_actions: POST /api/action-log fehlgeschlagen (result=None)")
         else:

--- a/assistant/assistant/routine_engine.py
+++ b/assistant/assistant/routine_engine.py
@@ -425,6 +425,9 @@ class RoutineEngine:
             )
             if not result:
                 return []
+            # HA gibt ggf. {"service_response": {entity: {forecast: [...]}}} zurueck
+            if isinstance(result, dict) and "service_response" in result:
+                result = result["service_response"]
             # HA gibt verschiedene Formate zurueck je nach Version
             # Format 1: [{entity_id: {forecast: [...]}}]
             if isinstance(result, list):


### PR DESCRIPTION
…ecast

- ha_client: Add per-request timeout param to mindhome_post, use 45s for action-log (server SQLite busy_timeout is 30s, 20s client timeout was too short)
- brain: Guard topic_summary.strip() against None from ollama.generate()
- function_calling + routine_engine: Unwrap HA service_response wrapper in weather.get_forecasts response — forecast data was silently lost

https://claude.ai/code/session_01X1uYXB69biM8CvpghiyPVC