### PR TITLE
Health-Check-Logs bei Nacht unterdrücken (localhost)

### DIFF
--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -2414,7 +2414,8 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                 )
 
         # Sarkasmus-Feedback: Reaktion auf vorherige sarkastische Antwort auswerten
-        if self.personality.sarcasm_level >= 3 and hasattr(
+        _sarc_lvl = getattr(self.personality, "sarcasm_level", 0)
+        if isinstance(_sarc_lvl, (int, float)) and _sarc_lvl >= 3 and hasattr(
             self, "_last_response_was_snarky"
         ):
             if self._last_response_was_snarky:

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -591,19 +591,25 @@ async def api_anomaly_middleware(request: Request, call_next):
             except Exception:
                 pass  # Non-critical
 
-    # Log unusual access times (2-5 AM)
-    if response.status_code == 200 and request.url.path.startswith("/api/assistant"):
+    # Log unusual access times (2-5 AM) — Health-Checks von localhost ausschliessen
+    _req_path = request.url.path
+    if response.status_code == 200 and _req_path.startswith("/api/assistant"):
         from datetime import datetime, timezone
 
         hour = datetime.now(timezone.utc).hour
         if 2 <= hour <= 5:
             client_ip = request.client.host if request.client else "unknown"
-            logger.info(
-                "API access at unusual hour %d from %s: %s",
-                hour,
-                client_ip,
-                request.url.path,
+            _is_local_health = (
+                _req_path.rstrip("/") == "/api/assistant/health"
+                and client_ip in ("127.0.0.1", "::1", "localhost")
             )
+            if not _is_local_health:
+                logger.info(
+                    "API access at unusual hour %d from %s: %s",
+                    hour,
+                    client_ip,
+                    _req_path,
+                )
 
     return response
 

--- a/assistant/tests/test_brain_comprehensive.py
+++ b/assistant/tests/test_brain_comprehensive.py
@@ -964,8 +964,12 @@ class TestGetStatesCached:
 class TestProcess:
     @pytest.mark.asyncio
     async def test_process_lock_timeout(self, brain):
-        brain._process_lock = asyncio.Lock()
-        await brain._process_lock.acquire()  # Lock is held
+        # The code uses per-person locks (_person_locks dict), not a global
+        # _process_lock.  For person=None the key is "_anonymous".
+        brain._person_locks_guard = asyncio.Lock()
+        anon_lock = asyncio.Lock()
+        await anon_lock.acquire()  # Hold the lock so process() times out
+        brain._person_locks = {"_anonymous": anon_lock}
 
         # Should return timeout message
         result = await asyncio.wait_for(
@@ -973,4 +977,4 @@ class TestProcess:
             timeout=35.0,
         )
         assert "beschaeftigt" in result["response"] or "Moment" in result["response"]
-        brain._process_lock.release()
+        anon_lock.release()


### PR DESCRIPTION
Der /api/assistant/health Endpoint wird alle 30s vom Add-on gepollt. Nachts (2-5 Uhr) wurde jeder dieser Aufrufe als "unusual hour" geloggt, was die Logs mit ~120 identischen Einträgen pro Stunde geflutet hat. Health-Checks von localhost werden jetzt ausgeschlossen.

https://claude.ai/code/session_011a3YY6buXGcu7JP3ExBefL