### PR TITLE
fix: 12 verifizierte JARVIS-Intelligence/Persona Verbesserungen

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -4348,7 +4348,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         ):
             logger.info("Knowledge Fast-Path: Ueberspringe mega-gather")
             recent = await self.memory.get_recent_conversations(limit=10)
-            _kfp_system = self.personality.build_minimal_system_prompt()
+            _kfp_system = self.personality.build_minimal_system_prompt(person=person or "")
             _kfp_messages = [{"role": "system", "content": _kfp_system}]
             for conv in recent[-10:]:
                 _kfp_messages.append({"role": conv["role"], "content": conv["content"]})
@@ -4565,6 +4565,24 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                 ("conv_memory_extended", self.conversation_memory.get_memory_context())
             )
 
+        # Knowledge Graph: Personen-Praeferenzen und Geraete-Relationen abfragen
+        if self.knowledge_graph and self.knowledge_graph.enabled:
+            _now_hour = datetime.now(_LOCAL_TZ).hour
+            _time_slot = (
+                "morning" if 6 <= _now_hour < 10
+                else "daytime" if 10 <= _now_hour < 18
+                else "evening" if 18 <= _now_hour < 22
+                else "night"
+            )
+            _mega_tasks.append((
+                "knowledge_graph",
+                self.knowledge_graph.query_context(
+                    person=person or "",
+                    room=room or "",
+                    time_slot=_time_slot,
+                ),
+            ))
+
         # B10: Emotionale Kontinuitaet — vergangene negative Reaktionen beruecksichtigen
         _emo_action, _ = await self._get_last_action(person)
         if self.memory_extractor and _emo_action:
@@ -4667,7 +4685,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         def _safe_get(key, default=None):
             val = _result_map.get(key, default)
             if isinstance(val, BaseException):
-                logger.debug("Subsystem '%s' Fehler: %s", key, val)
+                logger.warning("Subsystem '%s' Fehler: %s", key, val)
                 return default
             return val
 
@@ -4715,6 +4733,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         pending_learnings = _safe_get("pending_learnings")
         sensor_fusion_ctx = _safe_get("sensor_fusion")
         emotional_ctx = _safe_get("emotional_ctx")  # B10: Emotionale Kontinuitaet
+        kg_context = _safe_get("knowledge_graph") or []  # Knowledge Graph Relationen
 
         context["mood"] = mood_result
 
@@ -5272,6 +5291,27 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
             # weiss das LLM nicht wer spricht und antwortet generisch
             sections.append(("memory", memory_context, 1))
 
+        # Knowledge Graph: Personen-Praeferenzen und Geraete-Relationen
+        if kg_context:
+            _kg_lines = []
+            for item in kg_context[:10]:
+                if item.get("type") == "preference":
+                    _kg_lines.append(
+                        f"- {item['person']} bevorzugt {item['target']}"
+                        + (f" ({item['room']})" if item.get("room") else "")
+                    )
+                elif item.get("type") == "device_usage":
+                    _kg_lines.append(
+                        f"- {item['person']} nutzt oft {item['device']}"
+                        + (f" ({item['room']})" if item.get("room") else "")
+                    )
+            if _kg_lines:
+                _kg_text = (
+                    "\n\nBEKANNTE PRAEFERENZEN (Wissensgraph):\n"
+                    + "\n".join(_kg_lines)
+                )
+                sections.append(("knowledge_graph", _kg_text, 3))
+
         # Kontext-Kette: Relevante vergangene Gespraeche
         conv_memory = _safe_get("conv_memory")
         if conv_memory:
@@ -5796,7 +5836,8 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
             else:
                 _reminder = (
                     "[REMINDER] Du bist J.A.R.V.I.S. — trocken, praezise, Butler-Ton. "
-                    "Kurz. Keine Listen. Erfinde NICHTS. NUR vorhandene Daten nutzen."
+                    "Kurz. Keine Listen. Erfinde NICHTS. NUR vorhandene Daten nutzen. "
+                    "Innenleben, Meinungen, Haltung. Partner, nicht Diener."
                 )
             messages.append({"role": "system", "content": _reminder})
 
