### PR TITLE
Fix bare "Danke" not caught by smalltalk shortcut

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -7916,7 +7916,7 @@ class AssistantBrain(BrainCallbacksMixin):
             "danke jarvis", "danke dir", "danke schoen", "danke sehr",
             "vielen dank", "dankeschoen", "dankeschön", "danke schön",
         ]
-        if any(kw in t for kw in _thanks):
+        if any(kw in t for kw in _thanks) or t.strip().rstrip("!.") == "danke":
             _responses = [
                 f"Stets zu Diensten, {title}.",
                 f"Wie gewohnt, {title}.",

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -2015,7 +2015,7 @@ async def websocket_endpoint(websocket: WebSocket):
                                     try:
                                         result = _brain_task.result()
                                     except (asyncio.CancelledError, Exception) as e:
-                                        logger.info("Brain-Task abgebrochen: %s", type(e).__name__)
+                                        logger.info("Brain-Task abgebrochen: %s: %s", type(e).__name__, e)
 
                             # Ergebnis verarbeiten (nur wenn nicht unterbrochen)
                             if result and not _ws_interrupt_flag:


### PR DESCRIPTION
"Danke" without suffix (e.g. "danke jarvis") fell through to the LLM path and caused an error. Now bare "Danke" is handled directly by the smalltalk shortcut. Also improved Brain-Task error logging to show the actual error message, not just the exception type.

https://claude.ai/code/session_01JfcWAH6ksPy9E1YtnTsW1c