### PR TITLE
Fix runtime crash: formality_section dict has no .strip()

### DIFF
--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -1639,13 +1639,17 @@ class PersonalityEngine:
             effective_score = min(formality_score + 20, 70)
 
         if effective_score >= 70:
-            return self._formality_prompts.get("formal", "")
+            val = self._formality_prompts.get("formal", "")
         elif effective_score >= 50:
-            return self._formality_prompts.get("butler", "")
+            val = self._formality_prompts.get("butler", "")
         elif effective_score >= 35:
-            return self._formality_prompts.get("locker", "")
+            val = self._formality_prompts.get("locker", "")
         else:
-            return self._formality_prompts.get("freund", "")
+            val = self._formality_prompts.get("freund", "")
+        # Guard: config may deliver dicts instead of plain strings
+        if isinstance(val, dict):
+            val = val.get("text", val.get("prompt", str(val)))
+        return str(val) if val else ""
 
     # ------------------------------------------------------------------
     # Running Gags (Phase 6.9)


### PR DESCRIPTION
_build_formality_section could return a dict if the personality config stored structured values instead of plain strings. Add a guard to always return a string.

https://claude.ai/code/session_01Y9b164VwkzdYSf9yZArAYe