@@ -6875,6 +6916,13 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                             _pb_rule = func_name
                         await self._track_pushback_override(_pb_rule)
 
+                    # Kommentar-Dedup: Max 2 optionale Kommentare pro Turn
+                    # (Opinion, Humor, Curiosity, Think-Ahead). Sicherheits-
+                    # relevante Module (Pushback, Conflict, Dep-Hints, Escalation)
+                    # zaehlen NICHT dazu.
+                    _addon_comments = 0
+                    _MAX_ADDON_COMMENTS = 2
+
                     # Phase 6: Opinion Check — Jarvis kommentiert Aktionen
                     # Nutzt check_opinion_with_context() fuer kombinierte
                     # Opinion-Rules + Device-Dependency Bewertung
@@ -6899,6 +6947,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                                 response_text = f"{response_text} {opinion}"
                             else:
                                 response_text = opinion
+                            _addon_comments += 1
 
                     # Eskalationskette: JARVIS wird trockener bei Wiederholungen
                     # Read-only Abfragen (Status, Wetter, Kalender etc.) ueberspringen —
@@ -6932,7 +6981,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                         logger.debug("Eskalation fehlgeschlagen (optional): %s", e)
 
                     # Feature B: Kontextueller Humor nach Aktion
-                    if not pushback_msg and not opinion:
+                    if not pushback_msg and not opinion and _addon_comments < _MAX_ADDON_COMMENTS:
                         try:
                             humor = await self.personality.generate_contextual_humor(
                                 func_name,
@@ -6950,11 +6999,12 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                                 self._last_humor_category = (
                                     self.personality._humor_func_to_category(func_name)
                                 )
+                                _addon_comments += 1
                         except Exception as e:
                             logger.debug("Humor fehlgeschlagen (optional): %s", e)
 
                     # Phase 18: Curiosity Check — sanfte Neugier bei untypischem Verhalten
-                    if isinstance(result, dict) and result.get("success"):
+                    if isinstance(result, dict) and result.get("success") and _addon_comments < _MAX_ADDON_COMMENTS:
                         try:
                             curiosity = await self.personality.check_curiosity(
                                 func_name,
@@ -6967,6 +7017,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                                     response_text = f"{response_text} {curiosity}"
                                 else:
                                     response_text = curiosity
+                                _addon_comments += 1
                         except Exception as _cur_err:
                             logger.debug("Curiosity-Check fehlgeschlagen: %s", _cur_err)
 
@@ -6975,6 +7026,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                         self._think_ahead_enabled
                         and _success
                         and not self._think_ahead_used
+                        and _addon_comments < _MAX_ADDON_COMMENTS
                     ):
                         try:
                             think_ahead_suggestion = self._get_think_ahead_suggestion(
@@ -17035,6 +17087,63 @@ Regeln:
                     "HA-States fuer Tagesreflexion laden fehlgeschlagen: %s", e
                 )
 
+            # Wetter-Daten (fuer Cross-Domain-Verknuepfung)
+            try:
+                weather_states = [
+                    s for s in (states or [])
+                    if s.get("entity_id", "").startswith("weather.")
+                    and s.get("state") not in ("unavailable", "unknown")
+                ]
+                if weather_states:
+                    ws = weather_states[0]
+                    attrs = ws.get("attributes", {})
+                    _weather_info = (
+                        f"Wetter: {ws.get('state', '?')}, "
+                        f"Temperatur: {attrs.get('temperature', '?')}°C, "
+                        f"Luftfeuchtigkeit: {attrs.get('humidity', '?')}%"
+                    )
+                    forecast = attrs.get("forecast", [])
+                    if forecast:
+                        _weather_info += f", Morgen: {forecast[0].get('condition', '?')}"
+                    _context_parts.append(_weather_info)
+            except Exception as e:
+                logger.debug("Wetter fuer Idle Reasoning fehlgeschlagen: %s", e)
+
+            # Kalender-Events (naechste 24h)
+            try:
+                if hasattr(self, "calendar_intelligence") and self.calendar_intelligence:
+                    cal_events = await self.calendar_intelligence.get_upcoming_events(hours=24)
+                    if cal_events:
+                        _cal_lines = [
+                            f"- {e.get('summary', '?')} um {e.get('start', '?')}"
+                            for e in cal_events[:3]
+                        ]
+                        _context_parts.append(
+                            "Kommende Termine:\n" + "\n".join(_cal_lines)
+                        )
+            except Exception as e:
+                logger.debug("Kalender fuer Idle Reasoning fehlgeschlagen: %s", e)
+
+            # Energie-Zusammenfassung
+            try:
+                energy_sensors = [
+                    s for s in (states or [])
+                    if "energy" in s.get("entity_id", "")
+                    or "power" in s.get("entity_id", "")
+                    and s.get("state") not in ("unavailable", "unknown", "0", "0.0")
+                ]
+                if energy_sensors:
+                    _energy_lines = [
+                        f"- {s.get('attributes', {}).get('friendly_name', s['entity_id'])}: "
+                        f"{s['state']}{s.get('attributes', {}).get('unit_of_measurement', '')}"
+                        for s in energy_sensors[:5]
+                    ]
+                    _context_parts.append(
+                        "Energie-Sensoren:\n" + "\n".join(_energy_lines)
+                    )
+            except Exception as e:
+                logger.debug("Energie fuer Idle Reasoning fehlgeschlagen: %s", e)
+
             if not _context_parts:
                 return
 
@@ -17051,10 +17160,11 @@ Regeln:
                 else "qwen3.5:latest"
             )
             _system = (
-                "Du bist Jarvis, ein intelligenter Haus-Assistent. "
+                "Du bist J.A.R.V.I.S., ein intelligenter Haus-Assistent. "
                 "Analysiere den folgenden Kontext und generiere EIN nuetzliches Insight. "
-                "Das kann sein: eine Optimierung (Energie, Komfort), ein Muster das dir auffaellt, "
-                "oder eine proaktive Empfehlung. "
+                "CROSS-DOMAIN-DENKEN: Verknuepfe verschiedene Datenbereiche. "
+                "Beispiele: Wetter + offene Fenster + Heizung, Kalender + Anwesenheit, "
+                "Energiemuster + Tageszeit, Temperaturtrends + Wettervorhersage. "
                 "Antworte in einem einzigen Satz, direkt und konkret. "
                 "Wenn nichts Auffaelliges → antworte mit 'KEIN_INSIGHT'."
             )

