### PR TITLE
Fix WebSocket disconnect message flood during brain processing

### DIFF
--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -1683,7 +1683,16 @@ async def websocket_endpoint(websocket: WebSocket):
                                             pass  # Keep-alive ignorieren
                                     except json.JSONDecodeError:
                                         pass
+                                    except WebSocketDisconnect:
+                                        logger.info("WebSocket disconnected waehrend Brain-Processing")
+                                        _ws_interrupt_flag = True
+                                        break
                                     except Exception as _interim_err:
+                                        _err_msg = str(_interim_err)
+                                        if "disconnect" in _err_msg.lower():
+                                            logger.info("WebSocket disconnected waehrend Brain-Processing")
+                                            _ws_interrupt_flag = True
+                                            break
                                         logger.warning(
                                             "Interim-Nachricht Fehler: %s", _interim_err,
                                         )


### PR DESCRIPTION
When the WebSocket disconnects while brain.process() is running, the interim receive loop kept calling websocket.receive_text() in a tight loop, logging 20+ "Cannot call receive once disconnect" warnings per second.

Fix: Catch WebSocketDisconnect and "disconnect" string in exceptions, set interrupt flag, and break out of the loop immediately.

https://claude.ai/code/session_01JfcWAH6ksPy9E1YtnTsW1c