### PR TITLE
Bettsensor: konfigurierbare Aus-Verzögerung (off_delay) pro Bett

### DIFF
--- a/assistant/assistant/config.py
+++ b/assistant/assistant/config.py
@@ -357,6 +357,17 @@ def get_room_bed_sensors(room_cfg: dict) -> list[str]:
     return result
 
 
+def get_bed_sensor_off_delay(room_cfg: dict, entity_id: str) -> int:
+    """Gibt die off_delay (Sekunden) fuer einen bestimmten Bettsensor zurueck.
+
+    Default: 0 (sofort).
+    """
+    for entry in (room_cfg.get("bed_sensors") or []):
+        if isinstance(entry, dict) and entry.get("sensor") == entity_id:
+            return int(entry.get("off_delay", 0))
+    return 0
+
+
 def get_all_bed_sensors() -> list[str]:
     """Sammelt alle Bettsensoren aus room_profiles.yaml (zentrale Quelle).
 

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -1370,22 +1370,49 @@ class ProactiveManager:
             le = getattr(self.brain, "light_engine", None)
             if not le:
                 return
-            from .config import get_room_bed_sensors
+            from .config import get_room_bed_sensors, get_bed_sensor_off_delay
             profiles = get_room_profiles()
             rooms = profiles.get("rooms", {})
             room = None
-            for room_name, room_cfg in rooms.items():
-                if entity_id in get_room_bed_sensors(room_cfg):
+            room_cfg = None
+            for room_name, rcfg in rooms.items():
+                if entity_id in get_room_bed_sensors(rcfg):
                     room = room_name
+                    room_cfg = rcfg
                     break
             if not room:
                 return
             if new_val == "on" and old_val != "on":
+                # Bei on: sofort, evtl. laufenden off-Timer abbrechen
+                timer_key = f"_bed_off_timer_{entity_id}"
+                existing = getattr(self, timer_key, None)
+                if existing and not existing.done():
+                    existing.cancel()
+                    logger.debug("Bettsensor %s: off-delay abgebrochen (wieder belegt)", entity_id)
                 await le.on_bed_occupied(entity_id, room)
             elif new_val == "off" and old_val == "on":
-                await le.on_bed_clear(entity_id, room)
+                off_delay = get_bed_sensor_off_delay(room_cfg, entity_id)
+                if off_delay > 0:
+                    logger.debug("Bettsensor %s: off-delay %ds gestartet", entity_id, off_delay)
+                    timer_key = f"_bed_off_timer_{entity_id}"
+                    task = asyncio.create_task(self._delayed_bed_clear(le, entity_id, room, off_delay, timer_key))
+                    setattr(self, timer_key, task)
+                else:
+                    await le.on_bed_clear(entity_id, room)
         except Exception as e:
             logger.debug("Bettsensor-Licht Check fehlgeschlagen: %s", e)
+
+    async def _delayed_bed_clear(self, le, entity_id: str, room: str, delay: int, timer_key: str):
+        """Wartet delay Sekunden und fuehrt dann on_bed_clear aus, wenn nicht abgebrochen."""
+        try:
+            await asyncio.sleep(delay)
+            logger.debug("Bettsensor %s: off-delay abgelaufen → bed_clear", entity_id)
+            await le.on_bed_clear(entity_id, room)
+        except asyncio.CancelledError:
+            logger.debug("Bettsensor %s: off-delay wurde abgebrochen", entity_id)
+        finally:
+            if hasattr(self, timer_key):
+                delattr(self, timer_key)
 
     async def _check_lux_sensor_event(self, entity_id: str, new_val: str):
         """Lux-Sensor → LightEngine für adaptive Helligkeit."""

--- a/assistant/static/ui/app.js
+++ b/assistant/static/ui/app.js
@@ -7550,7 +7550,7 @@ function renderCentralBedSensors() {
   for (const name of roomNames) {
     const beds = _getBedSensorsForRoom(name);
     for (let i = 0; i < beds.length; i++) {
-      entries.push({room: name, index: i, sensor: beds[i].sensor || '', person: beds[i].person || ''});
+      entries.push({room: name, index: i, sensor: beds[i].sensor || '', person: beds[i].person || '', off_delay: beds[i].off_delay ?? 0});
     }
   }
 
@@ -7577,6 +7577,16 @@ function renderCentralBedSensors() {
       }
       html += '</select>';
     }
+    // Zeile 4: Off-Delay Slider (Verzögerung bei Aus-Erkennung)
+    const delayVal = e.off_delay || 0;
+    html += '<div style="margin-top:8px;">';
+    html += '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:2px;">';
+    html += '<label style="font-size:11px;color:var(--text-muted);">&#9202; Aus-Verzoegerung</label>';
+    html += '<span id="bedDelay_val_' + esc(e.room) + '_' + e.index + '" style="font-size:11px;color:var(--accent);font-weight:600;">' + delayVal + 's</span>';
+    html += '</div>';
+    html += '<input type="range" min="0" max="30" step="1" value="' + delayVal + '" style="width:100%;accent-color:var(--accent);" oninput="document.getElementById(\'bedDelay_val_' + esc(e.room) + '_' + e.index + '\').textContent=this.value+\'s\'" onchange="_updateBedEntry(\'' + esc(e.room) + '\',' + e.index + ',\'off_delay\',parseInt(this.value))">';
+    html += '<div style="display:flex;justify-content:space-between;font-size:9px;color:var(--text-muted);"><span>0s (sofort)</span><span>30s</span></div>';
+    html += '</div>';
     html += '</div>';
   }
 
@@ -7601,7 +7611,7 @@ function _addBedEntry() {
   const room = sel.value;
   // Kopie der bestehenden Betten + neues leeres Bett
   const beds = _getBedSensorsForRoom(room).slice();
-  beds.push({sensor: '', person: ''});
+  beds.push({sensor: '', person: '', off_delay: 0});
   _setBedSensorsForRoom(room, beds);
   renderCentralBedSensors();
 }


### PR DESCRIPTION
Fügt einen Slider (0-30 Sekunden) pro Bett im Bettsensoren-UI hinzu. Verhindert Fehlauslösungen bei kurzen Sensor-Unterbrechungen.

- UI: off_delay Slider pro Bett-Eintrag (0s sofort bis 30s)
- Backend: Verzögerter bed_clear mit Cancel bei erneutem on
- Config: get_bed_sensor_off_delay() Helper

https://claude.ai/code/session_01CzxA69EBATDQ44Fw22FGhY