### PR TITLE
Fix device queries misclassified as knowledge + tighten refinement

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -3605,8 +3605,8 @@ class AssistantBrain(BrainCallbacksMixin):
                             self.ollama.chat(
                                 messages=feedback_messages,
                                 model=model,
-                                temperature=0.4,
-                                max_tokens=300,
+                                temperature=0.3,
+                                max_tokens=150,
                                 think=False,
                             ),
                             timeout=15.0,

--- a/assistant/assistant/pre_classifier.py
+++ b/assistant/assistant/pre_classifier.py
@@ -150,6 +150,9 @@ _SMART_HOME_KEYWORDS = [
     "musik", "tv", "fernseher", "kamera", "sensor",
     "steckdose", "schalter", "thermostat",
     "status", "hausstatus", "haus-status", "ueberblick",
+    "watt", "strom", "verbrauch", "energie", "kwh",
+    "eingeschalten", "eingeschaltet", "ausgeschaltet",
+    "smart plug", "smartplug",
 ]
 
 


### PR DESCRIPTION
Two issues causing hallucinated responses:

1. Pre-classifier: "Wie viel Watt verbraucht die Maschine" matched knowledge pattern ("wie viel") but _SMART_HOME_KEYWORDS lacked energy terms (watt, strom, verbrauch, etc.). Query went to LLM without tools → pure hallucination. Added missing keywords.

2. Tool-feedback refinement: temperature=0.4 and max_tokens=300 gave LLM too much creative freedom. "Alle Geraete normal" became a paragraph about croissants. Reduced to temperature=0.3 and max_tokens=150 (1-2 sentences don't need 300 tokens).

https://claude.ai/code/session_01X1uYXB69biM8CvpghiyPVC