### PR TITLE
Add incremental write rule to prevent Claude Code freezing on large f…

### DIFF
--- a/docs/prompts/jarvis-mcu-session-1.md
+++ b/docs/prompts/jarvis-mcu-session-1.md
@@ -120,12 +120,23 @@ Markiere jedes vorhandene Feature mit:
 > Die Plan-Datei MUSS in kleinen Abschnitten geschrieben werden.
 
 **Schreibstrategie:**
-1. **Erstanlage:** Nur den Header + Fortschritts-Tracker + Schutzliste schreiben (Write-Tool, ~30 Zeilen)
-2. **Pro Kategorie:** Nach jeder fertigen Kategorie sofort per **Edit-Tool** an die Datei anhängen (~80-150 Zeilen)
-3. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
-4. **Changelog:** Am Ende separat per Edit anhängen
+1. **Erstanlage (Write-Tool):** Nur den Header schreiben (Status-Legende, Fortschritts-Tracker, Schutzliste + ein Platzhalter-Anker am Ende). Maximal ~40 Zeilen. Beispiel-Anker am Dateiende:
+   ```
+   <!-- NEXT_CATEGORY -->
+   ```
+2. **Pro Kategorie (Edit-Tool):** Nach jeder fertig analysierten Kategorie sofort per Edit den Platzhalter `<!-- NEXT_CATEGORY -->` ersetzen durch:
+   - Die komplette Kategorie-Analyse im **exakten Ausgabeformat** (siehe "Ausgabeformat" weiter unten)
+   - Gefolgt von einem neuen `<!-- NEXT_CATEGORY -->` Platzhalter für die nächste Kategorie
+3. **Changelog (Edit-Tool):** Am Ende den letzten `<!-- NEXT_CATEGORY -->` Platzhalter durch den Changelog-Eintrag ersetzen
+4. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
 
-**Technisch:** Verwende das Edit-Tool mit einem Anker-String (z.B. dem letzten geschriebenen Abschnitt) um den neuen Abschnitt direkt darunter einzufügen. Falls die Datei noch leer ist, verwende Write nur für den initialen Header.
+**Das Ausgabeformat (MCU-Benchmark, Status, V1/V2, Verbesserungsvorschläge, Akzeptanzkriterien) bleibt exakt gleich** — nur die Schreibmethode ändert sich (Edit statt Write). Inhaltlich und strukturell muss jede Kategorie genauso detailliert und vollständig sein wie bei einem einzelnen großen Write.
+
+**Beispiel für den Edit-Aufruf pro Kategorie:**
+```
+old_string: "<!-- NEXT_CATEGORY -->"
+new_string: "## 1. Natürliche Konversation & Sprachverständnis (×3)\n\n### MCU-Jarvis Benchmark\n...[vollständige Analyse]...\n\n<!-- NEXT_CATEGORY -->"
+```
 
 ---
 

--- a/docs/prompts/jarvis-mcu-session-1.md
+++ b/docs/prompts/jarvis-mcu-session-1.md
@@ -115,6 +115,18 @@ Markiere jedes vorhandene Feature mit:
 - **Notizen sofort aufschreiben** — nach jeder Kategorie Ergebnisse in die Plan-Datei schreiben
 - **Bei großen Dateien:** Erst Klassen-/Funktionsnamen suchen, dann gezielt relevante Methoden lesen
 
+### Regel 10: Inkrementelles Schreiben — NIEMALS alles auf einmal
+> **KRITISCH:** Claude Code friert ein oder trunkiert bei großen Write-Aufrufen (>400 Zeilen).
+> Die Plan-Datei MUSS in kleinen Abschnitten geschrieben werden.
+
+**Schreibstrategie:**
+1. **Erstanlage:** Nur den Header + Fortschritts-Tracker + Schutzliste schreiben (Write-Tool, ~30 Zeilen)
+2. **Pro Kategorie:** Nach jeder fertigen Kategorie sofort per **Edit-Tool** an die Datei anhängen (~80-150 Zeilen)
+3. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
+4. **Changelog:** Am Ende separat per Edit anhängen
+
+**Technisch:** Verwende das Edit-Tool mit einem Anker-String (z.B. dem letzten geschriebenen Abschnitt) um den neuen Abschnitt direkt darunter einzufügen. Falls die Datei noch leer ist, verwende Write nur für den initialen Header.
+
 ---
 
 ## MCU-Szenen-Katalog — Referenzmaterial