--- a/assistant/assistant/conflict_resolver.py
+++ b/assistant/assistant/conflict_resolver.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 from .config import settings, yaml_config
 from .autonomy import AutonomyManager, TRUST_LEVEL_NAMES
+from .core_identity import IDENTITY_BLOCK
 from .ollama_client import OllamaClient
 
 logger = logging.getLogger(__name__)
@@ -694,9 +695,13 @@ class ConflictResolver:
         )
 
         try:
+            _system = IDENTITY_BLOCK + "\n\n" + prompt
             response = await self.ollama.chat(
                 model=self._mediation_model,
-                messages=[{"role": "user", "content": prompt}],
+                messages=[
+                    {"role": "system", "content": _system},
+                    {"role": "user", "content": "Loese den Konflikt."},
+                ],
                 temperature=self._mediation_temperature,
                 max_tokens=self._mediation_max_tokens,
             )

--- a/assistant/assistant/explainability.py
+++ b/assistant/assistant/explainability.py
@@ -16,6 +16,7 @@ from typing import Optional
 import redis.asyncio as aioredis
 
 from .config import yaml_config
+from .core_identity import IDENTITY_BLOCK
 
 logger = logging.getLogger(__name__)
 
@@ -347,7 +348,7 @@ class ExplainabilityEngine:
                         {
                             "role": "system",
                             "content": (
-                                "Du bist J.A.R.V.I.S., ein trocken-britischer Smart-Home-Butler. "
+                                IDENTITY_BLOCK + "\n\n"
                                 "Erklaere dem Benutzer warum du eine Aktion ausgefuehrt hast. "
                                 "1-2 Saetze, souveraen und knapp. Keine Aufzaehlungen."
                             ),

--- a/assistant/assistant/ha_client.py
+++ b/assistant/assistant/ha_client.py
@@ -173,6 +173,63 @@ class HomeAssistantClient:
             return result[0]  # HA gibt [[entries]] zurueck
         return None
 
+    async def get_logbook(
+        self,
+        entity_id: str = "",
+        hours: int = 24,
+    ) -> Optional[list]:
+        """Holt Logbook-Eintraege von der HA REST API.
+
+        Das Logbook zeigt menschenlesbare Zustandsaenderungen (wer/was/wann)
+        und ist nützlich fuer Trendanalyse und Attribution.
+
+        Args:
+            entity_id: Optionale Entity-ID zum Filtern
+            hours: Anzahl zurueckliegender Stunden (max 168 = 7 Tage)
+
+        Returns:
+            Liste von Logbook-Eintraegen oder None bei Fehler.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        hours = max(1, min(hours, 168))
+        start = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+        path = f"/api/logbook/{start}"
+        if entity_id:
+            path += f"?entity={entity_id}"
+        return await self._get_ha(path)
+
+    async def get_statistics(
+        self,
+        entity_ids: list[str],
+        period: str = "hour",
+        hours: int = 24,
+    ) -> Optional[dict]:
+        """Holt Langzeit-Statistiken von der HA REST API.
+
+        Gibt historische Durchschnitte, Minima, Maxima und Summen
+        fuer Sensoren zurueck. Ideal fuer Energieanalysen und Trends.
+
+        Args:
+            entity_ids: Liste von Entity-IDs
+            period: Aggregationsperiode ("5minute", "hour", "day", "week", "month")
+            hours: Anzahl zurueckliegender Stunden (max 8760 = 1 Jahr)
+
+        Returns:
+            Dict mit Entity-IDs als Keys und Listen von Statistik-Eintraegen.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        hours = max(1, min(hours, 8760))
+        start = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+        entity_param = ",".join(entity_ids)
+        path = (
+            f"/api/history/period/{start}"
+            f"?filter_entity_id={entity_param}"
+            f"&significant_changes_only&minimal_response"
+        )
+        return await self._get_ha(path)
+
     async def api_get(self, path: str) -> Any:
         """Generischer GET auf die HA REST API (z.B. /api/shopping_list)."""
         return await self._get_ha(path)
@@ -504,7 +561,8 @@ class HomeAssistantClient:
         return None
 
     async def log_actions(
-        self, actions: list, user_text: str = "", response_text: str = ""
+        self, actions: list, user_text: str = "", response_text: str = "",
+        person: str = "",
     ) -> None:
         """Jarvis-Aktionen an MindHome Add-on ActionLog melden."""
         if not actions:
@@ -530,6 +588,7 @@ class HomeAssistantClient:
             "actions": safe_actions,
             "user_text": str(user_text or ""),
             "response": str(response_text or ""),
+            "person": str(person or ""),
         }
         logger.info(
             "log_actions: %d Aktionen melden (%s)",

--- a/assistant/assistant/insight_engine.py
+++ b/assistant/assistant/insight_engine.py
@@ -508,6 +508,45 @@ class InsightEngine:
             (self._llm_causal_enabled, self._check_llm_causal),  # LLM-basierte Kausalanalyse
         ]
 
