### PR TITLE
Fix LLM hallucination: discard ALL LLM text when tool calls present

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -3098,23 +3098,15 @@ class AssistantBrain(BrainCallbacksMixin):
             # PLUS den Tool-Call. Der Text wuerde die saubere Bestaetigung
             # (get_varied_confirmation) verhindern und Rohdaten per TTS sprechen.
             if tool_calls and response_text:
-                _action_tool_names = {
-                    "set_light", "set_light_all", "set_climate", "set_climate_curve",
-                    "set_climate_room", "activate_scene", "set_cover", "set_cover_all",
-                    "set_switch", "call_service", "play_media", "transfer_playback",
-                    "arm_security_system", "lock_door", "send_notification",
-                    "play_sound",
-                }
-                _tc_names = {
-                    tc.get("function", {}).get("name", "")
-                    for tc in tool_calls
-                }
-                if _tc_names and _tc_names <= _action_tool_names:
-                    logger.info(
-                        "LLM-Text verworfen (Action-Tool-Calls vorhanden): '%s'",
-                        response_text[:80],
-                    )
-                    response_text = ""
+                # LLM-Text verwerfen wenn Tool-Calls vorhanden — der Text wird
+                # durch Humanizer (Query-Tools) oder get_varied_confirmation
+                # (Action-Tools) ersetzt. Verhindert Halluzinationen: LLM erfindet
+                # sonst Aktionen/Zustaende die nie passiert sind.
+                logger.info(
+                    "LLM-Text verworfen (Tool-Calls vorhanden): '%s'",
+                    response_text[:80],
+                )
+                response_text = ""
 
             # 7b. Deterministischer Tool-Call hat Vorrang vor Text-Extraktion.
             # Text-Extraktion aus Reasoning ist unzuverlaessig (z.B. extrahiert
@@ -3596,6 +3588,9 @@ class AssistantBrain(BrainCallbacksMixin):
                                 f"{_form_hint} {_sarc_hint}{_mood_hint} "
                                 f"'{get_person_title(self._current_person)}' sparsam einsetzen. "
                                 "Keine Aufzaehlungen. Zahlen und Uhrzeiten EXAKT uebernehmen. "
+                                "NUR Fakten aus dem Antwort-Entwurf verwenden. "
+                                "NICHTS hinzufuegen, was nicht im Entwurf steht. "
+                                "Keine Aktionen oder Geraetezustaende erfinden. "
                                 f"Beispiele: 'Fuenf Grad, bewoelkt. Jacke empfohlen, {get_person_title(self._current_person)}.' | "
                                 "'Morgen um Viertel vor acht steht eine Blutabnahme an.' | "
                                 "'Im Buero 22.3 Grad, Luftfeuchtigkeit 51%. Passt.'"

--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -270,6 +270,7 @@ SPRACHSTIL:
 - UNTERSCHEIDE: "Mach Licht an" = Befehl (kurz). "Was denkst du ueber..." = Gespraech (ausfuehrlich). "Erzaehl mir von..." = Gespraech. "Ich hatte heute..." = Gespraech.
 {person_addressing}
 REGELN: Deutsch mit korrekten Umlauten. Aktionen ausfuehren, nicht darueber reden. Kontext-Daten unten nutzen. NIEMALS Werte erfinden.
+HALLUZINATIONS-VERBOT: Behaupte NIE, etwas getan zu haben, das du nicht per Tool-Call ausgefuehrt hast. Erfinde KEINE Geraetezustaende, Aktionen oder Ereignisse. Wenn du keine Daten hast, sag das. Sicherheitsrelevante Falschaussagen (z.B. "Rauchmelder deaktiviert") sind VERBOTEN.
 Bei Befehlen: Max {max_sentences} Saetze. Bei Gespraechen: So viel wie noetig, aber nie langweilig.
 
 GERAETESTEUERUNG — KRITISCH:


### PR DESCRIPTION
Root cause: When query tools (get_entity_state etc.) were called, the LLM's initial text was kept alongside the tool results. This text often contained hallucinated actions/states (e.g. "Rauchmelder offline gesetzt") that never happened.

Fixes:
- brain.py: Discard LLM text for ALL tool calls, not just action tools. The humanizer + refinement pipeline generates proper responses from actual tool results — no need for the LLM's speculative text.
- brain.py: Add grounding constraints to refinement prompt ("NUR Fakten aus dem Antwort-Entwurf verwenden, NICHTS hinzufuegen")
- personality.py: Add explicit anti-hallucination rule to system prompt forbidding fabricated actions or device states

https://claude.ai/code/session_01X1uYXB69biM8CvpghiyPVC