--- a/docs/prompts/jarvis-mcu-session-2.md
+++ b/docs/prompts/jarvis-mcu-session-2.md
@@ -112,10 +112,19 @@ Markiere als `[BESSER ALS MCU]` und stelle sicher dass Verbesserungsvorschläge 
 > Die Plan-Datei MUSS in kleinen Abschnitten geschrieben werden.
 
 **Schreibstrategie:**
-1. **Pro Kategorie:** Nach jeder fertigen Kategorie sofort per **Edit-Tool** an die Plan-Datei anhängen (~80-150 Zeilen)
-2. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
-3. **Changelog:** Am Ende separat per Edit anhängen
-4. **Technisch:** Verwende das Edit-Tool mit einem Anker-String (z.B. dem letzten Abschnitt) um den neuen Abschnitt direkt darunter einzufügen
+1. **Pro Kategorie (Edit-Tool):** Nach jeder fertig analysierten Kategorie sofort per Edit den Platzhalter `<!-- NEXT_CATEGORY -->` ersetzen durch:
+   - Die komplette Kategorie-Analyse im **exakten Ausgabeformat** (MCU-Benchmark, Status, V1/V2, Verbesserungsvorschläge, Akzeptanzkriterien)
+   - Gefolgt von einem neuen `<!-- NEXT_CATEGORY -->` Platzhalter
+2. **Changelog (Edit-Tool):** Am Ende den letzten `<!-- NEXT_CATEGORY -->` durch den Changelog-Eintrag ersetzen
+3. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
+
+**Das Ausgabeformat bleibt exakt gleich** — nur die Schreibmethode ändert sich. Inhaltlich und strukturell muss jede Kategorie genauso detailliert und vollständig sein.
+
+**Beispiel:**
+```
+old_string: "<!-- NEXT_CATEGORY -->"
+new_string: "## 5. Situationsbewusstsein (×2)\n\n### MCU-Jarvis Benchmark\n...[vollständige Analyse]...\n\n<!-- NEXT_CATEGORY -->"
+```
 
 ---
 

--- a/docs/prompts/jarvis-mcu-session-2.md
+++ b/docs/prompts/jarvis-mcu-session-2.md
@@ -107,6 +107,16 @@ Markiere als `[BESSER ALS MCU]` und stelle sicher dass Verbesserungsvorschläge 
 - **Notizen sofort aufschreiben**
 - **Bei großen Dateien:** Erst Funktionsnamen suchen, dann gezielt lesen
 
+### Regel 9: Inkrementelles Schreiben — NIEMALS alles auf einmal
+> **KRITISCH:** Claude Code friert ein oder trunkiert bei großen Write-Aufrufen (>400 Zeilen).
+> Die Plan-Datei MUSS in kleinen Abschnitten geschrieben werden.
+
+**Schreibstrategie:**
+1. **Pro Kategorie:** Nach jeder fertigen Kategorie sofort per **Edit-Tool** an die Plan-Datei anhängen (~80-150 Zeilen)
+2. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
+3. **Changelog:** Am Ende separat per Edit anhängen
+4. **Technisch:** Verwende das Edit-Tool mit einem Anker-String (z.B. dem letzten Abschnitt) um den neuen Abschnitt direkt darunter einzufügen
+
 ---
 
 ## MCU-Szenen-Katalog — Referenzmaterial

