### PR TITLE
fix: CI-Tests repariert — Urgency-Alert und Whitelist-Obergrenze

### DIFF
--- a/assistant/tests/jarvis_character_test.py
+++ b/assistant/tests/jarvis_character_test.py
@@ -410,7 +410,9 @@ class TestUrgencySystem:
         assert section == ""
 
     def test_single_alert_elevated(self, engine):
-        section = engine._build_urgency_section({"alerts": ["Rauchmelder Kueche"]})
+        # Nicht-Krisen-Alert: "Bewegungsmelder" enthält kein Krisen-Keyword
+        # (Rauchmelder wuerde seit S8#1 direkt KRITISCH auslösen)
+        section = engine._build_urgency_section({"alerts": ["Bewegungsmelder Flur"]})
         assert "ERHOEHT" in section or "ERHÖHT" in section
 
     def test_multiple_alerts_critical(self, engine):

--- a/assistant/tests/test_function_calling_safety.py
+++ b/assistant/tests/test_function_calling_safety.py
@@ -133,7 +133,7 @@ class TestAllowedFunctions:
     def test_total_count_reasonable(self):
         """Whitelist sollte nicht leer und nicht uebertrieben gross sein."""
         count = len(FunctionExecutor._ALLOWED_FUNCTIONS)
-        assert 20 <= count <= 80, f"Whitelist hat {count} Eintraege — pruefen!"
+        assert 20 <= count <= 90, f"Whitelist hat {count} Eintraege — pruefen!"
 
     def test_internal_methods_excluded(self):
         """Private/interne Methoden duerfen nicht in der Whitelist sein."""


### PR DESCRIPTION
- test_single_alert_elevated: "Rauchmelder Kueche" durch "Bewegungsmelder Flur" ersetzt, da Rauchmelder seit S8#1 als Krisen-Alert direkt KRITISCH auslöst
- test_total_count_reasonable: Whitelist-Obergrenze von 80 auf 90 erhöht, da neue Features die Whitelist auf 81 Einträge erweitert haben

https://claude.ai/code/session_011pHqf47BU8oJPfpcePyUif