### PR TITLE
Fix brain timeouts: Redis N+1, aggressive model upgrade, reload

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -2367,21 +2367,23 @@ class AssistantBrain(BrainCallbacksMixin):
         # 3. Modell waehlen (mit kontext-basiertem Upgrade)
         model = self.model_router.select_model(text)
 
-        # Kontext-basiertes Upgrade: Wenn viele Datenquellen relevant sind,
-        # braucht das LLM ein staerkeres Modell zum Reasoning
+        # Kontext-basiertes Upgrade: Nur bei echtem Reasoning-Bedarf upgraden.
+        # Schwellwert 3: Verhindert dass normale Kontext-Signale (learned_patterns,
+        # live_insights) allein das teure Deep-Modell triggern — das fuehrte zu
+        # 60s-Timeouts und Fallback-Kaskade bei knappem VRAM.
         _upgrade_signals = 0
         if problem_solving_ctx:
-            _upgrade_signals += 2  # Problemloesung braucht Deep
+            _upgrade_signals += 3  # Problemloesung braucht Deep
         if whatif_prompt:
-            _upgrade_signals += 2  # Hypothetisches Denken braucht Deep
+            _upgrade_signals += 3  # Hypothetisches Denken braucht Deep
         if anticipation_suggestions or learned_patterns:
             _upgrade_signals += 1  # Intelligence Fusion = mehr Kontext
         if live_insights:
             _upgrade_signals += 1  # Aktive Insights = mehr zu verarbeiten
         if sec_score and sec_score.get("level") in ("warning", "critical"):
-            _upgrade_signals += 2  # Sicherheit = immer Deep
+            _upgrade_signals += 3  # Sicherheit = immer Deep
 
-        if _upgrade_signals >= 2 and model != self.model_router.model_deep:
+        if _upgrade_signals >= 3 and model != self.model_router.model_deep:
             _upgraded = self.model_router._cap_model(self.model_router.model_deep)
             if _upgraded != model:
                 logger.info("Model Upgrade %s -> %s (signals: %d)", model, _upgraded, _upgrade_signals)

--- a/assistant/assistant/learning_observer.py
+++ b/assistant/assistant/learning_observer.py
@@ -334,84 +334,96 @@ class LearningObserver:
         # Tages-Muster lesen
         # Key: mha:learning:patterns:[person:]entity:state:HH:MM
         # Achtung: time_slot ist HH:MM (enthaelt Doppelpunkt) → rsplit(":", 2)
-        cursor = 0
         try:
+            # Phase 1: Alle Keys per SCAN sammeln (kein GET pro Key)
+            all_keys: list[str] = []
+            cursor = 0
             while True:
                 cursor, keys = await self.redis.scan(
-                    cursor, match=f"{KEY_PATTERNS}:*", count=50
+                    cursor, match=f"{KEY_PATTERNS}:*", count=200
                 )
                 for key in keys:
-                    key_str = key.decode() if isinstance(key, bytes) else key
-                    count = await self.redis.get(key)
-                    if count:
-                        count_val = int(count)
-                        if count_val >= 2:  # Ab 2 Wiederholungen anzeigen
-                            suffix = key_str.replace(f"{KEY_PATTERNS}:", "")
-                            # rsplit 2 → ["[person:]entity:state", "HH", "MM"]
-                            parts = suffix.rsplit(":", 2)
-                            if len(parts) != 3 or not parts[1].isdigit():
-                                continue
-                            action, ts_hour, ts_min = parts
-                            time_slot = f"{ts_hour}:{ts_min}"
-
-                            pattern_person, entity_action = _parse_person_prefix(action)
-
-                            if person and pattern_person != person:
-                                continue
-
-                            entity_state = entity_action.rsplit(":", 1)
-                            patterns.append({
-                                "action": entity_action,
-                                "entity": entity_state[0] if len(entity_state) > 1 else entity_action,
-                                "time_slot": time_slot,
-                                "count": count_val,
-                                "weekday": -1,
-                                "person": pattern_person,
-                            })
+                    all_keys.append(key.decode() if isinstance(key, bytes) else key)
                 if cursor == 0:
                     break
+
+            # Phase 2: Batch-GET via mget statt N einzelner GETs
+            if all_keys:
+                values = await self.redis.mget(*all_keys)
+                for key_str, count in zip(all_keys, values):
+                    if not count:
+                        continue
+                    count_val = int(count)
+                    if count_val < 2:
+                        continue
+                    suffix = key_str.replace(f"{KEY_PATTERNS}:", "")
+                    parts = suffix.rsplit(":", 2)
+                    if len(parts) != 3 or not parts[1].isdigit():
+                        continue
+                    action, ts_hour, ts_min = parts
+                    time_slot = f"{ts_hour}:{ts_min}"
+
+                    pattern_person, entity_action = _parse_person_prefix(action)
+
+                    if person and pattern_person != person:
+                        continue
+
+                    entity_state = entity_action.rsplit(":", 1)
+                    patterns.append({
+                        "action": entity_action,
+                        "entity": entity_state[0] if len(entity_state) > 1 else entity_action,
+                        "time_slot": time_slot,
+                        "count": count_val,
+                        "weekday": -1,
+                        "person": pattern_person,
+                    })
         except Exception as e:
             logger.warning("L4: Daily patterns SCAN failed: %s", e)
 
         # Wochentag-Muster lesen
         # Key: mha:learning:weekday_patterns:[person:]entity:state:HH:MM:weekday