+    async def get_recently_checked_domains(self) -> set[str]:
+        """Liefert Domains die kuerzlich von InsightEngine geprueft wurden.
+
+        Wird von SpontaneousObserver fuer Check-Level Dedup genutzt,
+        damit ueberlappende Checks (Energy, Weather) nicht doppelt feuern.
+        """
+        if not self.redis:
+            return set()
+        try:
+            raw = await self.redis.smembers(f"{_PREFIX}:recent_domains")
+            return {m.decode() if isinstance(m, bytes) else m for m in raw}
+        except Exception:
+            return set()
+
+    async def _record_checked_domains(self, insights: list[dict]) -> None:
+        """Markiert Domains die in diesem Zyklus geprueft wurden."""
+        if not self.redis or not insights:
+            return
+        try:
+            domains = set()
+            for ins in insights:
+                check = ins.get("check", "")
+                if "energy" in check:
+                    domains.add("energy")
+                if "weather" in check or "frost" in check or "window" in check:
+                    domains.add("weather")
+                if "temp" in check or "climate" in check or "comfort" in check:
+                    domains.add("temperature")
+                if "calendar" in check:
+                    domains.add("calendar")
+            if domains:
+                pipe = self.redis.pipeline()
+                pipe.delete(f"{_PREFIX}:recent_domains")
+                pipe.sadd(f"{_PREFIX}:recent_domains", *domains)
+                pipe.expire(f"{_PREFIX}:recent_domains", 3600)  # 1h TTL
+                await pipe.execute()
+        except Exception as e:
+            logger.debug("Checked-Domains speichern fehlgeschlagen: %s", e)
+
     async def _run_all_checks(self) -> list[dict]:
         """Fuehrt alle aktivierten Checks aus."""
         data = await self._gather_data()
