### PR TITLE
Set max_context_tokens to 0 (auto-scale with num_ctx)

### DIFF
--- a/assistant/config/settings.yaml
+++ b/assistant/config/settings.yaml
@@ -954,7 +954,7 @@ summarizer:
   max_tokens_weekly: 384
   max_tokens_monthly: 512
 context:
-  max_context_tokens: 12000
+  max_context_tokens: 0
   recent_conversations: 5
   api_timeout: 10
   llm_timeout: 60


### PR DESCRIPTION
Was hardcoded to 12000, causing token budget drops even when num_ctx had plenty of space (34% usage but sections still dropped). Value 0 means the budget automatically scales to num_ctx - 800 reserve.

https://claude.ai/code/session_019NPtnkMyzLpob2hYRsajfF