--- a/docs/prompts/jarvis-mcu-session-3.md
+++ b/docs/prompts/jarvis-mcu-session-3.md
@@ -72,10 +72,19 @@ Ignoriere alles aus dem MCU, was physisch unmöglich oder irrelevant für ein Sm
 > Die Plan-Datei MUSS in kleinen Abschnitten geschrieben werden.
 
 **Schreibstrategie:**
-1. **Pro Kategorie:** Nach jeder fertigen Kategorie sofort per **Edit-Tool** an die Plan-Datei anhängen (~80-150 Zeilen)
-2. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
-3. **Changelog:** Am Ende separat per Edit anhängen
-4. **Technisch:** Verwende das Edit-Tool mit einem Anker-String (z.B. dem letzten Abschnitt) um den neuen Abschnitt direkt darunter einzufügen
+1. **Pro Kategorie (Edit-Tool):** Nach jeder fertig analysierten Kategorie sofort per Edit den Platzhalter `<!-- NEXT_CATEGORY -->` ersetzen durch:
+   - Die komplette Kategorie-Analyse im **exakten Ausgabeformat** (MCU-Benchmark, Status, V1/V2, Verbesserungsvorschläge, Akzeptanzkriterien)
+   - Gefolgt von einem neuen `<!-- NEXT_CATEGORY -->` Platzhalter
+2. **Changelog (Edit-Tool):** Am Ende den letzten `<!-- NEXT_CATEGORY -->` durch den Changelog-Eintrag ersetzen
+3. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
+
+**Das Ausgabeformat bleibt exakt gleich** — nur die Schreibmethode ändert sich. Inhaltlich und strukturell muss jede Kategorie genauso detailliert und vollständig sein.
+
+**Beispiel:**
+```
+old_string: "<!-- NEXT_CATEGORY -->"
+new_string: "## 10. Multi-Room-Awareness (×1)\n\n### MCU-Jarvis Benchmark\n...[vollständige Analyse]...\n\n<!-- NEXT_CATEGORY -->"
+```
 
 ---
 

--- a/docs/prompts/jarvis-mcu-session-3.md
+++ b/docs/prompts/jarvis-mcu-session-3.md
@@ -67,6 +67,16 @@ Ignoriere alles aus dem MCU, was physisch unmöglich oder irrelevant für ein Sm
 - Kategorien sequentiell abarbeiten
 - Notizen sofort aufschreiben
 
+### Regel 9: Inkrementelles Schreiben — NIEMALS alles auf einmal
+> **KRITISCH:** Claude Code friert ein oder trunkiert bei großen Write-Aufrufen (>400 Zeilen).
+> Die Plan-Datei MUSS in kleinen Abschnitten geschrieben werden.
+
+**Schreibstrategie:**
+1. **Pro Kategorie:** Nach jeder fertigen Kategorie sofort per **Edit-Tool** an die Plan-Datei anhängen (~80-150 Zeilen)
+2. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
+3. **Changelog:** Am Ende separat per Edit anhängen
+4. **Technisch:** Verwende das Edit-Tool mit einem Anker-String (z.B. dem letzten Abschnitt) um den neuen Abschnitt direkt darunter einzufügen
+
 ---
 
 ## MCU-Szenen-Katalog (für Session 3 relevant)

--- a/docs/prompts/jarvis-mcu-session-4.md
+++ b/docs/prompts/jarvis-mcu-session-4.md
@@ -49,9 +49,18 @@ Kein Sprint-Task darf ein "Besser als MCU" Feature beschädigen. Prüfe jede Auf
 > Die Plan-Datei MUSS in kleinen Abschnitten geschrieben werden.
 
 **Schreibstrategie:**
-1. **Pro Sprint:** Nach jedem fertigen Sprint sofort per **Edit-Tool** an die Plan-Datei anhängen
+1. **Pro Sprint (Edit-Tool):** Nach jedem fertigen Sprint sofort per Edit den Platzhalter `<!-- NEXT_SPRINT -->` ersetzen durch:
+   - Den kompletten Sprint-Plan (Aufgaben, Dateien, Abhängigkeiten, Akzeptanzkriterien)
+   - Gefolgt von einem neuen `<!-- NEXT_SPRINT -->` Platzhalter
 2. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
