### PR TITLE
Fix device control frustration: pre-classifier, mood override, entity…

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -3098,15 +3098,47 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         _cl_cfg = cfg.yaml_config.get("character_lock", {})
         if (_cl_cfg.get("enabled", True) and _cl_cfg.get("mid_conversation_reminder", True)
                 and conv_tokens_used > 200):
-            _reminder = (
-                "[REMINDER] Du bist J.A.R.V.I.S. — trocken, praezise, Butler-Ton. "
-                "Kurz. Keine Listen. Erfinde NICHTS. NUR vorhandene Daten nutzen."
-            )
+            _current_mood = getattr(self, "_current_mood", "neutral")
+            if _current_mood in ("frustrated", "stressed"):
+                _reminder = (
+                    "[REMINDER] Du bist J.A.R.V.I.S. — trocken, praezise, Butler-Ton. "
+                    "Kurz. Keine Listen. Erfinde NICHTS. NUR vorhandene Daten nutzen. "
+                    "WICHTIG: User ist frustriert. MAX 1-2 Saetze. Sofort handeln, nicht fragen. "
+                    "Wenn du ein Geraet nicht findest, nutze get_switches mit dem richtigen Raum."
+                )
+            else:
+                _reminder = (
+                    "[REMINDER] Du bist J.A.R.V.I.S. — trocken, praezise, Butler-Ton. "
+                    "Kurz. Keine Listen. Erfinde NICHTS. NUR vorhandene Daten nutzen."
+                )
             messages.append({"role": "system", "content": _reminder})
 
+        # Raum-Kontext aus letzten Nachrichten extrahieren
+        # Hilft dem LLM den richtigen Raum zu nutzen wenn der User
+        # in Folge-Befehlen keinen Raum mehr explizit nennt
+        from .function_calling import _mindhome_rooms
+        _room_keywords = [r.lower() for r in _mindhome_rooms] if _mindhome_rooms else []
+        _last_mentioned_room = None
+        for msg in reversed(recent):
+            content_lower = (msg.get("content") or "").lower()
+            for rk in _room_keywords:
+                if rk in content_lower:
+                    _last_mentioned_room = rk
+                    break
+            if _last_mentioned_room:
+                break
+
         # Situation Delta als User-Message-Prefix (prominenter als System-Prompt-Sektion)
-        if situation_delta:
+        _room_hint = ""
+        if _last_mentioned_room and _last_mentioned_room not in text.lower():
+            _room_hint = f"Zuletzt genannter Raum: {_last_mentioned_room}"
+
+        if situation_delta and _room_hint:
+            user_content = f"[KONTEXT: {situation_delta.strip()} | {_room_hint}]\n{text}"
+        elif situation_delta:
             user_content = f"[KONTEXT: {situation_delta.strip()}]\n{text}"
+        elif _room_hint:
+            user_content = f"[KONTEXT: {_room_hint}]\n{text}"
         else:
             user_content = text
         messages.append({"role": "user", "content": user_content})
@@ -5007,6 +5039,14 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
             r'\brun_scene\b', r'\brun_script\b', r'\brun_automation\b',
             r'<tool_call>.*?</tool_call>',
             r'\{\s*"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:.*?\}',
+            # SSML-Tags: LLM gibt manchmal TTS-Markup in den Text aus
+            r'</?speak>',
+            r'<prosody[^>]*>',
+            r'</prosody>',
+            r'\bprosody\b',
+            r'</?break[^>]*>',
+            r'</?emphasis[^>]*>',
+            r'<lang[^>]*>.*?</lang>',
         ]
         for _ml_pat in _meta_leak_patterns:
             _new = re.sub(_ml_pat, '', text, flags=re.IGNORECASE | re.DOTALL)
@@ -5379,7 +5419,10 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         # Verbessertes Satz-Splitting: Schutzt Abkuerzungen, Dezimalzahlen und Auslassungspunkte
         max_sentences = max_sentences_override or filter_config.get("max_response_sentences", 0)
         if max_sentences > 0 and not max_sentences_override and getattr(self, "_active_conversation_mode", False):
-            max_sentences = 0  # Unbegrenzt im Gesprächsmodus
+            # Bei Frustration/Stress: Satz-Limit beibehalten trotz Gesprächsmodus
+            _current_mood = getattr(self, "_current_mood", "neutral")
+            if _current_mood not in ("frustrated", "stressed"):
+                max_sentences = 0  # Unbegrenzt im Gesprächsmodus (nur bei guter/neutraler Stimmung)
         if max_sentences > 0:
             # Schutz-Tokens: Bekannte Abkuerzungen und Muster VOR dem Split ersetzen
             _protected = text

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -7139,6 +7139,34 @@ class FunctionExecutor:
                     best_match = entity_id
                     best_len = score
 
