### PR TITLE
fix: Autonomie-Level wurde nicht korrekt geladen und angezeigt

### DIFF
--- a/assistant/assistant/autonomy.py
+++ b/assistant/assistant/autonomy.py
@@ -98,7 +98,9 @@ class AutonomyManager:
     """Verwaltet das Autonomie-Level des Assistenten und Trust-Levels pro Person."""
 
     def __init__(self):
-        self.level = settings.autonomy_level
+        # Level aus yaml_config lesen (UI-konfigurierbar), Fallback auf .env Default
+        auto_cfg = yaml_config.get("autonomy", {})
+        self.level = int(auto_cfg.get("level", settings.autonomy_level))
 
         # Phase 10: Trust-Level Konfiguration laden
         trust_cfg = yaml_config.get("trust_levels", {})

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -716,7 +716,7 @@ async def jarvis_status():
             _mood = brain.mood.get_current_mood()
             status["mood"] = _mood if isinstance(_mood, str) else _mood.get("mood", "neutral")
         if hasattr(brain, "autonomy"):
-            status["autonomy_level"] = getattr(brain.autonomy, "current_level", 2)
+            status["autonomy_level"] = getattr(brain.autonomy, "level", 2)
         status["processing"] = getattr(brain, "_is_processing", False)
     except Exception as e:
         logger.debug("Jarvis status error: %s", e)


### PR DESCRIPTION
Zwei Bugs behoben:
1. autonomy.py __init__: Level wurde aus .env Default (immer 2) statt aus yaml_config gelesen — bei Neustart ging die UI-Änderung verloren
2. main.py /api/jarvis/status: las 'current_level' (existiert nicht als Attribut) statt 'level' — zeigte im Chat-UI immer Level 2

https://claude.ai/code/session_01G76mGMsoMC1L6ecGB22Jxb