-        cursor = 0
         try:
+            all_keys = []
+            cursor = 0
             while True:
                 cursor, keys = await self.redis.scan(
-                    cursor, match=f"{KEY_WEEKDAY_PATTERNS}:*", count=50
+                    cursor, match=f"{KEY_WEEKDAY_PATTERNS}:*", count=200
                 )
-            for key in keys:
-                key_str = key.decode() if isinstance(key, bytes) else key
-                count = await self.redis.get(key)
-                if count:
-                    count_val = int(count)
-                    if count_val >= 2:
-                        suffix = key_str.replace(f"{KEY_WEEKDAY_PATTERNS}:", "")
-                        # rsplit 3 → ["[person:]entity:state", "HH", "MM", "weekday"]
-                        parts = suffix.rsplit(":", 3)
-                        if len(parts) != 4 or not parts[3].isdigit():
-                            continue
-                        action, ts_hour, ts_min, weekday_str = parts
-                        time_slot = f"{ts_hour}:{ts_min}"
-                        weekday_val = int(weekday_str)
-
-                        pattern_person, entity_action = _parse_person_prefix(action)
-
-                        if person and pattern_person != person:
-                            continue
-
-                        entity_state = entity_action.rsplit(":", 1)
-                        patterns.append({
-                            "action": entity_action,
-                            "entity": entity_state[0] if len(entity_state) > 1 else entity_action,
-                            "time_slot": time_slot,
-                            "count": count_val,
-                            "weekday": weekday_val,
-                            "person": pattern_person,
-                        })
+                for key in keys:
+                    all_keys.append(key.decode() if isinstance(key, bytes) else key)
                 if cursor == 0:
                     break
+
+            if all_keys:
+                values = await self.redis.mget(*all_keys)
+                for key_str, count in zip(all_keys, values):
+                    if not count:
+                        continue
+                    count_val = int(count)
+                    if count_val < 2:
+                        continue
+                    suffix = key_str.replace(f"{KEY_WEEKDAY_PATTERNS}:", "")
+                    parts = suffix.rsplit(":", 3)
+                    if len(parts) != 4 or not parts[3].isdigit():
+                        continue
+                    action, ts_hour, ts_min, weekday_str = parts
+                    time_slot = f"{ts_hour}:{ts_min}"
+                    weekday_val = int(weekday_str)
+
+                    pattern_person, entity_action = _parse_person_prefix(action)
+
+                    if person and pattern_person != person:
+                        continue
+
+                    entity_state = entity_action.rsplit(":", 1)
+                    patterns.append({
+                        "action": entity_action,
+                        "entity": entity_state[0] if len(entity_state) > 1 else entity_action,
+                        "time_slot": time_slot,
+                        "count": count_val,
+                        "weekday": weekday_val,
+                        "person": pattern_person,
+                    })
         except Exception as e:
             logger.warning("L5: Weekday patterns SCAN failed: %s", e)
 

--- a/assistant/assistant/model_router.py
+++ b/assistant/assistant/model_router.py
@@ -91,12 +91,21 @@ class ModelRouter:
 
     def reload_config(self):
         """
-        Laedt Enabled-Status und Keywords neu aus yaml_config.
+        Laedt Enabled-Status, Keywords UND Modellnamen neu aus yaml_config.
         Aufgerufen nach Settings-Aenderung ueber die UI.
         """
         old_fast = self._fast_enabled
         old_smart = self._smart_enabled
         old_deep = self._deep_enabled
+        old_model_fast = self.model_fast
+        old_model_smart = self.model_smart
+        old_model_deep = self.model_deep
+
+        # Modellnamen aus settings neu laden (config.py aktualisiert settings)
+        from .config import settings as cfg
+        self.model_fast = cfg.model_fast
+        self.model_smart = cfg.model_smart
+        self.model_deep = cfg.model_deep
 
         self._load_config()
         self._update_availability()
@@ -109,6 +118,12 @@ class ModelRouter:
             changes.append(f"Smart: {'AN' if self._smart_enabled else 'AUS'}")
         if old_deep != self._deep_enabled:
             changes.append(f"Deep: {'AN' if self._deep_enabled else 'AUS'}")
+        if old_model_fast != self.model_fast:
+            changes.append(f"Fast-Modell: {old_model_fast} -> {self.model_fast}")
+        if old_model_smart != self.model_smart:
+            changes.append(f"Smart-Modell: {old_model_smart} -> {self.model_smart}")
+        if old_model_deep != self.model_deep:
+            changes.append(f"Deep-Modell: {old_model_deep} -> {self.model_deep}")
 
         if changes:
             logger.info("Modell-Konfiguration geaendert: %s", ", ".join(changes))


### PR DESCRIPTION
3 fixes for extreme slowness (60s+ LLM timeouts, 30s task timeouts):

1. learned_patterns: Replace N+1 individual redis.get() per key with batch mget — eliminates the 30s timeout on large pattern sets. Also increase SCAN batch from 50 to 200.

2. Model upgrade threshold: Raise from 2 to 3 signals and bump strong signals (whatif, problem_solving, security) to weight 3. Previously, basic context (learned_patterns + live_insights) alone triggered upgrade to 27b, causing 60s timeout + fallback.

3. ModelRouter.reload_config(): Now also reloads model names from settings, not just enabled/disabled status. Fixes stale model references after settings.yaml changes without restart.

https://claude.ai/code/session_01DmtRv6njWovpDNUedjcPSm