### PR TITLE
fix: AttributeError in brain.initialize() — self.semantic_memory → se…

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -885,7 +885,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         # Post-init wiring: Cross-Modul-Referenzen (Plan Phase 1-3)
         # 1A: SpontaneousObserver ↔ SemanticMemory + InsightEngine
         if hasattr(self.spontaneous, 'semantic_memory'):
-            self.spontaneous.semantic_memory = self.semantic_memory
+            self.spontaneous.semantic_memory = self.memory.semantic
         if hasattr(self.spontaneous, 'insight_engine'):
             self.spontaneous.insight_engine = self.insight_engine
 


### PR DESCRIPTION
…lf.memory.semantic

The spontaneous observer wiring referenced self.semantic_memory which doesn't exist on AssistantBrain. All other modules use self.memory.semantic consistently.

https://claude.ai/code/session_011bWCgw979Np3VTqtVXiuLF