-3. **Technisch:** Verwende das Edit-Tool mit einem Anker-String (z.B. dem letzten Abschnitt) um den neuen Abschnitt direkt darunter einzufügen
+
+**Das Ausgabeformat und die Detailtiefe bleiben exakt gleich** — nur die Schreibmethode ändert sich.
+
+**Beispiel:**
+```
+old_string: "<!-- NEXT_SPRINT -->"
+new_string: "## Sprint 1: Persönlichkeit & Konversation\n\n...[vollständiger Sprint-Plan]...\n\n<!-- NEXT_SPRINT -->"
+```
 
 ---
 

--- a/docs/prompts/jarvis-mcu-session-4.md
+++ b/docs/prompts/jarvis-mcu-session-4.md
@@ -44,6 +44,15 @@ Kein Sprint-Task darf ein "Besser als MCU" Feature beschädigen. Prüfe jede Auf
 - Sprints sequentiell ausarbeiten — nicht alle gleichzeitig im Kontext halten
 - Nach jedem Sprint sofort in die Plan-Datei schreiben
 
+### Regel 5: Inkrementelles Schreiben — NIEMALS alles auf einmal
+> **KRITISCH:** Claude Code friert ein oder trunkiert bei großen Write-Aufrufen (>400 Zeilen).
+> Die Plan-Datei MUSS in kleinen Abschnitten geschrieben werden.
+
+**Schreibstrategie:**
+1. **Pro Sprint:** Nach jedem fertigen Sprint sofort per **Edit-Tool** an die Plan-Datei anhängen
+2. **Niemals die gesamte Datei neu schreiben** — immer nur den neuen Abschnitt per Edit einfügen
+3. **Technisch:** Verwende das Edit-Tool mit einem Anker-String (z.B. dem letzten Abschnitt) um den neuen Abschnitt direkt darunter einzufügen
+
 ---
 
 ## Phase 2: Abhängigkeitsgraph & Sprint-Plan

--- a/docs/prompts/jarvis-mcu-session-5.md
+++ b/docs/prompts/jarvis-mcu-session-5.md
@@ -21,6 +21,11 @@ Du bist ein Elite-Software-Architekt. Die vorherigen 4 Sessions haben eine volls
 
 **Wichtig:** Du hast frischen Kontext — nutze das! Die vorherigen Sessions hatten am Ende möglicherweise Kontext-Limit-Probleme. Du prüfst jetzt alles mit voller Aufmerksamkeit.
 
+### Inkrementelles Schreiben — NIEMALS alles auf einmal
+> **KRITISCH:** Claude Code friert ein oder trunkiert bei großen Write-Aufrufen (>400 Zeilen).
+> Änderungen an der Plan-Datei MÜSSEN in kleinen Abschnitten per **Edit-Tool** gemacht werden.
+> **Niemals die gesamte Datei neu schreiben** — immer nur gezielte Edits (Korrekturen, Ergänzungen, Status-Updates).
+
 ### Durchlauf-Nummer ermitteln
 Lies den **Changelog** am Ende von `docs/prompts/jarvis-mcu-implementation-plan.md`. Zähle die bestehenden Durchlauf-Einträge. Dein Durchlauf ist **der nächste** (z.B. wenn der letzte `#3` war, bist du `#4`). Beim allerersten Durchlauf (kein Changelog vorhanden) bist du `#1`.
 


### PR DESCRIPTION
…iles

Sessions were hanging because Claude tried to write the entire plan file in one Write call (500+ lines). Known Claude Code bug (GitHub #23053, #27896).

Fix: New rule in all 5 sessions forces incremental writing:
- Write only the header initially (~30 lines)
- Append each category via Edit tool (~80-150 lines each)
- Never rewrite the entire file at once

https://claude.ai/code/session_01SBr6KZwxXEqtdZ1ocb2U3h