### PR TITLE
Fix domain autonomy levels for cover and media to match required acti…

### DIFF
--- a/assistant/config/settings.yaml.example
+++ b/assistant/config/settings.yaml.example
@@ -190,8 +190,8 @@ autonomy:
   domain_levels:
     climate: 3       # Klima & Heizung
     light: 3         # Licht & Beleuchtung
-    media: 2         # Medien & Musik
-    cover: 2         # Rolllaeden
+    media: 3         # Medien & Musik
+    cover: 3         # Rolllaeden
     security: 1      # Sicherheit (niedrig empfohlen)
     automation: 2    # Automationen & Routinen
     notification: 2  # Benachrichtigungen


### PR DESCRIPTION
…on levels

The default domain levels for 'cover' (2) and 'media' (2) were below the required level 3 for their actions (set_cover, play_media), making anticipation auto-execute impossible when domain_levels_enabled is true. Raised both to 3.

https://claude.ai/code/session_01VHgYCxxrCgctQFgHaNMaks