### PR TITLE
fix(pre_classifier+brain): ß→ss Normalisierung für deutsche Eszett-Er…

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -9140,7 +9140,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         Wird für Tool-Call-Retry genutzt: Wenn das LLM keinen Tool-Call macht
         aber der Text offensichtlich ein Geraetebefehl ist.
         """
-        t = text.lower()
+        t = text.lower().replace("ß", "ss")
         has_noun = any(n in t for n in self._device_nouns)
         # Wort-genaue Aktionserkennung (kein Partial-Match auf "eine", "Auge" etc.)
         words = set(re.split(r'[\s,.!?]+', t))
@@ -9160,7 +9160,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         WICHTIG: Steuerungsbefehle ("stell auf 10%", "einstellen", "dimmen")
         werden NICHT als Status-Query erkannt, auch wenn sie "ist" enthalten.
         """
-        t = text.lower()
+        t = text.lower().replace("ß", "ss")
         has_noun = any(n in t for n in self._status_nouns)
         if not has_noun:
             return False
@@ -9184,7 +9184,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         Wird als Fallback genutzt wenn das LLM keinen Tool-Call generiert.
         Erkennt Status-Queries und einfache Steuerungsbefehle.
         """
-        t = text.lower()
+        t = text.lower().replace("ß", "ss")
         words = set(re.split(r'[\s,.!?]+', t))
 
         # --- Status-Queries: "Welche/Sind ... an/aus?" ---

--- a/assistant/assistant/pre_classifier.py
+++ b/assistant/assistant/pre_classifier.py
@@ -210,7 +210,7 @@ _STATUS_NOUNS = [
     "rollladen", "rolladen", "rolllaeden", "rollläden", "rolläden",
     "jalousie", "rollo",
     "fenster", "tuer", "tür", "türen",
-    "wetter", "aussen", "außen", "draussen", "draußen",
+    "wetter", "aussen", "draussen",
     "strom", "verbrauch", "watt", "energie",
     "status", "hausstatus", "ueberblick", "überblick",
     "musik", "spielt", "laeuft", "läuft",
@@ -227,13 +227,13 @@ _STATUS_SHORT_WORDS = re.compile(r'\b(?:an|aus)\b')
 # "Mir ist kalt" → Heizung hoch, "Es ist dunkel" → Licht an, etc.
 # Werden als DEVICE_FAST klassifiziert damit das LLM die passende Aktion waehlt.
 _IMPLICIT_COMMAND_PATTERNS = re.compile(
-    r"(?:mir ist (?:kalt|warm|heiss|heiß)|ich (?:friere|schwitz|schwitze|frier)"
+    r"(?:mir ist (?:kalt|warm|heiss)|ich (?:friere|schwitz|schwitze|frier)"
     r"|(?:es |hier |das )ist (?:(?:zu |so |viel zu |echt |total |ziemlich |sehr )?"
-    r"(?:kalt|warm|heiss|heiß|dunkel|hell|laut|leise|stickig))"
+    r"(?:kalt|warm|heiss|dunkel|hell|laut|leise|stickig))"
     r"|(?:es |hier )(?:zieht|stinkt|riecht)"
     r"|(?:ich (?:seh|sehe|kann) (?:nichts|nix|kaum (?:was|etwas)))"
     r"|(?:(?:zu |so |viel zu |echt |total |ziemlich |sehr )"
-    r"(?:kalt|warm|heiss|heiß|dunkel|hell|laut|leise|stickig) hier)"
+    r"(?:kalt|warm|heiss|dunkel|hell|laut|leise|stickig) hier)"
     r")"
 )
 
@@ -350,6 +350,9 @@ class PreClassifier:
           4. Alles andere → GENERAL
         """
         text_lower = text.lower().strip()
+        # Normalize ß → ss so regex patterns (e.g. "schliess") match
+        # both "schließe" and "schliesse" uniformly
+        text_lower = text_lower.replace("ß", "ss")
         word_count = len(text_lower.split())
 
         # 1. Geraete-Befehle: Verb-Start oder Nomen+Aktion, max 12 Woerter


### PR DESCRIPTION
…kennung

"Schließe die Rollläden" wurde als "general" statt "device_command" klassifiziert, weil die Regex-Patterns nur "schliess" (mit ss) enthalten, aber "schließe".lower() = "schließe" (mit ß) ergibt.

Fix: text.lower().replace("ß", "ss") in allen 4 Matching-Funktionen:
- PreClassifier.classify()
- Brain._is_device_command()
- Brain._is_status_query()
- Brain._deterministic_tool_call()

Entfernt redundante ß-Varianten aus _STATUS_NOUNS und _IMPLICIT_COMMAND_PATTERNS, da nach Normalisierung nur noch die ss-Variante matchen kann.

https://claude.ai/code/session_015cqK6f57A2aLxQJWzZ2Acr