### PR TITLE
fix: brain timeout + num_ctx routing fuer Deep-Modell (27B)

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -3023,7 +3023,10 @@ class AssistantBrain(BrainCallbacksMixin):
                 _max_resp = self.ollama.num_ctx // 4
                 response_tokens = max(response_tokens, min(2048, _max_resp))
 
-            llm_timeout = (cfg.yaml_config.get("context") or {}).get("llm_timeout", 60)
+            # Model-spezifischer Timeout: Deep-Modelle (27B+) brauchen mehr Zeit
+            # fuer Prompt-Eval bei grossem Context. ollama_client._get_timeout()
+            # liefert tier-spezifische Werte (Fast=30, Smart=45, Deep=120).
+            llm_timeout = self.ollama._get_timeout(model)
 
             # Tool-Filter: set_vacuum/get_vacuum nur anbieten wenn
             # (a) vacuum.enabled in settings.yaml UND

--- a/assistant/assistant/constants.py
+++ b/assistant/assistant/constants.py
@@ -14,7 +14,7 @@ from typing import Final
 # Ollama LLM Timeouts
 LLM_TIMEOUT_FAST: Final[int] = 30
 LLM_TIMEOUT_SMART: Final[int] = 45
-LLM_TIMEOUT_DEEP: Final[int] = 60
+LLM_TIMEOUT_DEEP: Final[int] = 120
 LLM_TIMEOUT_STREAM: Final[int] = 120
 LLM_TIMEOUT_AVAILABILITY: Final[int] = 5
 

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -3696,6 +3696,18 @@ async def ui_update_settings(req: SettingsUpdateFull, token: str = ""):
         # Household → persons/trust_levels synchronisieren
         cfg.apply_household_to_config()
 
+        # Modellnamen in settings synchronisieren (damit num_ctx_for/
+        # _get_timeout das richtige Tier erkennen — ohne das bleibt
+        # z.B. model_deep auf dem Startwert und num_ctx_for() gibt
+        # den falschen num_ctx zurueck).
+        _models_new = cfg.yaml_config.get("models", {})
+        if _models_new.get("fast"):
+            cfg.settings.model_fast = _models_new["fast"]
+        if _models_new.get("smart"):
+            cfg.settings.model_smart = _models_new["smart"]
+        if _models_new.get("deep"):
+            cfg.settings.model_deep = _models_new["deep"]
+
         # ModelRouter neu laden (Enabled-Status, Keywords)
         if hasattr(brain, "model_router") and brain.model_router:
             brain.model_router.reload_config()


### PR DESCRIPTION
3 Bugs gefixt:
1. Brain nutzte fixen 60s Timeout fuer ALLE Modelle — jetzt model-spezifisch via ollama_client._get_timeout() (Fast=30, Smart=45, Deep=120)
2. LLM_TIMEOUT_DEEP von 60s auf 120s erhoeht — 27B mit 16K Context braucht mehr Zeit fuer Prompt-Eval auf RTX 3090
3. settings.model_* wurde bei UI-Aenderungen nicht aktualisiert — dadurch erkannte num_ctx_for() das falsche Modell-Tier und gab num_ctx=4096 statt num_ctx_smart=8192 zurueck. Sektionen wurden unnoetig gedropt.

https://claude.ai/code/session_01DmtRv6njWovpDNUedjcPSm