+        # Phase 3: Erweiterter Fuzzy-Search — Einzelwort-Matching
+        # Wenn Phase 1+2 nichts finden, versuche Teilwörter des Suchbegriffs
+        # gegen alle Entities im Domain zu matchen
+        if not best_match:
+            search_words = [w for w in search_norm.split() if len(w) > 3]
+            if search_words:
+                all_entities = [
+                    s for s in (states or await self.ha.get_states() or [])
+                    if s.get("entity_id", "").startswith(f"{domain}.")
+                    and not self.is_entity_hidden(s.get("entity_id", ""))
+                ]
+                word_matches: list[tuple[int, int, str]] = []
+                for entity in all_entities:
+                    eid = entity.get("entity_id", "").lower()
+                    fname = (entity.get("attributes", {}).get("friendly_name", "") or "").lower()
+                    eid_norm = self._normalize_name(eid.split(".", 1)[1] if "." in eid else eid)
+                    fname_norm = self._normalize_name(fname)
+                    match_count = sum(1 for w in search_words if w in eid_norm or w in fname_norm)
+                    if match_count > 0:
+                        word_matches.append((match_count, len(fname_norm), entity.get("entity_id")))
+                if word_matches:
+                    word_matches.sort(key=lambda x: (-x[0], x[1]))  # Meiste Treffer, kürzester Name
+                    best_match = word_matches[0][2]
+                    logger.info(
+                        "_find_entity: Fuzzy-Match '%s' -> %s (%d Wort-Treffer)",
+                        search, best_match, word_matches[0][0],
+                    )
+
         if not best_match:
             # Diagnose: Alle verfügbaren Entities dieser Domain loggen
             available = [

--- a/assistant/assistant/ha_client.py
+++ b/assistant/assistant/ha_client.py
@@ -358,7 +358,7 @@ class HomeAssistantClient:
         logger.info("log_actions: %d Aktionen melden (%s)",
                      len(safe_actions),
                      [a["function"] for a in safe_actions])
-        result = await self.mindhome_post("/api/action-log", payload, retries=1, timeout=45)
+        result = await self.mindhome_post("/api/action-log", payload, retries=0, timeout=10)
         if result is None:
             logger.warning("log_actions: POST /api/action-log fehlgeschlagen (result=None)")
         else:

--- a/assistant/assistant/pre_classifier.py
+++ b/assistant/assistant/pre_classifier.py
@@ -54,7 +54,7 @@ PROFILE_DEVICE_FAST = RequestProfile(
     need_activity=False,
     need_room_profile=True,       # Raum-Kontext fuer Geraete-Zuordnung
     need_memories=False,
-    need_mood=False,
+    need_mood=True,               # Mood auch bei Device-Commands — Frustration muss erkannt werden
     need_formality=False,
     need_irony=False,
     need_time_hints=True,         # Zeitkontext ist wichtig (z.B. "Licht aus" um 3 Uhr)
@@ -145,6 +145,12 @@ _DEVICE_VERBS_EMBEDDED = re.compile(
     r"|aktivieren?\w*|deaktivieren?\w*|abdunkeln?\w*|aufdrehen?\w*|zudrehen?\w*"
     r"|hochfahren?\w*|runterfahren?\w*|oeffnen?\w*|schliessen?\w*"
     r"|abspielen?\w*|stoppen?\w*|pausieren?\w*)\b",
+)
+
+# Trennbare Verben: "schalte die Maschine aus", "mach das Licht an"
+# Deutsche Trennverben haben den Praefix am Satzende
+_DEVICE_VERBS_SEPARATED = re.compile(
+    r"\b(mach|schalt\w*|stell\w*|dreh\w*|fahr\w*)\b.+\b(ein|aus|an|ab|auf|zu|um|hoch|runter)\b"
 )
 
 _DEVICE_NOUNS = [
@@ -250,10 +256,22 @@ class PreClassifier:
 
         # 1b. Eingebettete Device-Verben: "Ich will dass du X ausschaltest"
         #     Erkennt konjugierte Formen wie "ausschaltest", "einschalten", "anmachen"
-        if word_count <= 12 and not _is_question:
+        if word_count <= 16 and not _is_question:
             if _DEVICE_VERBS_EMBEDDED.search(text_lower):
                 logger.debug("PreClassifier: DEVICE_FAST (embedded verb: %s)", text)
                 return PROFILE_DEVICE_FAST
+
+        # 1c. Trennbare Verben: "schalte die Maschine aus", "mach das Licht an"
+        #     Deutsche Trennverben: Verb am Anfang/Mitte, Praefix am Satzende
+        if word_count <= 16 and not _is_question:
+            if _DEVICE_VERBS_SEPARATED.search(text_lower):
+                _has_device_context = (
+                    any(n in text_lower for n in _DEVICE_NOUNS)
+                    or any(w in text_lower for w in ("maschine", "geraet", "gerät", "dose"))
+                )
+                if _has_device_context:
+                    logger.debug("PreClassifier: DEVICE_FAST (separated verb: %s)", text)
+                    return PROFILE_DEVICE_FAST
 
         # 2. Status-Abfragen: "Wie warm ist es?", "Sind die Rolllaeden offen?"
         if word_count <= 10:

--- a/assistant/tests/test_pre_classifier.py
+++ b/assistant/tests/test_pre_classifier.py
@@ -119,10 +119,45 @@ class TestDeviceFastEmbeddedVerbs:
         assert result.category == "device_command", f"'{text}' sollte DEVICE_FAST sein"
 
     def test_too_long_embedded_verb_goes_general(self, classifier):
-        """Eingebettete Verben mit >12 Woertern → GENERAL."""
-        long_text = "Ich moechte bitte dass du jetzt sofort endlich mal die Lampe im Wohnzimmer ausschaltest bitte danke"
+        """Eingebettete Verben mit >16 Woertern → GENERAL."""
+        long_text = "Ich moechte bitte dass du jetzt sofort endlich mal die Lampe im Wohnzimmer ausschaltest bitte danke und zwar sofort"
         result = classifier.classify(long_text)
-        # >12 Woerter → nicht als embedded verb erkannt
+        # >16 Woerter → nicht als embedded verb erkannt
+        assert result.category == "general"
+
+    def test_embedded_verb_up_to_16_words(self, classifier):
+        """Eingebettete Verben mit bis zu 16 Woertern → DEVICE_FAST."""
+        text = "Ich moechte bitte dass du jetzt sofort endlich mal die Lampe im Wohnzimmer ausschaltest bitte danke"
+        result = classifier.classify(text)
+        assert result.category == "device_command"
+
+
+# ============================================================
+# DEVICE_FAST: Trennbare Verben (Verb...Praefix-am-Ende)
+# ============================================================
+
+class TestDeviceFastSeparatedVerbs:
+    """Trennbare Verben: 'schalte die Maschine aus', 'mach das Licht an'."""
+
+    @pytest.fixture
+    def classifier(self):
+        return PreClassifier()
+
+    @pytest.mark.parametrize("text", [
+        "schalte die Steckdose im Wohnzimmer aus",
+        "mach die Steckdose an",
+        "Das ist gut und jetzt schaltet die Maschine im Wohnzimmer aus",
+        "dreh die Heizung im Schlafzimmer ab",
+        "stell die Lampe im Flur an",
+    ])
+    def test_separated_verbs_recognized(self, classifier, text):
+        result = classifier.classify(text)
+        assert result.category == "device_command", f"'{text}' sollte device_command sein"
+
+    def test_separated_verb_without_device_noun_goes_general(self, classifier):
+        """Trennbares Verb ohne Geraete-Nomen bei >8 Woertern → GENERAL."""
+        text = "Kannst du bitte das grosse schwere Buch im oberen Regal um stellen"
+        result = classifier.classify(text)
         assert result.category == "general"
 
 
@@ -139,8 +174,9 @@ class TestDeviceFastProfile:
         assert PROFILE_DEVICE_FAST.need_time_hints is True
         assert PROFILE_DEVICE_FAST.need_security is True
         assert PROFILE_DEVICE_FAST.need_guest_mode is True
+        # Mood muss AN sein (Frustrations-Erkennung auch bei Device-Commands)
+        assert PROFILE_DEVICE_FAST.need_mood is True
         # Diese sollten AUS sein:
-        assert PROFILE_DEVICE_FAST.need_mood is False
         assert PROFILE_DEVICE_FAST.need_formality is False
         assert PROFILE_DEVICE_FAST.need_irony is False
         assert PROFILE_DEVICE_FAST.need_memories is False


### PR DESCRIPTION
… matching

- Pre-classifier: Add separated verb pattern for German trennbare Verben ("schalte die Maschine aus"), increase embedded verb word limit 12→16, enable mood detection in DEVICE_FAST profile
- Brain: Enforce sentence limit when user is frustrated/stressed even in conversation mode, add SSML tag patterns to meta-leak filter, extract room context from conversation history for LLM hints, stronger character-lock reminder during frustration
- Entity matching: Add fuzzy word-match fallback when exact matching fails
- HA client: Reduce action-log timeout 45s→10s, retries 1→0

https://claude.ai/code/session_019NPtnkMyzLpob2hYRsajfF