### PR TITLE
Fix: Geräte-Trigger × Button auf Mobile nicht klickbar

### DIFF
--- a/assistant/static/ui/app.js
+++ b/assistant/static/ui/app.js
@@ -4004,7 +4004,7 @@ function renderScenes() {
         <div class="scene-field">
           <span class="scene-field-label">Geräte-Trigger</span>
           <div class="scene-device-triggers" data-scene-id="${esc(sc.id)}">
-            ${(sc.device_triggers||[]).map((dt, i) => `<div class="scene-dt-row" style="display:flex;gap:4px;margin-bottom:4px;">
+            ${(sc.device_triggers||[]).map((dt, i) => `<div class="scene-dt-row" style="display:flex;gap:4px;margin-bottom:4px;align-items:center;">
               <div class="entity-pick-wrap" style="position:relative;flex:1;">
                 <input type="text" class="scene-dt-input form-input entity-pick-input" value="${esc(dt)}"
                   placeholder="z.B. media_player.tv, binary_sensor.button"
@@ -4015,7 +4015,7 @@ function renderScenes() {
                   style="font-size:11px;font-family:var(--mono);">
                 <div class="entity-pick-dropdown" style="display:none;"></div>
               </div>
-              <button class="btn btn-sm" style="padding:2px 6px;font-size:11px;" onclick="removeSceneDeviceTrigger('${esc(sc.id)}',${i})">&#10005;</button>
+              <button type="button" class="btn btn-sm scene-dt-rm" style="padding:6px 10px;font-size:14px;min-width:36px;min-height:36px;z-index:10000;position:relative;flex-shrink:0;color:var(--danger,#ef4444);" onclick="event.stopPropagation();removeSceneDeviceTrigger('${esc(sc.id)}',${i})" ontouchend="event.preventDefault();event.stopPropagation();removeSceneDeviceTrigger('${esc(sc.id)}',${i})">&#10005;</button>
             </div>`).join('')}
             <button class="btn btn-sm" style="padding:2px 8px;font-size:11px;margin-top:2px;" onclick="addSceneDeviceTrigger('${esc(sc.id)}')">+ Geraet</button>
           </div>
@@ -4107,7 +4107,13 @@ function addSceneDeviceTrigger(sceneId) {
   renderCurrentTab();
 }
 
+let _dtRemovePending = false;
 function removeSceneDeviceTrigger(sceneId, index) {
+  // Debounce: ontouchend + onclick können beide feuern
+  if (_dtRemovePending) return;
+  _dtRemovePending = true;
+  setTimeout(() => { _dtRemovePending = false; }, 300);
+
   const scenes = _getScenes();
   const sc = scenes.find(s => s.id === sceneId);
   if (!sc || !sc.device_triggers) return;

--- a/assistant/static/ui/index.html
+++ b/assistant/static/ui/index.html
@@ -618,6 +618,7 @@ textarea { resize:vertical; min-height:70px; font-family:var(--mono); font-size:
 .scene-field input[type="range"] { flex:1; accent-color:var(--accent); }
 .scene-silence-toggle { display:flex; align-items:center; gap:6px; font-size:11px; cursor:pointer; color:var(--text-secondary); }
 .scene-silence-toggle input { accent-color:var(--warning, #f59e0b); width:16px; height:16px; }
+.scene-dt-rm { touch-action:manipulation; -webkit-tap-highlight-color:transparent; }
 @media (max-width:640px) {
   .scene-grid { grid-template-columns:1fr; }
   .scene-card-body { gap:4px; }


### PR DESCRIPTION
- Touch-Target von ~15px auf min 36px vergrössert
- type="button" hinzugefügt (verhindert Form-Submit)
- z-index:10000 damit Button über Entity-Picker-Dropdown liegt
- ontouchend Handler als Fallback für Mobile
- Debounce gegen Doppel-Auslösung (ontouchend + onclick)
- touch-action:manipulation CSS für besseres Mobile-Verhalten
- Button rot gefärbt für bessere Sichtbarkeit

https://claude.ai/code/session_01QdGJzcv7AGWSgT3vvpxSas