### PR TITLE
Fix: TTS spricht wieder — sounds.enabled blockierte auch Sprache

### DIFF
--- a/assistant/assistant/sound_manager.py
+++ b/assistant/assistant/sound_manager.py
@@ -508,11 +508,7 @@ class SoundManager:
         Returns:
             True wenn erfolgreich.
         """
-        logger.info("speak_response aufgerufen: text='%s', room=%s, tts_data_keys=%s",
-                    text[:50] if text else '', room, list((tts_data or {}).keys()))
-        if not self.enabled:
-            logger.warning("speak_response: SoundManager DISABLED")
-            return False
+        # TTS ist IMMER aktiv — sounds.enabled betrifft nur Event-Sounds (Chimes)
 
         tts_data = tts_data or {}
 


### PR DESCRIPTION
sounds.enabled (Sound-Effekte Toggle) deaktivierte auch speak_response(). TTS-Sprachausgabe ist jetzt IMMER aktiv — der Toggle betrifft nur Event-Sounds (Chimes/Pings). Debug-Logging entfernt.

https://claude.ai/code/session_01CzxA69EBATDQ44Fw22FGhY