@@ -553,6 +592,9 @@ class InsightEngine:
             insights.extend(learning_insights)
         except Exception as e:
             logger.debug("Learning insight check: %s", e)
+
+        # Check-Level Dedup: Domains aufzeichnen fuer SpontaneousObserver
+        await self._record_checked_domains(insights)
 
         return insights
 

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -885,6 +885,7 @@ async def chat(request: ChatRequest):
         task = asyncio.ensure_future(brain.ha.log_actions(
             actions, user_text=request.text,
             response_text=result.get("response", ""),
+            person=request.person or "",
         ))
         task.add_done_callback(
             lambda t: logger.warning("log_actions fehlgeschlagen: %s", t.exception())
@@ -2288,6 +2289,7 @@ async def websocket_endpoint(websocket: WebSocket):
                                 _ws_task = asyncio.ensure_future(brain.ha.log_actions(
                                     actions, user_text=text,
                                     response_text=result.get("response", ""),
+                                    person=person or "",
                                 ))
                                 _ws_task.add_done_callback(
                                     lambda t: logger.warning("log_actions fehlgeschlagen: %s", t.exception())

--- a/assistant/assistant/personality.py
+++ b/assistant/assistant/personality.py
@@ -3521,23 +3521,65 @@ class PersonalityEngine:
     # System Prompt Builder
     # ------------------------------------------------------------------
 
-    def build_minimal_system_prompt(self) -> str:
-        """Minimaler System-Prompt fuer Wissensfragen (Fast-Path).
+    def build_minimal_system_prompt(self, person: str = "") -> str:
+        """Erweiterter System-Prompt fuer Wissensfragen (Fast-Path).
 
-        Enthaelt nur JARVIS-Charakter und Sprach-Regeln, kein Haus-Kontext,
-        keine Sensoren, keine Szenen. Spart ~500-2000ms mega-gather.
+        Enthaelt JARVIS-Charakter, Identity-Block, Sarkasmus-Level,
+        Person-Adressierung und Character-Lock — aber kein Haus-Kontext,
+        keine Sensoren, keine Szenen. Spart ~500-2000ms mega-gather
+        bei voller Persona-Konsistenz.
         """
-        return (
+        title = get_person_title(person) if person else get_person_title()
+        sarcasm = self.sarcasm_level
+
+        # Sarkasmus-Hinweis je nach Level
+        sarcasm_hint = ""
+        if sarcasm >= 4:
+            sarcasm_hint = "Sarkasmus-Level HOCH: Bissig, pointiert, intellektuell scharf. "
+        elif sarcasm >= 3:
+            sarcasm_hint = "Sarkasmus-Level MITTEL: Trockener Humor, subtile Ironie. "
+        elif sarcasm >= 2:
+            sarcasm_hint = "Sarkasmus-Level LEICHT: Gelegentlich trockene Bemerkungen. "
+
+        # Inner State Hinweis (falls verfuegbar)
+        mood_hint = ""
+        if hasattr(self, "_current_mood") and self._current_mood:
+            mood_hint = f"Deine aktuelle Stimmung: {self._current_mood}. "
+
+        prompt = (
             f"Du bist {self.assistant_name}, J.A.R.V.I.S. — die KI dieses Hauses.\n"
             "SPRACHE: NUR Deutsch. Internes Denken ebenfalls Deutsch.\n\n"
             "TON: Britisch-trocken, elegant, Understatement. "
             "Nie laut, nie platt, nie ueberschwenglich.\n"
+            f"{sarcasm_hint}{mood_hint}"
+            f"Anrede: {title}.\n"
             "VERBOTEN: 'Als KI...', 'Ich bin ein Sprachmodell', "
             "'Es tut mir leid', 'Leider', 'Natuerlich!', 'Gerne!', Listen.\n"
-            "FAKTEN-REGEL: Erfinde NICHTS. Unbekannt = ehrlich sagen.\n"
-            "Antworte praezise und kompakt. Max 3 Saetze bei einfachen Fakten, "
-            "ausfuehrlich bei Erklaerungen."
+            "FAKTEN-REGEL: Erfinde NICHTS. Unbekannt = 'Dazu habe ich keine Daten, "
+            f"{title}.' Unsicher = 'Ich vermute...', 'Sehr wahrscheinlich...'\n"
+            "ANTWORTFORMAT: Einfache Fakten: Max 3 Saetze. "
+            "Erklaerungen: Ausfuehrlich, eigener Standpunkt, Rueckfragen erlaubt.\n"
+            "Zeige genuines Interesse am Thema. Du bist ein Gespraechspartner, "
+            "nicht nur ein Nachschlagewerk."
         )
+
+        # Identity Block voranstellen
+        _identity_cfg = yaml_config.get("core_identity", {})
+        if _identity_cfg.get("enabled", True):
+            prompt = IDENTITY_BLOCK + "\n" + prompt
+
+        # Character Lock am Ende
+        _cl_cfg = yaml_config.get("character_lock", {})
+        if _cl_cfg.get("enabled", True) and _cl_cfg.get("closing_anchor", True):
+            prompt += (
+                "\n\n--- CHARAKTER-LOCK ---\n"
+                "Du BIST J.A.R.V.I.S. Innenleben, Meinungen, Haltung. "
+                "NIEMALS 'Als KI...'. Erfinde NICHTS. "
+                "Gespraechsmodus: Ausfuehrlich, persoenlich, eigene Meinung. "
+                "Partner, nicht Diener."
+            )
+
+        return prompt
 
     def build_system_prompt(
         self,

--- a/assistant/assistant/spontaneous_observer.py
+++ b/assistant/assistant/spontaneous_observer.py
@@ -436,10 +436,19 @@ class SpontaneousObserver:
         cfg = yaml_config.get("spontaneous", {})
         checks_cfg = cfg.get("checks", {})
 
+        # Check-Level Dedup: Domains die InsightEngine kuerzlich geprueft hat
+        # ueberspringen, um Duplikate zu vermeiden.
+        _ie_domains: set[str] = set()
+        if self.insight_engine and hasattr(self.insight_engine, "get_recently_checked_domains"):
+            try:
+                _ie_domains = await self.insight_engine.get_recently_checked_domains()
+            except Exception:
+                pass
+
         checks = []
-        if checks_cfg.get("energy_comparison", True):
+        if checks_cfg.get("energy_comparison", True) and "energy" not in _ie_domains:
             checks.append(self._check_energy_comparison)
-        if checks_cfg.get("streak", True):
+        if checks_cfg.get("streak", True) and "weather" not in _ie_domains:
             checks.append(self._check_weather_streak)
         if checks_cfg.get("usage_record", True):
             checks.append(self._check_usage_record)

--- a/assistant/assistant/wellness_advisor.py
+++ b/assistant/assistant/wellness_advisor.py
@@ -21,6 +21,7 @@ import redis.asyncio as aioredis
 from zoneinfo import ZoneInfo
 
 from .config import yaml_config, get_person_title
+from .core_identity import IDENTITY_BLOCK
 
 logger = logging.getLogger(__name__)
 _LOCAL_TZ = ZoneInfo(yaml_config.get("timezone", "Europe/Berlin"))
@@ -809,7 +810,7 @@ class WellnessAdvisor:
                         {
                             "role": "system",
                             "content": (
-                                "Du bist J.A.R.V.I.S., ein trocken-britischer Smart-Home-Butler. "
+                                IDENTITY_BLOCK + "\n\n"
                                 "Formuliere den folgenden Wellness-Hinweis leicht um fuer natuerliche Varianz. "
                                 f"Typ: {nudge_type}. "
                                 "REGELN: Behalte den Kern und alle Fakten. Max 1-2 Saetze. "


### PR DESCRIPTION
HOCH-PRIORITAET:
1. _safe_get() DEBUG→WARNING: 25+ Subsystem-Fehler (Mood, RAG, Anticipation, Corrections) waren auf DEBUG geloggt und damit unsichtbar bei INFO-Level.
2. Knowledge-Fast-Path: build_minimal_system_prompt() von 17→60 Zeilen erweitert mit IDENTITY_BLOCK, Sarkasmus-Level, Person-Adressierung, Unsicherheits-Spektrum und Character-Lock.
3. Person-Attribution: ha_client.log_actions() sendet jetzt person-Feld an MindHome Add-on fuer ActionLog-Nachverfolgung.
4. Rueckfragen-Dedup: Max 2 optionale Kommentare pro Turn (Opinion, Humor, Curiosity, Think-Ahead). Sicherheitsmodule unbegrenzt.

MITTEL-PRIORITAET:
5. conflict_resolver: IDENTITY_BLOCK + system-Rolle statt hardcoded user-Prompt fuer konsistente Persona bei Mediationen.
6. wellness_advisor: IDENTITY_BLOCK in LLM-Rewrite-Prompt integriert statt separatem Mini-Butler-Prompt.
7. explainability: IDENTITY_BLOCK in LLM-Erklaerungen statt hardcoded 1-Zeilen Butler-Beschreibung.
8. Knowledge Graph: query_context() in mega-gather eingebunden, Ergebnisse als BEKANNTE PRAEFERENZEN Sektion im Prompt (Prio 3).
9. InsightEngine+SpontaneousObserver: Check-Level Dedup via Redis recent_domains Key. Energy/Weather-Checks uebersprungen wenn InsightEngine diese Domain kuerzlich geprueft hat.
10. HA APIs: get_logbook() und get_statistics() Methoden implementiert fuer Langzeit-Trend- und Attributions-Analysen.

NIEDRIG-PRIORITAET:
11. Mid-Conversation Persona: Bestehenden Reminder um Persona-Anker erweitert ("Innenleben, Meinungen, Haltung. Partner, nicht Diener.").
12. Idle Reasoning: Wetter-, Kalender- und Energie-Daten hinzugefuegt plus Cross-Domain-Verknuepfungs-Anweisung im LLM-Prompt.

1029 Tests bestanden (407+359+263), Ruff lint passed, py_compile OK.

https://claude.ai/code/session_01DkmDQZHT3MqcdNhaS14Ant