### PR TITLE
feat: Personal Assistant Layer - 5 neue Module fuer Jarvis als Familien-Assistent

### DIFF
--- a/addon/rootfs/opt/mindhome/engines/cover_control.py
+++ b/addon/rootfs/opt/mindhome/engines/cover_control.py
@@ -166,7 +166,8 @@ class CoverControlManager:
                     state = self.ha.get_state(a.entity_id) if self.ha else None
                     attrs = state.get("attributes", {}) if state else {}
                     cover_conf = all_configs.get(a.entity_id, {})
-                    override = self._manual_overrides.get(a.entity_id)
+                    with self._lock:
+                        override = self._manual_overrides.get(a.entity_id)
                     covers.append({
                         "entity_id": a.entity_id,
                         "state": state.get("state", "unknown") if state else "unknown",
@@ -593,11 +594,14 @@ class CoverControlManager:
             local = now
 
         # Deferred wake-open: Rolladen oeffnen sobald Sonne hoch genug
-        if self._wake_pending_open:
+        with self._lock:
+            _wake_pending = self._wake_pending_open
+        if _wake_pending:
             min_elevation = config.get("wakeup_min_sun_elevation_deg", -6.0)
             if sun_data.get("elevation", 0) >= min_elevation:
                 if not self._is_bed_occupied():
-                    self._wake_pending_open = False
+                    with self._lock:
+                        self._wake_pending_open = False
                     for cover in covers:
                         if not self._is_overridden(cover["entity_id"]):
                             self.set_position(cover["entity_id"], 100, source="wakeup_deferred")
@@ -651,7 +655,9 @@ class CoverControlManager:
                 today = local.date()
                 for s in schedules:
                     # Dedup: Jedes Schedule nur einmal pro Tag ausfuehren
-                    if self._executed_schedules.get(s.id) == today:
+                    with self._lock:
+                        _already_run = self._executed_schedules.get(s.id) == today
+                    if _already_run:
                         continue
                     days = s.days or [0, 1, 2, 3, 4, 5, 6]
                     if current_day not in days:
@@ -659,7 +665,8 @@ class CoverControlManager:
                     if s.presence_mode and s.presence_mode != presence_mode:
                         continue
 
-                    self._executed_schedules[s.id] = today
+                    with self._lock:
+                        self._executed_schedules[s.id] = today
                     if s.entity_id and not self._is_overridden(s.entity_id):
                         self.set_position(s.entity_id, s.position, source="schedule")
                         if s.tilt is not None:
@@ -711,7 +718,8 @@ class CoverControlManager:
         covers = self.get_covers()
         for cover in covers:
             eid = cover["entity_id"]
-            last = self._last_simulation.get(eid)
+            with self._lock:
+                last = self._last_simulation.get(eid)
             actual_interval = interval + random.randint(-variance, variance)
             if last and (now - last).total_seconds() < actual_interval * 60:
                 continue
@@ -719,7 +727,8 @@ class CoverControlManager:
             # Randomly open or close
             new_pos = random.choice([0, 30, 70, 100])
             self.set_position(eid, new_pos, source="simulation")
-            self._last_simulation[eid] = now
+            with self._lock:
+                self._last_simulation[eid] = now
             logger.info(f"Presence simulation: {eid} → {new_pos}%")
 
     # ── Rule Evaluation ─────────────────────────────────────
@@ -866,9 +875,10 @@ class CoverControlManager:
         if context.get("user_id"):
             config = self.get_config()
             duration = config.get("manual_override_duration_min", 120)
-            self._manual_overrides[entity_id] = (
-                datetime.now(timezone.utc) + timedelta(minutes=duration)
-            )
+            with self._lock:
+                self._manual_overrides[entity_id] = (
+                    datetime.now(timezone.utc) + timedelta(minutes=duration)
+                )
             logger.info(f"Manual override detected for {entity_id} ({duration}min)")
 
             # Learning: log manual action for pattern detection
@@ -886,7 +896,8 @@ class CoverControlManager:
             return
         if not config.get("sleep_close_enabled"):
             return
-        self._wake_pending_open = False  # Reset deferred wake-open
+        with self._lock:
+            self._wake_pending_open = False  # Reset deferred wake-open
         covers = self.get_covers()
         for cover in covers:
             if not self._is_overridden(cover["entity_id"]):
@@ -911,7 +922,8 @@ class CoverControlManager:
         sun_data = self._get_sun_data()
         min_elevation = config.get("wakeup_min_sun_elevation_deg", -6.0)
         if sun_data.get("elevation", 0) < min_elevation:
-            self._wake_pending_open = True
+            with self._lock:
+                self._wake_pending_open = True
             logger.info(
                 "Wake detected but too dark (sun elevation %.1f° < %.1f°) "
                 "— deferring cover open until sunrise",
@@ -919,7 +931,8 @@ class CoverControlManager:
             )
             return
 
-        self._wake_pending_open = False
+        with self._lock:
+            self._wake_pending_open = False
         covers = self.get_covers()
         for cover in covers:
             if not self._is_overridden(cover["entity_id"]):

--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -1364,6 +1364,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         self.meal_planner.smart_shopping = self.smart_shopping
         self.meal_planner.semantic_memory = getattr(self, "semantic_memory", None)
         self.meal_planner.ha = self.ha
+        self.meal_planner.set_model_router(self.model_router)
 
         if "MultiRoomAudio" not in _degraded_modules:
             await _safe_init(

--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -14748,14 +14748,61 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         if len(parts) < 2:
             return None
 
+        # Bug 1 Fix: Verb und Aktion aus dem ersten Part fuer Folge-Parts vererben.
+        # "Fahre die Rolläden im Wohnzimmer und der Küche runter" →
+        #   Part 1: "Fahre die Rolläden im Wohnzimmer" (hat Verb + Raum)
+        #   Part 2: "der Küche runter" (kein Verb, Raum braucht Kontext)
+        # Fuer Part 2 ergaenzen wir den Verb-Kontext des ersten Parts.
+        first_part = parts[0].strip()
+        # Verb am Anfang extrahieren (z.B. "Fahre", "Mach", "Schalt")
+        _verb_match = _re.match(
+            r"((?:fahr|mach|schalt|schalte|stell|setz|dreh|oeffne|schliess|aktiviere)\w*"
+            r"(?:\s+(?:die|das|den|dem|der|alle|meine?)\s+\w+)?)",
+            first_part,
+            _re.IGNORECASE,
+        )
+        verb_prefix = _verb_match.group(1) if _verb_match else ""
+
         cmds = []
-        for part in parts:
+        for i, part in enumerate(parts):
             part = part.strip()
             if not part:
                 continue
+
+            # Erster Part: direkt versuchen
+            if i == 0:
+                cmd = cls._detect_device_command(part, room=room)
+                if cmd:
+                    cmds.append(cmd)
+                continue
+
+            # Folge-Parts: erst direkt versuchen
             cmd = cls._detect_device_command(part, room=room)
             if cmd:
                 cmds.append(cmd)
+                continue
+
+            # Fallback 1: Raum aus lockerer Extraktion ("der Küche" → "Küche")
+            room_match = _re.search(
+                r"(?:der|dem|des|die|das|im|in|ins|vom|am)\s+"
+                r"([A-ZÄÖÜa-zäöüß][A-ZÄÖÜa-zäöüß\-]+)",
+                part,
+                _re.IGNORECASE,
+            )
+            if room_match and verb_prefix:
+                # Verb-Kontext + Raum-Präposition ergaenzen
+                enriched = f"{verb_prefix} im {room_match.group(1)}"
+                # Aktions-Wort aus dem Teil anhängen (z.B. "runter", "hoch", "aus")
+                action_words = _re.findall(
+                    r"\b(runter|rauf|hoch|auf|zu|an|aus|ein|ab)\b",
+                    part,
+                    _re.IGNORECASE,
+                )
+                if action_words:
+                    enriched += " " + " ".join(action_words)
+                cmd = cls._detect_device_command(enriched, room=room)
+                if cmd:
+                    cmds.append(cmd)
 
         if len(cmds) < 2:
             # Weniger als 2 erkannte Kommandos → kein Multi-Command

--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -1359,7 +1359,7 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         self.personal_dates.set_semantic_memory(
             getattr(self, "semantic_memory", None)
         )
-        self.personal_dates.set_notify_callback(self._handle_proactive_message)
+        self.personal_dates.set_notify_callback(self._handle_personal_date_reminder)
         self.meal_planner.inventory = self.inventory
         self.meal_planner.smart_shopping = self.smart_shopping
         self.meal_planner.semantic_memory = getattr(self, "semantic_memory", None)
@@ -5648,6 +5648,26 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                 f"- {h}" for h in timer_hints
             )
             sections.append(("timers", timer_text, 2))
+
+        # Personal Assistant Module Context Hints
+        pa_hints = []
+        for pa_mod in [
+            self.task_manager,
+            self.note_manager,
+            self.family_manager,
+            self.meal_planner,
+        ]:
+            try:
+                hints = pa_mod.get_context_hints()
+                if hints:
+                    pa_hints.extend(hints)
+            except Exception:
+                pass
+        if pa_hints:
+            pa_text = "\n\nPERSOENLICHER ASSISTENT:\n" + "\n".join(
+                f"- {h}" for h in pa_hints
+            )
+            sections.append(("personal_assistant", pa_text, 1))
 
         if guest_mode_active:
             sections.append(
@@ -11888,6 +11908,24 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         # Proaktive Meldung in Working Memory speichern für Konversations-Kontext
         self._remember_exchange("[proaktiv: Zeiterkennung]", formatted)
         logger.info("TimeAwareness [%s] -> Meldung: %s", urgency, formatted)
+
+    async def _handle_personal_date_reminder(self, message: str = "", priority: str = "medium", **kwargs):
+        """Callback fuer PersonalDatesManager — Geburtstags-/Jahrestags-Erinnerungen."""
+        if not message:
+            return
+        urgency = "high" if priority == "high" else "medium"
+        if not await self._callback_should_speak(
+            urgency, source="PersonalDates"
+        ):
+            return
+        formatted = await self._format_callback_with_escalation(
+            message,
+            urgency,
+            "personal_date",
+        )
+        await self._speak_and_emit(formatted)
+        self._remember_exchange("[proaktiv: Persoenlicher Termin]", formatted)
+        logger.info("Personal Date Reminder [%s]: %s", priority, formatted)
 
     async def _handle_health_alert(self, alert_type: str, urgency: str, message: str):
         """Callback für Health Monitor — leitet an proaktive Meldung weiter."""
@@ -19105,6 +19143,11 @@ Regeln:
             self.autonomy,
             self.routines,
             self.action_planner,
+            self.task_manager,
+            self.personal_dates,
+            self.family_manager,
+            self.note_manager,
+            self.meal_planner,
         ]:
             try:
                 await component.stop()

--- a/assistant/assistant/brain.py
+++ b/assistant/assistant/brain.py
@@ -40,8 +40,13 @@ from .feedback import FeedbackTracker
 from .function_calling import get_assistant_tools, FunctionExecutor
 from .function_validator import FunctionValidator
 from .ha_client import HomeAssistantClient
+from .family_manager import FamilyManager
 from .inventory import InventoryManager
+from .meal_planner import MealPlanner
+from .note_manager import NoteManager
+from .personal_dates import PersonalDatesManager
 from .smart_shopping import SmartShopping
+from .task_manager import TaskManager
 from .conversation_memory import ConversationMemory
 from .multi_room_audio import MultiRoomAudio
 from .knowledge_base import KnowledgeBase
@@ -504,6 +509,13 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
 
         # Wellness Advisor (Caring Loops)
         self.wellness_advisor = WellnessAdvisor(self.ha, self.activity, self.mood)
+
+        # Personal Assistant Module
+        self.task_manager = TaskManager(self.ha)
+        self.personal_dates = PersonalDatesManager()
+        self.family_manager = FamilyManager(self.ha)
+        self.note_manager = NoteManager()
+        self.meal_planner = MealPlanner(self.ollama)
 
         # Phase 18: MCU-Upgrade — Proactive Planner + Seasonal Insight
         self.proactive_planner = ProactiveSequencePlanner(self.ha, self.anticipation)
@@ -1299,6 +1311,26 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
                 "WorkshopGenerator",
                 self.workshop_generator.initialize(redis_client=self.memory.redis),
             ),
+            _safe_init(
+                "TaskManager",
+                self.task_manager.initialize(redis_client=self.memory.redis),
+            ),
+            _safe_init(
+                "PersonalDates",
+                self.personal_dates.initialize(redis_client=self.memory.redis),
+            ),
+            _safe_init(
+                "FamilyManager",
+                self.family_manager.initialize(redis_client=self.memory.redis),
+            ),
+            _safe_init(
+                "NoteManager",
+                self.note_manager.initialize(redis_client=self.memory.redis),
+            ),
+            _safe_init(
+                "MealPlanner",
+                self.meal_planner.initialize(redis_client=self.memory.redis),
+            ),
         )
 
         # Post-init wiring (Callbacks, Cross-References, Start-Calls)
@@ -1317,6 +1349,21 @@ class AssistantBrain(BrainHumanizersMixin, BrainCallbacksMixin):
         self.conditional_commands.set_action_callback(
             lambda func, args: self.executor.execute(func, args)
         )
+
+        # Personal Assistant Module wiring
+        self.executor._task_manager = self.task_manager
+        self.executor._note_manager = self.note_manager
+        self.executor._family_manager = self.family_manager
+        self.executor._meal_planner = self.meal_planner
+        self.executor._personal_dates = self.personal_dates
+        self.personal_dates.set_semantic_memory(
+            getattr(self, "semantic_memory", None)
+        )
+        self.personal_dates.set_notify_callback(self._handle_proactive_message)
+        self.meal_planner.inventory = self.inventory
+        self.meal_planner.smart_shopping = self.smart_shopping
+        self.meal_planner.semantic_memory = getattr(self, "semantic_memory", None)
+        self.meal_planner.ha = self.ha
 
         if "MultiRoomAudio" not in _degraded_modules:
             await _safe_init(

--- a/assistant/assistant/cover_config.py
+++ b/assistant/assistant/cover_config.py
@@ -68,7 +68,15 @@ def _load_list(filepath: Path) -> list:
         if filepath.exists():
             data = json.loads(filepath.read_text())
             if isinstance(data, list):
-                return data
+                # Nur Dict-Items behalten (schützt gegen korrupte JSON-Dateien)
+                valid = [item for item in data if isinstance(item, dict)]
+                if len(valid) != len(data):
+                    logger.warning(
+                        "%s enthält %d ungültige Einträge (keine Dicts) — ignoriert",
+                        filepath.name,
+                        len(data) - len(valid),
+                    )
+                return valid
     except Exception as e:
         logger.warning("Laden von %s fehlgeschlagen: %s", filepath.name, e)
     return []

--- a/assistant/assistant/family_manager.py
+++ b/assistant/assistant/family_manager.py
@@ -1,0 +1,474 @@
+"""
+Family Manager - Familien-Profile und personalisierte Erfahrung.
+
+Verwaltet strukturierte Familien-Profile die ueber die einfache
+Speaker-Recognition und Person-Preferences hinausgehen.
+
+Features:
+- Strukturierte Familien-Beziehungen (Partner, Kind, Eltern, etc.)
+- Personalisiertes Morgen-Briefing pro Person
+- Altersgerechte Kommunikation (Kind vs. Erwachsener)
+- Familien-Gruppennachrichten
+- Persoenliche Interessen und Vorlieben
+- Begruessung basierend auf Person und Tageszeit
+
+Redis Keys:
+- mha:family:member:{person}     - Profil-Daten (Hash)
+- mha:family:members             - Set aller Familienmitglieder
+- mha:family:groups:{group}      - Nachrichtengruppen (Set)
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+import redis.asyncio as aioredis
+
+from .config import yaml_config, get_person_title
+
+logger = logging.getLogger(__name__)
+
+_cfg = yaml_config.get("family", {})
+
+_RELATIONSHIP_TYPES = frozenset(
+    {
+        "partner",
+        "spouse",
+        "child",
+        "parent",
+        "sibling",
+        "grandparent",
+        "grandchild",
+        "roommate",
+        "friend",
+        "other",
+    }
+)
+
+_AGE_GROUPS = {
+    "child": (0, 12),
+    "teen": (13, 17),
+    "adult": (18, 200),
+}
+
+_COMMUNICATION_STYLES = {
+    "child": {
+        "greeting_prefix": "Hey",
+        "formality": "informal",
+        "emoji_level": "high",
+        "vocabulary": "simple",
+    },
+    "teen": {
+        "greeting_prefix": "Hi",
+        "formality": "casual",
+        "emoji_level": "medium",
+        "vocabulary": "normal",
+    },
+    "adult": {
+        "greeting_prefix": "",  # Wird vom Persoenlichkeits-System bestimmt
+        "formality": "butler",
+        "emoji_level": "none",
+        "vocabulary": "full",
+    },
+}
+
+
+class FamilyManager:
+    """Verwaltet Familien-Profile und personalisierte Interaktionen."""
+
+    def __init__(self, ha_client):
+        self.ha = ha_client
+        self.redis: Optional[aioredis.Redis] = None
+        self._notify_callback = None
+
+    async def initialize(self, redis_client: Optional[aioredis.Redis] = None):
+        """Initialisiert mit Redis-Verbindung."""
+        self.redis = redis_client
+
+        # Lade initiale Profile aus settings.yaml
+        await self._load_profiles_from_config()
+        logger.info("FamilyManager initialisiert")
+
+    def set_notify_callback(self, callback):
+        """Setzt Callback fuer Gruppen-Nachrichten."""
+        self._notify_callback = callback
+
+    # ------------------------------------------------------------------
+    # Profil-Verwaltung
+    # ------------------------------------------------------------------
+
+    async def add_member(
+        self,
+        name: str,
+        relationship: str = "other",
+        birth_year: int = 0,
+        interests: str = "",
+        ha_person_entity: str = "",
+        notification_target: str = "",
+    ) -> dict:
+        """Fuegt ein Familienmitglied hinzu oder aktualisiert es."""
+        if not name:
+            return {"success": False, "message": "Kein Name angegeben."}
+
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        name_key = name.lower().strip()
+        relationship = relationship.lower()
+        if relationship not in _RELATIONSHIP_TYPES:
+            relationship = "other"
+
+        profile = {
+            "name": name.strip(),
+            "name_key": name_key,
+            "relationship": relationship,
+            "birth_year": str(birth_year) if birth_year else "",
+            "interests": interests,
+            "ha_person_entity": ha_person_entity or f"person.{name_key}",
+            "notification_target": notification_target,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        await self.redis.hset(f"mha:family:member:{name_key}", mapping=profile)
+        await self.redis.sadd("mha:family:members", name_key)
+
+        return {
+            "success": True,
+            "message": f"{name} als {relationship} zur Familie hinzugefuegt.",
+        }
+
+    async def update_member(self, name: str, **kwargs) -> dict:
+        """Aktualisiert einzelne Felder eines Familienmitglieds."""
+        if not name or not self.redis:
+            return {"success": False, "message": "Name oder Redis fehlt."}
+
+        name_key = name.lower().strip()
+        exists = await self.redis.exists(f"mha:family:member:{name_key}")
+        if not exists:
+            return {
+                "success": False,
+                "message": f"{name} ist kein bekanntes Familienmitglied.",
+            }
+
+        updates = {}
+        for key, value in kwargs.items():
+            if value is not None and key in {
+                "relationship",
+                "birth_year",
+                "interests",
+                "ha_person_entity",
+                "notification_target",
+            }:
+                updates[key] = str(value)
+
+        if updates:
+            await self.redis.hset(f"mha:family:member:{name_key}", mapping=updates)
+
+        return {"success": True, "message": f"Profil von {name} aktualisiert."}
+
+    async def get_member(self, name: str) -> Optional[dict]:
+        """Gibt das Profil eines Familienmitglieds zurueck."""
+        if not self.redis:
+            return None
+
+        name_key = name.lower().strip()
+        data = await self.redis.hgetall(f"mha:family:member:{name_key}")
+        if not data:
+            return None
+
+        return _decode_redis_hash(data)
+
+    async def get_all_members(self) -> list[dict]:
+        """Gibt alle Familien-Profile zurueck."""
+        if not self.redis:
+            return []
+
+        members = await self.redis.smembers("mha:family:members")
+        if not members:
+            return []
+
+        results = []
+        pipe = self.redis.pipeline()
+        names = []
+        for m in members:
+            name = m if isinstance(m, str) else m.decode()
+            names.append(name)
+            pipe.hgetall(f"mha:family:member:{name}")
+        all_data = await pipe.execute()
+
+        for name, data in zip(names, all_data):
+            if data:
+                results.append(_decode_redis_hash(data))
+
+        return sorted(results, key=lambda m: m.get("name", ""))
+
+    async def remove_member(self, name: str) -> dict:
+        """Entfernt ein Familienmitglied."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        name_key = name.lower().strip()
+        existed = await self.redis.delete(f"mha:family:member:{name_key}")
+        await self.redis.srem("mha:family:members", name_key)
+
+        if existed:
+            return {"success": True, "message": f"{name} aus Familie entfernt."}
+        return {"success": False, "message": f"{name} nicht gefunden."}
+
+    # ------------------------------------------------------------------
+    # Personalisierung
+    # ------------------------------------------------------------------
+
+    async def get_age_group(self, name: str) -> str:
+        """Bestimmt die Altersgruppe eines Familienmitglieds."""
+        profile = await self.get_member(name)
+        if not profile or not profile.get("birth_year"):
+            return "adult"
+
+        try:
+            birth_year = int(profile["birth_year"])
+            age = datetime.now(timezone.utc).year - birth_year
+
+            for group, (min_age, max_age) in _AGE_GROUPS.items():
+                if min_age <= age <= max_age:
+                    return group
+            return "adult"
+        except (ValueError, TypeError):
+            return "adult"
+
+    async def get_communication_style(self, name: str) -> dict:
+        """Gibt den Kommunikationsstil fuer eine Person zurueck."""
+        age_group = await self.get_age_group(name)
+        style = _COMMUNICATION_STYLES.get(age_group, _COMMUNICATION_STYLES["adult"])
+        return dict(style)  # Kopie zurueckgeben
+
+    async def get_personalized_greeting(self, name: str) -> str:
+        """Erstellt eine personalisierte Begruessung."""
+        profile = await self.get_member(name)
+        if not profile:
+            # Fallback: Nutze get_person_title aus config
+            title = get_person_title(name)
+            return f"Hallo {title}"
+
+        age_group = await self.get_age_group(name)
+        display_name = profile.get("name", name).title()
+        relationship = profile.get("relationship", "")
+
+        now = datetime.now(timezone.utc)
+        hour = now.hour
+
+        if age_group == "child":
+            if hour < 12:
+                return f"Guten Morgen, {display_name}!"
+            elif hour < 18:
+                return f"Hey {display_name}!"
+            else:
+                return f"Guten Abend, {display_name}!"
+        else:
+            # Standard Butler-Stil - wird vom Persoenlichkeits-System uebersteuert
+            title = get_person_title(name)
+            return f"{title}"
+
+    async def get_context_for_person(self, name: str) -> dict:
+        """Liefert Kontext-Informationen fuer personalisierte LLM-Antworten."""
+        profile = await self.get_member(name)
+        if not profile:
+            return {}
+
+        age_group = await self.get_age_group(name)
+        style = await self.get_communication_style(name)
+
+        context = {
+            "person_name": profile.get("name", name),
+            "relationship": profile.get("relationship", ""),
+            "age_group": age_group,
+            "interests": profile.get("interests", ""),
+            "communication_style": style,
+        }
+
+        return context
+
+    # ------------------------------------------------------------------
+    # Gruppen-Nachrichten
+    # ------------------------------------------------------------------
+
+    async def send_family_message(
+        self,
+        message: str,
+        group: str = "all",
+        exclude: Optional[list[str]] = None,
+    ) -> dict:
+        """Sendet eine Nachricht an die Familie oder eine Gruppe.
+
+        Args:
+            message: Die Nachricht
+            group: 'all' oder Gruppenname
+            exclude: Liste von Personen die ausgenommen werden sollen
+        """
+        if not self._notify_callback:
+            return {
+                "success": False,
+                "message": "Benachrichtigungs-System nicht verfuegbar.",
+            }
+
+        exclude_set = {n.lower() for n in (exclude or [])}
+
+        if group == "all":
+            members = await self.get_all_members()
+        else:
+            members = await self._get_group_members(group)
+
+        if not members:
+            return {"success": False, "message": "Keine Empfaenger gefunden."}
+
+        sent_count = 0
+        for member in members:
+            name_key = member.get("name_key", member.get("name", "").lower())
+            if name_key in exclude_set:
+                continue
+
+            try:
+                await self._notify_callback(
+                    message=message,
+                    person=member.get("name", name_key),
+                    priority="medium",
+                )
+                sent_count += 1
+            except Exception as e:
+                logger.warning(
+                    "Fehler beim Senden an %s: %s",
+                    member.get("name", "?"),
+                    e,
+                )
+
+        return {
+            "success": sent_count > 0,
+            "message": f"Nachricht an {sent_count} Familienmitglied(er) gesendet.",
+        }
+
+    async def create_group(self, group_name: str, members: list[str]) -> dict:
+        """Erstellt eine Nachrichtengruppe."""
+        if not self.redis or not group_name or not members:
+            return {
+                "success": False,
+                "message": "Gruppenname und Mitglieder erforderlich.",
+            }
+
+        key = f"mha:family:groups:{group_name.lower()}"
+        for m in members:
+            await self.redis.sadd(key, m.lower().strip())
+
+        return {
+            "success": True,
+            "message": f"Gruppe '{group_name}' mit {len(members)} Mitgliedern erstellt.",
+        }
+
+    async def _get_group_members(self, group: str) -> list[dict]:
+        """Laedt die Mitglieder einer Gruppe."""
+        if not self.redis:
+            return []
+
+        key = f"mha:family:groups:{group.lower()}"
+        member_names = await self.redis.smembers(key)
+        if not member_names:
+            return []
+
+        results = []
+        for name in member_names:
+            name_str = name if isinstance(name, str) else name.decode()
+            profile = await self.get_member(name_str)
+            if profile:
+                results.append(profile)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Briefing-Integration
+    # ------------------------------------------------------------------
+
+    async def get_personalized_briefing_context(self, person: str) -> dict:
+        """Liefert personalisierten Kontext fuers Morgen-Briefing."""
+        profile = await self.get_member(person)
+        if not profile:
+            return {"person": person, "style": "default"}
+
+        age_group = await self.get_age_group(person)
+        interests = profile.get("interests", "")
+
+        context = {
+            "person": profile.get("name", person),
+            "age_group": age_group,
+            "interests": interests,
+            "relationship": profile.get("relationship", ""),
+        }
+
+        if age_group == "child":
+            context["style"] = "kind"  # Einfache Sprache, freundlich
+            context["briefing_hint"] = (
+                "Halte das Briefing kurz, einfach und freundlich. "
+                "Erwaehne Schule/Freizeit statt Arbeit."
+            )
+        elif age_group == "teen":
+            context["style"] = "jugendlich"
+            context["briefing_hint"] = (
+                "Lockerer Ton, nicht zu foermlich. Relevante Infos fuer Jugendliche."
+            )
+        else:
+            context["style"] = "butler"
+            context["briefing_hint"] = ""
+
+        return context
+
+    # ------------------------------------------------------------------
+    # Hilfsfunktionen
+    # ------------------------------------------------------------------
+
+    async def _load_profiles_from_config(self):
+        """Laedt initiale Profile aus settings.yaml 'persons' Sektion."""
+        if not self.redis:
+            return
+
+        persons = yaml_config.get("persons", {})
+        for name, config in persons.items():
+            name_key = name.lower().strip()
+
+            # Nur erstellen wenn noch nicht vorhanden
+            exists = await self.redis.exists(f"mha:family:member:{name_key}")
+            if exists:
+                continue
+
+            profile = {
+                "name": name.strip(),
+                "name_key": name_key,
+                "relationship": config.get("relationship", "other"),
+                "birth_year": str(config.get("birth_year", "")),
+                "interests": config.get("interests", ""),
+                "ha_person_entity": config.get("ha_entity", f"person.{name_key}"),
+                "notification_target": config.get("notification_target", ""),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            }
+
+            await self.redis.hset(f"mha:family:member:{name_key}", mapping=profile)
+            await self.redis.sadd("mha:family:members", name_key)
+            logger.info("Familienprofil aus Config geladen: %s", name)
+
+    def get_context_hints(self) -> list[str]:
+        """Gibt Kontext-Hints fuer den Context Builder zurueck."""
+        return [
+            "FamilyManager aktiv: Familien-Profile, Gruppen-Nachrichten, "
+            "personalisierte Kommunikation verfuegbar"
+        ]
+
+    async def shutdown(self):
+        """Cleanup."""
+        pass
+
+
+def _decode_redis_hash(data: dict) -> dict:
+    """Dekodiert Redis-Hash bytes zu strings."""
+    decoded = {}
+    for k, v in data.items():
+        key = k if isinstance(k, str) else k.decode()
+        val = v if isinstance(v, str) else v.decode()
+        decoded[key] = val
+    return decoded

--- a/assistant/assistant/family_manager.py
+++ b/assistant/assistant/family_manager.py
@@ -463,6 +463,10 @@ class FamilyManager:
         """Cleanup."""
         pass
 
+    async def stop(self):
+        """Alias fuer shutdown (Brain-Kompatibilitaet)."""
+        await self.shutdown()
+
 
 def _decode_redis_hash(data: dict) -> dict:
     """Dekodiert Redis-Hash bytes zu strings."""

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -4322,11 +4322,32 @@ class FunctionExecutor:
         self._config_versioning = versioning
 
     async def _mark_cover_jarvis_acting(self, entity_id: str):
-        """Setzt jarvis_acting Flag damit proactive.py keinen Manual Override erkennt."""
+        """Setzt jarvis_acting Flag UND manual_override fuer Voice-Befehle.
+
+        jarvis_acting: Verhindert dass proactive.py den State-Change
+        als externen Manual Override erkennt (z.B. von HA UI/Button).
+        manual_override: Blockiert die automatische Cover-Steuerung
+        (Solar, Zeitplan etc.) fuer die konfigurierte Override-Dauer.
+        Beide Flags sind noetig weil Voice-Befehle vom User kommen
+        (→ Automatik soll pausieren) aber ueber Jarvis ausgefuehrt
+        werden (→ kein falscher Override-Alarm).
+        """
         redis = getattr(self, "_redis", None)
         if redis:
             try:
                 await redis.set(f"mha:cover:jarvis_acting:{entity_id}", "1", ex=300)
+                # Voice-Befehl = User-Intention → Automatik pausieren
+                from .config import yaml_config
+
+                override_hours = (
+                    yaml_config.get("seasonal_actions", {})
+                    .get("cover_automation", {})
+                    .get("manual_override_hours", 2)
+                )
+                override_ttl = int(override_hours * 3600)
+                await redis.set(
+                    f"mha:cover:manual_override:{entity_id}", "1", ex=override_ttl
+                )
             except Exception as e:
                 logger.debug("Redis Cover-Jarvis-Acting Flag fehlgeschlagen: %s", e)
 

--- a/assistant/assistant/function_calling.py
+++ b/assistant/assistant/function_calling.py
@@ -3984,6 +3984,259 @@ def _get_assistant_tools_static() -> list:
                 },
             },
         },
+        # ==============================================================
+        # Personal Assistant Tools
+        # ==============================================================
+        {
+            "type": "function",
+            "function": {
+                "name": "manage_tasks",
+                "description": "Aufgaben/Todo-Listen verwalten. Aufgaben hinzufuegen, auflisten, erledigen, entfernen. Auch wiederkehrende Aufgaben (taeglich, woechentlich, monatlich).",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "add",
+                                "list",
+                                "complete",
+                                "remove",
+                                "add_recurring",
+                                "list_recurring",
+                                "delete_recurring",
+                            ],
+                            "description": "Aktion: hinzufuegen, auflisten, erledigen, entfernen, wiederkehrende erstellen/auflisten/loeschen",
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Aufgabentext (fuer add, complete, remove, add_recurring, delete_recurring)",
+                        },
+                        "person": {
+                            "type": "string",
+                            "description": "Person der die Aufgabe zugewiesen wird (optional)",
+                        },
+                        "due_date": {
+                            "type": "string",
+                            "description": "Faelligkeitsdatum YYYY-MM-DD (optional)",
+                        },
+                        "priority": {
+                            "type": "string",
+                            "enum": ["low", "medium", "high", "urgent"],
+                            "description": "Prioritaet (default: medium)",
+                        },
+                        "recurrence": {
+                            "type": "string",
+                            "enum": ["daily", "weekly", "monthly", "weekday"],
+                            "description": "Wiederholungstyp (fuer add_recurring)",
+                        },
+                        "weekday": {
+                            "type": "string",
+                            "description": "Wochentag fuer woechentliche Aufgaben (z.B. 'montag')",
+                        },
+                    },
+                    "required": ["action"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "manage_notes",
+                "description": "Notizen erstellen, durchsuchen, auflisten und loeschen. Fuer schnelle Memos, Ideen, Informationen die man sich merken will.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["add", "list", "search", "delete", "categories"],
+                            "description": "Aktion: hinzufuegen, auflisten, suchen, loeschen, Kategorien anzeigen",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Notiztext (fuer add) oder Suchbegriff (fuer search)",
+                        },
+                        "category": {
+                            "type": "string",
+                            "enum": [
+                                "haushalt",
+                                "arbeit",
+                                "ideen",
+                                "einkauf",
+                                "gesundheit",
+                                "technik",
+                                "finanzen",
+                                "familie",
+                                "rezept",
+                                "sonstiges",
+                            ],
+                            "description": "Kategorie (optional, default: sonstiges)",
+                        },
+                        "person": {
+                            "type": "string",
+                            "description": "Person der die Notiz zugeordnet wird (optional)",
+                        },
+                        "note_id": {
+                            "type": "string",
+                            "description": "Notiz-ID (fuer delete)",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximale Anzahl Ergebnisse (default: 10)",
+                        },
+                    },
+                    "required": ["action"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "manage_family",
+                "description": "Familien-Profile verwalten: Mitglieder hinzufuegen, auflisten, aktualisieren. Gruppen-Nachrichten senden.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "add_member",
+                                "list_members",
+                                "get_member",
+                                "update_member",
+                                "remove_member",
+                                "send_family_message",
+                                "create_group",
+                            ],
+                            "description": "Aktion auf der Familien-Verwaltung",
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Name der Person",
+                        },
+                        "relationship": {
+                            "type": "string",
+                            "enum": [
+                                "partner",
+                                "spouse",
+                                "child",
+                                "parent",
+                                "sibling",
+                                "grandparent",
+                                "grandchild",
+                                "roommate",
+                                "friend",
+                                "other",
+                            ],
+                            "description": "Beziehungstyp (fuer add_member)",
+                        },
+                        "birth_year": {
+                            "type": "integer",
+                            "description": "Geburtsjahr (fuer add_member, optional)",
+                        },
+                        "interests": {
+                            "type": "string",
+                            "description": "Interessen/Hobbys kommagetrennt (optional)",
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Nachricht (fuer send_family_message)",
+                        },
+                        "group": {
+                            "type": "string",
+                            "description": "Gruppenname (fuer send_family_message oder create_group, default: all)",
+                        },
+                        "members": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Mitglieder-Namen (fuer create_group)",
+                        },
+                    },
+                    "required": ["action"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_personal_dates",
+                "description": "Anstehende Geburtstage, Jahrestage und persoenliche Termine abfragen.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "days_ahead": {
+                            "type": "integer",
+                            "description": "Wie viele Tage vorausschauen (default: 30)",
+                        },
+                        "person": {
+                            "type": "string",
+                            "description": "Termine nur fuer eine bestimmte Person (optional)",
+                        },
+                    },
+                    "required": [],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "manage_meals",
+                "description": "Essensplanung: Gerichte aus Vorraeten vorschlagen, Wochenplan erstellen, Mahlzeiten protokollieren, Zutaten pruefen.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": [
+                                "suggest",
+                                "weekly_plan",
+                                "log_meal",
+                                "history",
+                                "check_ingredients",
+                                "current_plan",
+                            ],
+                            "description": "suggest: Was kochen mit Vorraeten. weekly_plan: Wochenplan erstellen. log_meal: Mahlzeit protokollieren. history: Essenshistorie. check_ingredients: Fehlende Zutaten zur Einkaufsliste. current_plan: Aktuellen Wochenplan anzeigen.",
+                        },
+                        "meal": {
+                            "type": "string",
+                            "description": "Gerichtsname (fuer log_meal)",
+                        },
+                        "meal_type": {
+                            "type": "string",
+                            "enum": [
+                                "fruehstueck",
+                                "mittagessen",
+                                "abendessen",
+                                "snack",
+                            ],
+                            "description": "Mahlzeitentyp (default: abendessen)",
+                        },
+                        "portions": {
+                            "type": "integer",
+                            "description": "Anzahl Portionen (optional)",
+                        },
+                        "rating": {
+                            "type": "integer",
+                            "description": "Bewertung 1-5 (fuer log_meal, optional)",
+                        },
+                        "preferences": {
+                            "type": "string",
+                            "description": "Wuensche fuer den Wochenplan (z.B. 'viel Gemuese', 'keine Pasta')",
+                        },
+                        "ingredients": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Zutatenliste (fuer check_ingredients)",
+                        },
+                        "days": {
+                            "type": "integer",
+                            "description": "Anzahl Tage fuer History (default: 7)",
+                        },
+                    },
+                    "required": ["action"],
+                },
+            },
+        },
     ]
     return _ASSISTANT_TOOLS_STATIC
 
@@ -4171,6 +4424,11 @@ class FunctionExecutor:
             "retrieve_memory",
             "retrieve_history",
             "verify_device_state",
+            "manage_tasks",
+            "manage_notes",
+            "manage_family",
+            "get_personal_dates",
+            "manage_meals",
         }
     )
 
@@ -12194,3 +12452,223 @@ class FunctionExecutor:
         except Exception as e:
             logger.error("verify_device_state fehlgeschlagen: %s", e)
             return {"success": False, "message": f"State-Abfrage fehlgeschlagen: {e}"}
+
+    # ==================================================================
+    # Personal Assistant Tools
+    # ==================================================================
+
+    async def _exec_manage_tasks(self, args: dict) -> dict:
+        """Aufgaben/Todo-Listen verwalten."""
+        import assistant.main as main_module
+
+        brain = main_module.brain
+        try:
+            tm = brain.task_manager
+        except AttributeError:
+            return {"success": False, "message": "Task Manager nicht verfuegbar."}
+
+        action = args.get("action", "")
+
+        if action == "add":
+            return await tm.add_task(
+                title=args.get("title", ""),
+                person=args.get("person", ""),
+                due_date=args.get("due_date", ""),
+                priority=args.get("priority", "medium"),
+            )
+        elif action == "list":
+            return await tm.list_tasks(
+                person=args.get("person", ""),
+            )
+        elif action == "complete":
+            return await tm.complete_task(title=args.get("title", ""))
+        elif action == "remove":
+            return await tm.remove_task(title=args.get("title", ""))
+        elif action == "add_recurring":
+            return await tm.add_recurring_task(
+                title=args.get("title", ""),
+                recurrence=args.get("recurrence", ""),
+                weekday=args.get("weekday", ""),
+                person=args.get("person", ""),
+            )
+        elif action == "list_recurring":
+            return await tm.list_recurring_tasks()
+        elif action == "delete_recurring":
+            return await tm.delete_recurring_task(title=args.get("title", ""))
+
+        return {"success": False, "message": f"Unbekannte Aktion: {action}"}
+
+    async def _exec_manage_notes(self, args: dict) -> dict:
+        """Notizen verwalten."""
+        nm = getattr(self, "_note_manager", None)
+        if not nm:
+            return {"success": False, "message": "Notiz-System nicht verfuegbar."}
+
+        action = args.get("action", "")
+
+        if action == "add":
+            return await nm.add_note(
+                content=args.get("content", ""),
+                category=args.get("category", "sonstiges"),
+                person=args.get("person", ""),
+            )
+        elif action == "list":
+            return await nm.list_notes(
+                category=args.get("category", ""),
+                person=args.get("person", ""),
+                limit=args.get("limit", 10),
+            )
+        elif action == "search":
+            return await nm.search_notes(
+                query=args.get("content", ""),
+                limit=args.get("limit", 5),
+            )
+        elif action == "delete":
+            return await nm.delete_note(note_id=args.get("note_id", ""))
+        elif action == "categories":
+            return await nm.get_note_categories()
+
+        return {"success": False, "message": f"Unbekannte Aktion: {action}"}
+
+    async def _exec_manage_family(self, args: dict) -> dict:
+        """Familien-Profile verwalten."""
+        fm = getattr(self, "_family_manager", None)
+        if not fm:
+            return {"success": False, "message": "Family Manager nicht verfuegbar."}
+
+        action = args.get("action", "")
+
+        if action == "add_member":
+            return await fm.add_member(
+                name=args.get("name", ""),
+                relationship=args.get("relationship", "other"),
+                birth_year=args.get("birth_year", 0),
+                interests=args.get("interests", ""),
+            )
+        elif action == "list_members":
+            members = await fm.get_all_members()
+            if not members:
+                return {"success": True, "message": "Noch keine Familienmitglieder eingetragen."}
+            lines = []
+            for m in members:
+                name = m.get("name", "?").title()
+                rel = m.get("relationship", "")
+                interests = m.get("interests", "")
+                rel_hint = f" ({rel})" if rel and rel != "other" else ""
+                int_hint = f" - Interessen: {interests}" if interests else ""
+                lines.append(f"- {name}{rel_hint}{int_hint}")
+            return {"success": True, "message": "Familie:\n" + "\n".join(lines)}
+        elif action == "get_member":
+            member = await fm.get_member(args.get("name", ""))
+            if not member:
+                return {"success": False, "message": f"{args.get('name', '?')} nicht gefunden."}
+            lines = [f"{k}: {v}" for k, v in member.items() if v and k != "name_key"]
+            return {"success": True, "message": "\n".join(lines)}
+        elif action == "update_member":
+            kwargs = {}
+            for field in ("relationship", "birth_year", "interests"):
+                if field in args:
+                    kwargs[field] = args[field]
+            return await fm.update_member(name=args.get("name", ""), **kwargs)
+        elif action == "remove_member":
+            return await fm.remove_member(name=args.get("name", ""))
+        elif action == "send_family_message":
+            return await fm.send_family_message(
+                message=args.get("message", ""),
+                group=args.get("group", "all"),
+            )
+        elif action == "create_group":
+            return await fm.create_group(
+                group_name=args.get("group", ""),
+                members=args.get("members", []),
+            )
+
+        return {"success": False, "message": f"Unbekannte Aktion: {action}"}
+
+    async def _exec_get_personal_dates(self, args: dict) -> dict:
+        """Anstehende persoenliche Termine abfragen."""
+        pd = getattr(self, "_personal_dates", None)
+        if not pd:
+            return {"success": False, "message": "Personal Dates nicht verfuegbar."}
+
+        person = args.get("person", "")
+        days_ahead = args.get("days_ahead", 30)
+
+        if person:
+            dates = await pd.get_person_dates(person)
+            if not dates:
+                return {
+                    "success": True,
+                    "message": f"Keine gespeicherten Termine fuer {person}.",
+                }
+        else:
+            dates = await pd.get_upcoming_dates(days_ahead)
+            if not dates:
+                return {
+                    "success": True,
+                    "message": f"Keine persoenlichen Termine in den naechsten {days_ahead} Tagen.",
+                }
+
+        lines = []
+        for d in dates:
+            person_name = d.get("person", "?").title()
+            date_type = d.get("date_type", "")
+            label = d.get("label", "")
+            date_mm_dd = d.get("date_mm_dd", "")
+            days_until = d.get("days_until")
+
+            type_text = label or {
+                "birthday": "Geburtstag",
+                "anniversary": "Jahrestag",
+                "wedding": "Hochzeitstag",
+            }.get(date_type, date_type or "Termin")
+
+            time_hint = ""
+            if days_until is not None:
+                if days_until == 0:
+                    time_hint = " (HEUTE!)"
+                elif days_until == 1:
+                    time_hint = " (morgen)"
+                elif days_until <= 7:
+                    time_hint = f" (in {days_until} Tagen)"
+
+            lines.append(f"- {person_name}: {type_text} am {date_mm_dd}{time_hint}")
+
+        return {"success": True, "message": "Persoenliche Termine:\n" + "\n".join(lines)}
+
+    async def _exec_manage_meals(self, args: dict) -> dict:
+        """Essensplanung verwalten."""
+        mp = getattr(self, "_meal_planner", None)
+        if not mp:
+            return {"success": False, "message": "Essensplanung nicht verfuegbar."}
+
+        action = args.get("action", "")
+
+        if action == "suggest":
+            return await mp.suggest_from_inventory(
+                portions=args.get("portions", 0),
+            )
+        elif action == "weekly_plan":
+            return await mp.create_weekly_plan(
+                preferences=args.get("preferences", ""),
+                portions=args.get("portions", 0),
+            )
+        elif action == "log_meal":
+            return await mp.log_meal(
+                meal=args.get("meal", ""),
+                meal_type=args.get("meal_type", "abendessen"),
+                portions=args.get("portions", 0),
+                rating=args.get("rating", 0),
+            )
+        elif action == "history":
+            return await mp.get_meal_history(
+                days=args.get("days", 7),
+            )
+        elif action == "check_ingredients":
+            return await mp.add_missing_to_shopping(
+                recipe_ingredients=args.get("ingredients", []),
+            )
+        elif action == "current_plan":
+            return await mp.get_current_plan()
+
+        return {"success": False, "message": f"Unbekannte Aktion: {action}"}

--- a/assistant/assistant/main.py
+++ b/assistant/assistant/main.py
@@ -7699,6 +7699,315 @@ async def ui_delete_personal_date(fact_id: str, token: str = ""):
         raise HTTPException(status_code=500, detail="Interner Fehler")
 
 
+# ==================================================================
+# Personal Assistant UI Endpoints
+# ==================================================================
+
+
+@app.get("/api/ui/tasks")
+async def ui_get_tasks(
+    token: str = "", person: str = "", status: str = "needs_action"
+):
+    """Aufgaben auflisten."""
+    await _check_token(token)
+    try:
+        return await brain.task_manager.list_tasks(person=person, status=status)
+    except Exception as e:
+        logger.error("Tasks API Fehler: %s", e)
+        return {"success": False, "message": "Task Manager nicht verfuegbar."}
+
+
+@app.post("/api/ui/tasks")
+async def ui_add_task(request: Request, token: str = ""):
+    """Neue Aufgabe hinzufuegen."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.task_manager.add_task(
+            title=body.get("title", ""),
+            person=body.get("person", ""),
+            due_date=body.get("due_date", ""),
+            priority=body.get("priority", "medium"),
+            description=body.get("description", ""),
+        )
+    except Exception as e:
+        logger.error("Task add Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.post("/api/ui/tasks/complete")
+async def ui_complete_task(request: Request, token: str = ""):
+    """Aufgabe als erledigt markieren."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.task_manager.complete_task(title=body.get("title", ""))
+    except Exception as e:
+        logger.error("Task complete Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.delete("/api/ui/tasks")
+async def ui_remove_task(request: Request, token: str = ""):
+    """Aufgabe entfernen."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.task_manager.remove_task(title=body.get("title", ""))
+    except Exception as e:
+        logger.error("Task remove Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.get("/api/ui/tasks/recurring")
+async def ui_get_recurring_tasks(token: str = ""):
+    """Wiederkehrende Aufgaben auflisten."""
+    await _check_token(token)
+    try:
+        return await brain.task_manager.list_recurring_tasks()
+    except Exception as e:
+        logger.error("Recurring tasks Fehler: %s", e)
+        return {"success": False, "message": "Task Manager nicht verfuegbar."}
+
+
+@app.post("/api/ui/tasks/recurring")
+async def ui_add_recurring_task(request: Request, token: str = ""):
+    """Wiederkehrende Aufgabe erstellen."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.task_manager.add_recurring_task(
+            title=body.get("title", ""),
+            recurrence=body.get("recurrence", ""),
+            weekday=body.get("weekday", ""),
+            person=body.get("person", ""),
+        )
+    except Exception as e:
+        logger.error("Recurring task add Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.delete("/api/ui/tasks/recurring")
+async def ui_delete_recurring_task(request: Request, token: str = ""):
+    """Wiederkehrende Aufgabe loeschen."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.task_manager.delete_recurring_task(
+            title=body.get("title", "")
+        )
+    except Exception as e:
+        logger.error("Recurring task delete Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+# --- Notizen ---
+
+
+@app.get("/api/ui/notes")
+async def ui_get_notes(
+    token: str = "",
+    category: str = "",
+    person: str = "",
+    limit: int = 20,
+):
+    """Notizen auflisten."""
+    await _check_token(token)
+    try:
+        return await brain.note_manager.list_notes(
+            category=category, person=person, limit=min(limit, 100)
+        )
+    except Exception as e:
+        logger.error("Notes API Fehler: %s", e)
+        return {"success": False, "message": "Notiz-System nicht verfuegbar."}
+
+
+@app.post("/api/ui/notes")
+async def ui_add_note(request: Request, token: str = ""):
+    """Neue Notiz erstellen."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.note_manager.add_note(
+            content=body.get("content", ""),
+            category=body.get("category", "sonstiges"),
+            person=body.get("person", ""),
+            tags=body.get("tags", ""),
+        )
+    except Exception as e:
+        logger.error("Note add Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.get("/api/ui/notes/search")
+async def ui_search_notes(token: str = "", query: str = "", limit: int = 10):
+    """Notizen durchsuchen."""
+    await _check_token(token)
+    try:
+        return await brain.note_manager.search_notes(
+            query=query, limit=min(limit, 50)
+        )
+    except Exception as e:
+        logger.error("Notes search Fehler: %s", e)
+        return {"success": False, "message": "Suche fehlgeschlagen."}
+
+
+@app.delete("/api/ui/notes/{note_id}")
+async def ui_delete_note(note_id: str, token: str = ""):
+    """Notiz loeschen."""
+    await _check_token(token)
+    try:
+        return await brain.note_manager.delete_note(note_id=note_id)
+    except Exception as e:
+        logger.error("Note delete Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.get("/api/ui/notes/categories")
+async def ui_note_categories(token: str = ""):
+    """Notiz-Kategorien mit Anzahl."""
+    await _check_token(token)
+    try:
+        return await brain.note_manager.get_note_categories()
+    except Exception as e:
+        logger.error("Note categories Fehler: %s", e)
+        return {"success": False, "message": "Fehler."}
+
+
+# --- Familie ---
+
+
+@app.get("/api/ui/family")
+async def ui_get_family(token: str = ""):
+    """Alle Familienmitglieder auflisten."""
+    await _check_token(token)
+    try:
+        members = await brain.family_manager.get_all_members()
+        return {"success": True, "members": members}
+    except Exception as e:
+        logger.error("Family API Fehler: %s", e)
+        return {"success": False, "members": []}
+
+
+@app.post("/api/ui/family")
+async def ui_add_family_member(request: Request, token: str = ""):
+    """Familienmitglied hinzufuegen."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        result = await brain.family_manager.add_member(
+            name=body.get("name", ""),
+            relationship=body.get("relationship", "other"),
+            birth_year=body.get("birth_year", 0),
+            interests=body.get("interests", ""),
+            ha_person_entity=body.get("ha_person_entity", ""),
+            notification_target=body.get("notification_target", ""),
+        )
+        if result.get("success"):
+            _audit_log("family_member_add", {"name": body.get("name", "")})
+        return result
+    except Exception as e:
+        logger.error("Family add Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.put("/api/ui/family/{name}")
+async def ui_update_family_member(name: str, request: Request, token: str = ""):
+    """Familienmitglied aktualisieren."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.family_manager.update_member(name=name, **body)
+    except Exception as e:
+        logger.error("Family update Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.delete("/api/ui/family/{name}")
+async def ui_delete_family_member(name: str, token: str = ""):
+    """Familienmitglied entfernen."""
+    await _check_token(token)
+    try:
+        result = await brain.family_manager.remove_member(name=name)
+        if result.get("success"):
+            _audit_log("family_member_remove", {"name": name})
+        return result
+    except Exception as e:
+        logger.error("Family delete Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+# --- Essensplanung ---
+
+
+@app.get("/api/ui/meals/plan")
+async def ui_get_meal_plan(token: str = ""):
+    """Aktuellen Wochenplan abrufen."""
+    await _check_token(token)
+    try:
+        return await brain.meal_planner.get_current_plan()
+    except Exception as e:
+        logger.error("Meal plan Fehler: %s", e)
+        return {"success": False, "message": "Essensplanung nicht verfuegbar."}
+
+
+@app.post("/api/ui/meals/plan")
+async def ui_create_meal_plan(request: Request, token: str = ""):
+    """Neuen Wochenplan erstellen."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.meal_planner.create_weekly_plan(
+            preferences=body.get("preferences", ""),
+            portions=body.get("portions", 0),
+        )
+    except Exception as e:
+        logger.error("Meal plan create Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.get("/api/ui/meals/history")
+async def ui_get_meal_history(token: str = "", days: int = 7):
+    """Mahlzeiten-Historie abrufen."""
+    await _check_token(token)
+    try:
+        return await brain.meal_planner.get_meal_history(days=min(days, 90))
+    except Exception as e:
+        logger.error("Meal history Fehler: %s", e)
+        return {"success": False, "message": "Fehler."}
+
+
+@app.post("/api/ui/meals/log")
+async def ui_log_meal(request: Request, token: str = ""):
+    """Mahlzeit protokollieren."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.meal_planner.log_meal(
+            meal=body.get("meal", ""),
+            meal_type=body.get("meal_type", "abendessen"),
+            portions=body.get("portions", 0),
+            rating=body.get("rating", 0),
+        )
+    except Exception as e:
+        logger.error("Meal log Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
+@app.post("/api/ui/meals/suggest")
+async def ui_suggest_meals(request: Request, token: str = ""):
+    """Gerichte aus Vorraeten vorschlagen."""
+    await _check_token(token)
+    body = await request.json()
+    try:
+        return await brain.meal_planner.suggest_from_inventory(
+            portions=body.get("portions", 0),
+        )
+    except Exception as e:
+        logger.error("Meal suggest Fehler: %s", e)
+        raise HTTPException(status_code=500, detail="Interner Fehler")
+
+
 @app.get("/api/ui/logs")
 async def ui_get_logs(token: str = "", limit: int = 50):
     """Letzte Konversationen aus dem Working Memory."""

--- a/assistant/assistant/meal_planner.py
+++ b/assistant/assistant/meal_planner.py
@@ -60,6 +60,11 @@ class MealPlanner:
         self.smart_shopping = None
         self.semantic_memory = None
         self.ha = None
+        self.model_router = None
+
+    def set_model_router(self, router):
+        """Setzt den ModelRouter fuer LLM-Tier-Auswahl."""
+        self.model_router = router
 
     async def initialize(self, redis_client: Optional[aioredis.Redis] = None):
         """Initialisiert mit Redis-Verbindung."""
@@ -386,9 +391,14 @@ class MealPlanner:
     # Interne Helfer
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _get_model(tier: str) -> str:
+    def _get_model(self, tier: str) -> str:
         """Holt das konfigurierte Modell fuer eine Tier-Stufe."""
+        if self.model_router:
+            return getattr(
+                self.model_router,
+                f"model_{tier}",
+                self.model_router.model_smart,
+            )
         from .config import settings
 
         tier_map = {

--- a/assistant/assistant/meal_planner.py
+++ b/assistant/assistant/meal_planner.py
@@ -1,0 +1,555 @@
+"""
+Meal Planner - Essensplanung die Cooking, Shopping und Inventory verbindet.
+
+Erstellt Wochenplaene basierend auf:
+- Vorhandenen Vorraeten (Inventory)
+- Gespeicherten Vorlieben & Allergien (Semantic Memory)
+- Vergangenen Mahlzeiten (History)
+- Einkaufsmustern (Smart Shopping)
+
+Features:
+- Wochenplan erstellen (LLM-gestuetzt)
+- "Was koennen wir mit dem kochen was wir haben?"
+- Fehlende Zutaten automatisch auf Einkaufsliste
+- Mahlzeiten-Historie fuehren
+- Ernaehrungsbalance beruecksichtigen
+
+Redis Keys:
+- mha:meals:plan:{week_key}      - Wochenplan (Hash)
+- mha:meals:history               - Mahlzeiten-Historie (Sorted Set)
+- mha:meals:entry:{meal_id}       - Einzelne Mahlzeit (Hash)
+"""
+
+import json
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import redis.asyncio as aioredis
+
+from .config import yaml_config
+
+logger = logging.getLogger(__name__)
+
+_cfg = yaml_config.get("meal_planner", {})
+_ENABLED = _cfg.get("enabled", True)
+_DEFAULT_PORTIONS = _cfg.get("default_portions", 2)
+_HISTORY_MAX_ENTRIES = _cfg.get("history_max_entries", 100)
+_PLAN_TTL_DAYS = _cfg.get("plan_ttl_days", 14)
+
+_MEAL_TYPES = frozenset({"fruehstueck", "mittagessen", "abendessen", "snack"})
+_WEEKDAYS_DE = [
+    "Montag",
+    "Dienstag",
+    "Mittwoch",
+    "Donnerstag",
+    "Freitag",
+    "Samstag",
+    "Sonntag",
+]
+
+
+class MealPlanner:
+    """Essensplanung mit Integration von Cooking, Shopping und Inventory."""
+
+    def __init__(self, ollama_client):
+        self.ollama = ollama_client
+        self.redis: Optional[aioredis.Redis] = None
+        self.inventory = None
+        self.smart_shopping = None
+        self.semantic_memory = None
+        self.ha = None
+
+    async def initialize(self, redis_client: Optional[aioredis.Redis] = None):
+        """Initialisiert mit Redis-Verbindung."""
+        self.redis = redis_client
+        logger.info("MealPlanner initialisiert")
+
+    # ------------------------------------------------------------------
+    # Oeffentliche API
+    # ------------------------------------------------------------------
+
+    async def suggest_from_inventory(self, portions: int = 0) -> dict:
+        """Schlaegt Gerichte vor basierend auf vorhandenen Vorraeten.
+
+        'Was koennen wir mit dem kochen was wir haben?'
+        """
+        if not self.inventory:
+            return {
+                "success": False,
+                "message": "Inventar-System nicht verfuegbar.",
+            }
+
+        portions = portions or _DEFAULT_PORTIONS
+
+        # Vorraete laden
+        inv_result = await self.inventory.list_items()
+        items = inv_result.get("items", [])
+        if not items:
+            return {
+                "success": True,
+                "message": "Keine Vorraete gespeichert. "
+                "Fuege zuerst Artikel zum Inventar hinzu.",
+            }
+
+        # Items die bald ablaufen priorisieren
+        item_names = []
+        priority_items = []
+        for item in items:
+            name = item.get("name", "")
+            if name:
+                item_names.append(name)
+                expiry = item.get("expiry_date", "")
+                if expiry:
+                    try:
+                        exp_date = datetime.strptime(expiry, "%Y-%m-%d").replace(
+                            tzinfo=timezone.utc
+                        )
+                        days_left = (
+                            exp_date.date() - datetime.now(timezone.utc).date()
+                        ).days
+                        if days_left <= 3:
+                            priority_items.append(
+                                f"{name} (laeuft in {days_left} Tagen ab!)"
+                            )
+                    except ValueError:
+                        pass
+
+        # Vorlieben und Allergien laden
+        dietary_info = await self._get_dietary_info()
+
+        # LLM fragen
+        prompt = self._build_suggestion_prompt(
+            item_names, priority_items, dietary_info, portions
+        )
+
+        try:
+            response = await self.ollama.generate(
+                prompt=prompt,
+                model_tier="smart",
+                max_tokens=800,
+            )
+            return {
+                "success": True,
+                "message": response.strip(),
+            }
+        except Exception as e:
+            logger.error("LLM-Fehler bei Essensvorschlag: %s", e)
+            return {
+                "success": False,
+                "message": "Konnte keine Vorschlaege generieren.",
+            }
+
+    async def create_weekly_plan(
+        self, preferences: str = "", portions: int = 0
+    ) -> dict:
+        """Erstellt einen Wochenplan.
+
+        Args:
+            preferences: Optionale Wuensche ("viel Gemuese", "keine Pasta", etc.)
+            portions: Anzahl Portionen
+        """
+        portions = portions or _DEFAULT_PORTIONS
+
+        # Kontext sammeln
+        dietary_info = await self._get_dietary_info()
+        recent_meals = await self._get_recent_meals(14)  # Letzte 2 Wochen
+        inventory_items = await self._get_inventory_items()
+
+        prompt = self._build_plan_prompt(
+            dietary_info, recent_meals, inventory_items, preferences, portions
+        )
+
+        try:
+            response = await self.ollama.generate(
+                prompt=prompt,
+                model_tier="deep",  # Komplexere Aufgabe
+                max_tokens=1500,
+            )
+
+            # Plan speichern
+            if self.redis:
+                now = datetime.now(timezone.utc)
+                week_key = now.strftime("%Y-W%V")
+                plan_data = {
+                    "content": response.strip(),
+                    "portions": str(portions),
+                    "preferences": preferences,
+                    "created_at": now.isoformat(),
+                }
+                await self.redis.hset(f"mha:meals:plan:{week_key}", mapping=plan_data)
+                await self.redis.expire(
+                    f"mha:meals:plan:{week_key}", _PLAN_TTL_DAYS * 86400
+                )
+
+            return {"success": True, "message": response.strip()}
+        except Exception as e:
+            logger.error("LLM-Fehler bei Wochenplan: %s", e)
+            return {
+                "success": False,
+                "message": "Konnte keinen Wochenplan erstellen.",
+            }
+
+    async def log_meal(
+        self,
+        meal: str,
+        meal_type: str = "abendessen",
+        portions: int = 0,
+        rating: int = 0,
+    ) -> dict:
+        """Protokolliert eine Mahlzeit.
+
+        Args:
+            meal: Was wurde gegessen
+            meal_type: fruehstueck, mittagessen, abendessen, snack
+            portions: Wie viele Portionen
+            rating: 1-5 Bewertung (0 = keine)
+        """
+        if not meal:
+            return {"success": False, "message": "Keine Mahlzeit angegeben."}
+
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        meal_type = (
+            meal_type.lower() if meal_type.lower() in _MEAL_TYPES else "abendessen"
+        )
+
+        meal_id = f"meal_{uuid.uuid4().hex[:8]}"
+        now = datetime.now(timezone.utc)
+
+        entry = {
+            "id": meal_id,
+            "meal": meal.strip(),
+            "meal_type": meal_type,
+            "portions": str(portions or _DEFAULT_PORTIONS),
+            "rating": str(max(0, min(5, rating))),
+            "date": now.strftime("%Y-%m-%d"),
+            "created_at": now.isoformat(),
+        }
+
+        await self.redis.hset(f"mha:meals:entry:{meal_id}", mapping=entry)
+        await self.redis.zadd("mha:meals:history", {meal_id: now.timestamp()})
+
+        # Limit einhalten
+        total = await self.redis.zcard("mha:meals:history")
+        if total > _HISTORY_MAX_ENTRIES:
+            oldest = await self.redis.zrange(
+                "mha:meals:history", 0, total - _HISTORY_MAX_ENTRIES - 1
+            )
+            for old_id in oldest:
+                old_str = old_id if isinstance(old_id, str) else old_id.decode()
+                await self.redis.delete(f"mha:meals:entry:{old_str}")
+                await self.redis.zrem("mha:meals:history", old_str)
+
+        rating_hint = (
+            f" (Bewertung: {'★' * rating}{'☆' * (5 - rating)})" if rating else ""
+        )
+        return {
+            "success": True,
+            "message": f"Mahlzeit '{meal}' protokolliert{rating_hint}.",
+        }
+
+    async def get_meal_history(self, days: int = 7) -> dict:
+        """Zeigt die Mahlzeiten-Historie der letzten X Tage."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        meal_ids = await self.redis.zrangebyscore(
+            "mha:meals:history",
+            cutoff.timestamp(),
+            "+inf",
+        )
+
+        if not meal_ids:
+            return {
+                "success": True,
+                "message": f"Keine Mahlzeiten in den letzten {days} Tagen protokolliert.",
+            }
+
+        pipe = self.redis.pipeline()
+        ids_list = []
+        for mid in meal_ids:
+            mid_str = mid if isinstance(mid, str) else mid.decode()
+            ids_list.append(mid_str)
+            pipe.hgetall(f"mha:meals:entry:{mid_str}")
+        results = await pipe.execute()
+
+        meals = []
+        for mid, data in zip(ids_list, results):
+            if data:
+                decoded = _decode_hash(data)
+                meals.append(decoded)
+
+        meals.sort(key=lambda m: m.get("created_at", ""), reverse=True)
+
+        lines = []
+        current_date = ""
+        for m in meals:
+            date = m.get("date", "?")
+            if date != current_date:
+                current_date = date
+                lines.append(f"\n{date}:")
+            meal_type = m.get("meal_type", "")
+            meal_name = m.get("meal", "?")
+            rating = int(m.get("rating", "0"))
+            rating_str = f" {'★' * rating}" if rating > 0 else ""
+            lines.append(f"  {meal_type}: {meal_name}{rating_str}")
+
+        return {
+            "success": True,
+            "message": f"Mahlzeiten (letzte {days} Tage):" + "\n".join(lines),
+        }
+
+    async def add_missing_to_shopping(self, recipe_ingredients: list[str]) -> dict:
+        """Fuegt fehlende Zutaten zur Einkaufsliste hinzu.
+
+        Prueft gegen Inventar was bereits vorhanden ist.
+        """
+        if not recipe_ingredients:
+            return {"success": False, "message": "Keine Zutaten angegeben."}
+
+        # Was ist bereits im Inventar?
+        available = set()
+        if self.inventory:
+            inv_result = await self.inventory.list_items()
+            for item in inv_result.get("items", []):
+                available.add(item.get("name", "").lower())
+
+        # Fehlende Zutaten ermitteln
+        missing = []
+        for ingredient in recipe_ingredients:
+            ingredient_clean = ingredient.strip().lower()
+            if ingredient_clean and ingredient_clean not in available:
+                missing.append(ingredient.strip())
+
+        if not missing:
+            return {
+                "success": True,
+                "message": "Alle Zutaten sind bereits vorhanden!",
+            }
+
+        # Auf Einkaufsliste setzen via HA
+        added = []
+        if self.ha:
+            for item in missing:
+                success = await self.ha.call_service(
+                    "shopping_list", "add_item", {"name": item}
+                )
+                if success:
+                    added.append(item)
+
+        if added:
+            return {
+                "success": True,
+                "message": f"{len(added)} fehlende Zutat(en) auf die Einkaufsliste gesetzt: "
+                + ", ".join(added),
+            }
+
+        return {
+            "success": False,
+            "message": "Konnte Zutaten nicht zur Einkaufsliste hinzufuegen.",
+        }
+
+    async def get_current_plan(self) -> dict:
+        """Gibt den aktuellen Wochenplan zurueck."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        now = datetime.now(timezone.utc)
+        week_key = now.strftime("%Y-W%V")
+
+        data = await self.redis.hgetall(f"mha:meals:plan:{week_key}")
+        if not data:
+            return {
+                "success": True,
+                "message": "Kein Wochenplan fuer diese Woche vorhanden. "
+                "Soll ich einen erstellen?",
+            }
+
+        decoded = _decode_hash(data)
+        return {
+            "success": True,
+            "message": decoded.get("content", "Plan nicht lesbar."),
+        }
+
+    def get_context_hints(self) -> list[str]:
+        """Kontext-Hints fuer Context Builder."""
+        return [
+            "MealPlanner aktiv: Essensplanung, Wochenplaene, Mahlzeiten-Historie, "
+            "Zutatenpruefung gegen Inventar"
+        ]
+
+    # ------------------------------------------------------------------
+    # Interne Helfer
+    # ------------------------------------------------------------------
+
+    async def _get_dietary_info(self) -> str:
+        """Laedt Ernaehrungsinfos aus Semantic Memory."""
+        if not self.semantic_memory:
+            return ""
+
+        try:
+            # Gesundheitsfakten (Allergien, Unvertraeglichkeiten)
+            health_facts = await self.semantic_memory.query_facts(
+                category="health", limit=10
+            )
+            # Vorlieben
+            pref_facts = await self.semantic_memory.query_facts(
+                category="preference", limit=10
+            )
+
+            info_parts = []
+            for fact in health_facts or []:
+                content = fact.get("content", "")
+                if content:
+                    info_parts.append(f"Gesundheit: {content}")
+
+            for fact in pref_facts or []:
+                content = fact.get("content", "")
+                if content and any(
+                    kw in content.lower()
+                    for kw in [
+                        "essen",
+                        "kochen",
+                        "gericht",
+                        "mag",
+                        "liebling",
+                        "allergi",
+                    ]
+                ):
+                    info_parts.append(f"Vorliebe: {content}")
+
+            return "\n".join(info_parts) if info_parts else ""
+        except Exception as e:
+            logger.debug("Dietary info Fehler: %s", e)
+            return ""
+
+    async def _get_recent_meals(self, days: int) -> list[str]:
+        """Laedt letzte Mahlzeiten als Strings."""
+        if not self.redis:
+            return []
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        meal_ids = await self.redis.zrangebyscore(
+            "mha:meals:history",
+            cutoff.timestamp(),
+            "+inf",
+        )
+
+        if not meal_ids:
+            return []
+
+        meals = []
+        pipe = self.redis.pipeline()
+        for mid in meal_ids:
+            mid_str = mid if isinstance(mid, str) else mid.decode()
+            pipe.hget(f"mha:meals:entry:{mid_str}", "meal")
+        results = await pipe.execute()
+
+        for r in results:
+            if r:
+                meal_str = r if isinstance(r, str) else r.decode()
+                meals.append(meal_str)
+
+        return meals
+
+    async def _get_inventory_items(self) -> list[str]:
+        """Laedt Inventar-Artikel als Namen."""
+        if not self.inventory:
+            return []
+
+        try:
+            result = await self.inventory.list_items()
+            return [
+                item.get("name", "")
+                for item in result.get("items", [])
+                if item.get("name")
+            ]
+        except Exception:
+            return []
+
+    def _build_suggestion_prompt(
+        self,
+        items: list[str],
+        priority_items: list[str],
+        dietary_info: str,
+        portions: int,
+    ) -> str:
+        """Baut den LLM-Prompt fuer Essensvorschlaege."""
+        prompt = (
+            f"Du bist ein Kochberater. Schlage 3 einfache Gerichte vor, "
+            f"die man mit folgenden Zutaten kochen kann ({portions} Portionen).\n\n"
+            f"Vorhandene Zutaten: {', '.join(items)}\n"
+        )
+        if priority_items:
+            prompt += (
+                f"\nPRIORITAET - Diese Zutaten bald verbrauchen: "
+                f"{', '.join(priority_items)}\n"
+            )
+        if dietary_info:
+            prompt += f"\nErnaehrungshinweise:\n{dietary_info}\n"
+
+        prompt += (
+            "\nFormat: Nummerierte Liste mit Gerichtname und kurzer Zubereitungsinfo. "
+            "Antworte auf Deutsch, kurz und praktisch."
+        )
+        return prompt
+
+    def _build_plan_prompt(
+        self,
+        dietary_info: str,
+        recent_meals: list[str],
+        inventory: list[str],
+        preferences: str,
+        portions: int,
+    ) -> str:
+        """Baut den LLM-Prompt fuer den Wochenplan."""
+        prompt = (
+            f"Erstelle einen Wochenplan fuer Abendessen (Montag bis Sonntag, "
+            f"{portions} Portionen).\n"
+        )
+
+        if dietary_info:
+            prompt += f"\nErnaehrungshinweise:\n{dietary_info}\n"
+
+        if recent_meals:
+            prompt += (
+                f"\nLetzte Gerichte (nicht wiederholen): "
+                f"{', '.join(recent_meals[-10:])}\n"
+            )
+
+        if inventory:
+            prompt += (
+                f"\nVorhandene Zutaten (bevorzugt verwenden): "
+                f"{', '.join(inventory[:20])}\n"
+            )
+
+        if preferences:
+            prompt += f"\nBesondere Wuensche: {preferences}\n"
+
+        prompt += (
+            "\nFormat:\n"
+            "Montag: Gericht - kurze Beschreibung\n"
+            "Dienstag: ...\n"
+            "...\n\n"
+            "Am Ende: Liste der einzukaufenden Zutaten.\n"
+            "Antworte auf Deutsch, praktisch und abwechslungsreich."
+        )
+        return prompt
+
+    async def shutdown(self):
+        """Cleanup."""
+        pass
+
+
+def _decode_hash(data: dict) -> dict:
+    """Dekodiert Redis-Hash bytes zu strings."""
+    decoded = {}
+    for k, v in data.items():
+        key = k if isinstance(k, str) else k.decode()
+        val = v if isinstance(v, str) else v.decode()
+        decoded[key] = val
+    return decoded

--- a/assistant/assistant/meal_planner.py
+++ b/assistant/assistant/meal_planner.py
@@ -127,7 +127,7 @@ class MealPlanner:
         try:
             response = await self.ollama.generate(
                 prompt=prompt,
-                model_tier="smart",
+                model=self._get_model("smart"),
                 max_tokens=800,
             )
             return {
@@ -164,7 +164,7 @@ class MealPlanner:
         try:
             response = await self.ollama.generate(
                 prompt=prompt,
-                model_tier="deep",  # Komplexere Aufgabe
+                model=self._get_model("deep"),
                 max_tokens=1500,
             )
 
@@ -386,6 +386,18 @@ class MealPlanner:
     # Interne Helfer
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _get_model(tier: str) -> str:
+        """Holt das konfigurierte Modell fuer eine Tier-Stufe."""
+        from .config import settings
+
+        tier_map = {
+            "fast": settings.model_fast,
+            "smart": settings.model_smart,
+            "deep": settings.model_deep,
+        }
+        return tier_map.get(tier, settings.model_smart)
+
     async def _get_dietary_info(self) -> str:
         """Laedt Ernaehrungsinfos aus Semantic Memory."""
         if not self.semantic_memory:
@@ -543,6 +555,10 @@ class MealPlanner:
     async def shutdown(self):
         """Cleanup."""
         pass
+
+    async def stop(self):
+        """Alias fuer shutdown (Brain-Kompatibilitaet)."""
+        await self.shutdown()
 
 
 def _decode_hash(data: dict) -> dict:

--- a/assistant/assistant/note_manager.py
+++ b/assistant/assistant/note_manager.py
@@ -1,0 +1,398 @@
+"""
+Note Manager - Persistentes Notiz-System mit semantischer Suche.
+
+Speichert Notizen in Redis (persistent) und ChromaDB (semantische Suche).
+Bietet schnellen Zugriff auf Notizen per Kategorie, Datum und Freitext.
+
+Features:
+- Schnelle Notiz-Erfassung ("Jarvis, merke dir...")
+- Kategorisierte Notizen (haushalt, arbeit, ideen, einkauf, gesundheit, etc.)
+- Semantische Suche via ChromaDB
+- Per-Person Notizen
+- Notiz-Archivierung nach 90 Tagen (statt Loeschung)
+
+Redis Keys:
+- mha:notes:{note_id}           - Notiz-Daten (Hash)
+- mha:notes:all                  - Alle Notiz-IDs (Sorted Set by timestamp)
+- mha:notes:category:{cat}       - Notiz-IDs pro Kategorie (Set)
+- mha:notes:person:{person}      - Notiz-IDs pro Person (Set)
+
+ChromaDB Collection: jarvis_notes
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+import redis.asyncio as aioredis
+
+from .config import yaml_config
+
+logger = logging.getLogger(__name__)
+
+_cfg = yaml_config.get("notes", {})
+_ENABLED = _cfg.get("enabled", True)
+_MAX_NOTES = _cfg.get("max_notes", 500)
+_ARCHIVE_AFTER_DAYS = _cfg.get("archive_after_days", 90)
+_CHROMA_COLLECTION = "jarvis_notes"
+
+_CATEGORIES = frozenset(
+    {
+        "haushalt",
+        "arbeit",
+        "ideen",
+        "einkauf",
+        "gesundheit",
+        "technik",
+        "finanzen",
+        "familie",
+        "rezept",
+        "sonstiges",
+    }
+)
+
+
+class NoteManager:
+    """Persistentes Notiz-System mit semantischer Suche."""
+
+    def __init__(self):
+        self.redis: Optional[aioredis.Redis] = None
+        self.chroma_collection = None
+
+    async def initialize(self, redis_client: Optional[aioredis.Redis] = None):
+        """Initialisiert mit Redis-Verbindung."""
+        self.redis = redis_client
+        logger.info("NoteManager initialisiert")
+
+    def set_chroma_collection(self, collection):
+        """Setzt die ChromaDB Collection fuer semantische Suche."""
+        self.chroma_collection = collection
+
+    # ------------------------------------------------------------------
+    # Oeffentliche API
+    # ------------------------------------------------------------------
+
+    async def add_note(
+        self,
+        content: str,
+        category: str = "sonstiges",
+        person: str = "",
+        tags: str = "",
+    ) -> dict:
+        """Speichert eine neue Notiz."""
+        if not content or not content.strip():
+            return {"success": False, "message": "Kein Notiztext angegeben."}
+
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        content = content.strip()
+        category = category.lower() if category.lower() in _CATEGORIES else "sonstiges"
+
+        note_id = f"note_{uuid.uuid4().hex[:10]}"
+        now = datetime.now(timezone.utc)
+        timestamp = now.timestamp()
+
+        note = {
+            "id": note_id,
+            "content": content,
+            "category": category,
+            "person": person.lower() if person else "",
+            "tags": tags,
+            "created_at": now.isoformat(),
+            "archived": "false",
+        }
+
+        # Redis: Notiz speichern
+        await self.redis.hset(f"mha:notes:{note_id}", mapping=note)
+        await self.redis.zadd("mha:notes:all", {note_id: timestamp})
+        await self.redis.sadd(f"mha:notes:category:{category}", note_id)
+        if person:
+            await self.redis.sadd(f"mha:notes:person:{person.lower()}", note_id)
+
+        # ChromaDB: Fuer semantische Suche indexieren
+        if self.chroma_collection:
+            try:
+                self.chroma_collection.add(
+                    ids=[note_id],
+                    documents=[content],
+                    metadatas=[
+                        {
+                            "category": category,
+                            "person": person.lower() if person else "",
+                            "created_at": now.isoformat(),
+                        }
+                    ],
+                )
+            except Exception as e:
+                logger.warning("ChromaDB Indexierung fehlgeschlagen: %s", e)
+
+        # Limit pruefen
+        total = await self.redis.zcard("mha:notes:all")
+        if total > _MAX_NOTES:
+            await self._archive_oldest()
+
+        return {
+            "success": True,
+            "message": f"Notiz gespeichert ({category}).",
+            "note_id": note_id,
+        }
+
+    async def list_notes(
+        self,
+        category: str = "",
+        person: str = "",
+        limit: int = 10,
+        include_archived: bool = False,
+    ) -> dict:
+        """Listet Notizen auf."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        # IDs ermitteln
+        if category and person:
+            cat_ids = await self.redis.smembers(
+                f"mha:notes:category:{category.lower()}"
+            )
+            person_ids = await self.redis.smembers(f"mha:notes:person:{person.lower()}")
+            note_ids = cat_ids & person_ids
+        elif category:
+            note_ids = await self.redis.smembers(
+                f"mha:notes:category:{category.lower()}"
+            )
+        elif person:
+            note_ids = await self.redis.smembers(f"mha:notes:person:{person.lower()}")
+        else:
+            # Neueste N Notizen (Sorted Set, absteigend)
+            raw = await self.redis.zrevrange("mha:notes:all", 0, limit - 1)
+            note_ids = set(raw) if raw else set()
+
+        if not note_ids:
+            hint = ""
+            if category:
+                hint += f" in '{category}'"
+            if person:
+                hint += f" von {person}"
+            return {"success": True, "message": f"Keine Notizen{hint} gefunden."}
+
+        # Notizen laden
+        notes = await self._fetch_notes(note_ids, include_archived)
+
+        # Sortieren nach Erstellungsdatum (neueste zuerst)
+        notes.sort(key=lambda n: n.get("created_at", ""), reverse=True)
+        notes = notes[:limit]
+
+        if not notes:
+            return {"success": True, "message": "Keine Notizen gefunden."}
+
+        lines = []
+        for n in notes:
+            date_str = n.get("created_at", "")[:10]
+            cat = n.get("category", "")
+            content = n.get("content", "")
+            # Kuerzen wenn zu lang
+            if len(content) > 100:
+                content = content[:97] + "..."
+            person_hint = f" [{n['person']}]" if n.get("person") else ""
+            lines.append(f"- [{date_str}] ({cat}){person_hint} {content}")
+
+        return {
+            "success": True,
+            "message": f"{len(notes)} Notizen:\n" + "\n".join(lines),
+        }
+
+    async def search_notes(self, query: str, limit: int = 5) -> dict:
+        """Durchsucht Notizen semantisch via ChromaDB."""
+        if not query:
+            return {"success": False, "message": "Kein Suchbegriff angegeben."}
+
+        # Erst ChromaDB (semantisch)
+        if self.chroma_collection:
+            try:
+                results = self.chroma_collection.query(
+                    query_texts=[query],
+                    n_results=limit,
+                )
+                if results and results.get("ids") and results["ids"][0]:
+                    note_ids = set(results["ids"][0])
+                    notes = await self._fetch_notes(note_ids)
+
+                    if notes:
+                        lines = []
+                        for n in notes:
+                            date_str = n.get("created_at", "")[:10]
+                            content = n.get("content", "")
+                            if len(content) > 120:
+                                content = content[:117] + "..."
+                            lines.append(f"- [{date_str}] {content}")
+
+                        return {
+                            "success": True,
+                            "message": f"Gefunden ({len(notes)} Treffer):\n"
+                            + "\n".join(lines),
+                        }
+            except Exception as e:
+                logger.warning("ChromaDB Suche fehlgeschlagen: %s", e)
+
+        # Fallback: Einfache Redis-Suche (Substring-Match)
+        return await self._redis_text_search(query, limit)
+
+    async def delete_note(self, note_id: str) -> dict:
+        """Loescht eine Notiz."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        data = await self.redis.hgetall(f"mha:notes:{note_id}")
+        if not data:
+            return {"success": False, "message": f"Notiz '{note_id}' nicht gefunden."}
+
+        decoded = _decode_hash(data)
+        category = decoded.get("category", "")
+        person = decoded.get("person", "")
+
+        # Aus allen Indices entfernen
+        await self.redis.delete(f"mha:notes:{note_id}")
+        await self.redis.zrem("mha:notes:all", note_id)
+        if category:
+            await self.redis.srem(f"mha:notes:category:{category}", note_id)
+        if person:
+            await self.redis.srem(f"mha:notes:person:{person}", note_id)
+
+        # ChromaDB
+        if self.chroma_collection:
+            try:
+                self.chroma_collection.delete(ids=[note_id])
+            except Exception as e:
+                logger.debug("ChromaDB Delete: %s", e)
+
+        return {"success": True, "message": "Notiz geloescht."}
+
+    async def get_note_categories(self) -> dict:
+        """Listet verfuegbare Kategorien mit Anzahl."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        counts = {}
+        for cat in _CATEGORIES:
+            count = await self.redis.scard(f"mha:notes:category:{cat}")
+            if count > 0:
+                counts[cat] = count
+
+        if not counts:
+            return {"success": True, "message": "Noch keine Notizen vorhanden."}
+
+        lines = [f"- {cat}: {count} Notizen" for cat, count in sorted(counts.items())]
+        return {
+            "success": True,
+            "message": "Notiz-Kategorien:\n" + "\n".join(lines),
+        }
+
+    def get_context_hints(self) -> list[str]:
+        """Kontext-Hints fuer Context Builder."""
+        return ["NoteManager aktiv: Notizen erstellen, suchen und verwalten"]
+
+    # ------------------------------------------------------------------
+    # Interne Helfer
+    # ------------------------------------------------------------------
+
+    async def _fetch_notes(
+        self, note_ids: set, include_archived: bool = False
+    ) -> list[dict]:
+        """Laedt Notizen per Pipeline."""
+        if not self.redis or not note_ids:
+            return []
+
+        pipe = self.redis.pipeline()
+        ids_list = []
+        for nid in note_ids:
+            nid_str = nid if isinstance(nid, str) else nid.decode()
+            ids_list.append(nid_str)
+            pipe.hgetall(f"mha:notes:{nid_str}")
+        results = await pipe.execute()
+
+        notes = []
+        for nid, data in zip(ids_list, results):
+            if not data:
+                continue
+            decoded = _decode_hash(data)
+            if not include_archived and decoded.get("archived") == "true":
+                continue
+            notes.append(decoded)
+
+        return notes
+
+    async def _archive_oldest(self):
+        """Archiviert die aeltesten Notizen wenn Limit ueberschritten."""
+        if not self.redis:
+            return
+
+        total = await self.redis.zcard("mha:notes:all")
+        if total <= _MAX_NOTES:
+            return
+
+        # Aelteste Eintraege archivieren
+        excess = total - _MAX_NOTES
+        oldest = await self.redis.zrange("mha:notes:all", 0, excess - 1)
+        for nid in oldest:
+            nid_str = nid if isinstance(nid, str) else nid.decode()
+            await self.redis.hset(f"mha:notes:{nid_str}", "archived", "true")
+
+    async def _redis_text_search(self, query: str, limit: int) -> dict:
+        """Einfache Textsuche ueber Redis (Fallback wenn kein ChromaDB)."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        query_lower = query.lower()
+        # Neueste 100 Notizen durchsuchen
+        recent_ids = await self.redis.zrevrange("mha:notes:all", 0, 99)
+        if not recent_ids:
+            return {"success": True, "message": "Keine Notizen gefunden."}
+
+        matches = []
+        pipe = self.redis.pipeline()
+        ids_list = []
+        for nid in recent_ids:
+            nid_str = nid if isinstance(nid, str) else nid.decode()
+            ids_list.append(nid_str)
+            pipe.hget(f"mha:notes:{nid_str}", "content")
+        contents = await pipe.execute()
+
+        for nid, content in zip(ids_list, contents):
+            if content:
+                content_str = content if isinstance(content, str) else content.decode()
+                if query_lower in content_str.lower():
+                    matches.append(nid)
+                    if len(matches) >= limit:
+                        break
+
+        if not matches:
+            return {"success": True, "message": f"Keine Notizen zu '{query}' gefunden."}
+
+        notes = await self._fetch_notes(set(matches))
+        lines = []
+        for n in notes:
+            date_str = n.get("created_at", "")[:10]
+            content = n.get("content", "")
+            if len(content) > 120:
+                content = content[:117] + "..."
+            lines.append(f"- [{date_str}] {content}")
+
+        return {
+            "success": True,
+            "message": f"{len(notes)} Treffer:\n" + "\n".join(lines),
+        }
+
+    async def shutdown(self):
+        """Cleanup."""
+        pass
+
+
+def _decode_hash(data: dict) -> dict:
+    """Dekodiert Redis-Hash bytes zu strings."""
+    decoded = {}
+    for k, v in data.items():
+        key = k if isinstance(k, str) else k.decode()
+        val = v if isinstance(v, str) else v.decode()
+        decoded[key] = val
+    return decoded

--- a/assistant/assistant/note_manager.py
+++ b/assistant/assistant/note_manager.py
@@ -387,6 +387,10 @@ class NoteManager:
         """Cleanup."""
         pass
 
+    async def stop(self):
+        """Alias fuer shutdown (Brain-Kompatibilitaet)."""
+        await self.shutdown()
+
 
 def _decode_hash(data: dict) -> dict:
     """Dekodiert Redis-Hash bytes zu strings."""

--- a/assistant/assistant/personal_dates.py
+++ b/assistant/assistant/personal_dates.py
@@ -1,0 +1,350 @@
+"""
+Personal Dates - Geburtstags- und Jahrestags-Automatik.
+
+Prueft taeglich (und beim Morgen-Briefing) ob persoenliche Termine
+anstehen. Nutzt die bestehende semantic_memory personal_date Kategorie.
+
+Features:
+- Taeglicher Check auf anstehende Geburtstage/Jahrestage
+- Integration ins Morgen-Briefing
+- Proaktive Erinnerungen 3 Tage, 1 Tag und am Tag selbst
+- Altersberechnung wenn Geburtsjahr bekannt
+- Geschenkvorschlaege basierend auf gespeicherten Vorlieben
+
+Redis Keys:
+- mha:personal_dates:reminded:{date_key}  - Bereits erinnerte Daten (TTL 2 Tage)
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import redis.asyncio as aioredis
+
+from .config import yaml_config
+
+logger = logging.getLogger(__name__)
+
+_cfg = yaml_config.get("personal_dates", {})
+_ENABLED = _cfg.get("enabled", True)
+_REMIND_DAYS_BEFORE = _cfg.get("remind_days_before", [3, 1, 0])
+_CHECK_INTERVAL_HOURS = _cfg.get("check_interval_hours", 6)
+_BRIEFING_LOOKAHEAD_DAYS = _cfg.get("briefing_lookahead_days", 7)
+
+
+class PersonalDatesManager:
+    """Geburtstags- und Jahrestags-Erinnerungen."""
+
+    def __init__(self):
+        self.redis: Optional[aioredis.Redis] = None
+        self.semantic_memory = None
+        self._notify_callback = None
+        self._check_task: Optional[asyncio.Task] = None
+
+    async def initialize(self, redis_client: Optional[aioredis.Redis] = None):
+        """Initialisiert mit Redis-Verbindung."""
+        self.redis = redis_client
+        if _ENABLED and self.redis:
+            self._check_task = asyncio.create_task(self._check_loop())
+            self._check_task.add_done_callback(
+                lambda t: t.exception() if not t.cancelled() else None
+            )
+        logger.info("PersonalDatesManager initialisiert")
+
+    def set_notify_callback(self, callback):
+        """Setzt Callback fuer proaktive Erinnerungen."""
+        self._notify_callback = callback
+
+    def set_semantic_memory(self, semantic_memory):
+        """Verbindet mit dem SemanticMemory fuer Fakten-Zugriff."""
+        self.semantic_memory = semantic_memory
+
+    # ------------------------------------------------------------------
+    # Morgen-Briefing Integration
+    # ------------------------------------------------------------------
+
+    async def get_briefing_section(self, days_ahead: int = 0) -> str:
+        """Liefert den persoenliche-Termine-Abschnitt fuers Morgen-Briefing.
+
+        Args:
+            days_ahead: Wie viele Tage vorausschauen (0 = Config-Default)
+        """
+        if not _ENABLED:
+            return ""
+
+        lookahead = days_ahead or _BRIEFING_LOOKAHEAD_DAYS
+        upcoming = await self.get_upcoming_dates(lookahead)
+
+        if not upcoming:
+            return ""
+
+        lines = []
+        for entry in upcoming:
+            days_until = entry["days_until"]
+            person = entry.get("person", "Unbekannt")
+            date_type = entry.get("date_type", "")
+            label = entry.get("label", "")
+            year = entry.get("year", "")
+
+            # Typ-spezifische Bezeichnung
+            type_text = _format_date_type(date_type, label)
+
+            # Altersberechnung
+            age_text = ""
+            if year and date_type == "birthday":
+                try:
+                    birth_year = int(year)
+                    now = datetime.now(timezone.utc)
+                    age = now.year - birth_year
+                    age_text = f" (wird {age})"
+                except (ValueError, TypeError):
+                    pass
+
+            # Zeitangabe
+            if days_until == 0:
+                time_text = "HEUTE"
+            elif days_until == 1:
+                time_text = "morgen"
+            else:
+                time_text = f"in {days_until} Tagen"
+
+            person_title = person.title() if person else "Unbekannt"
+            lines.append(f"- {person_title}: {type_text}{age_text} {time_text}")
+
+        return "Persoenliche Termine:\n" + "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Daten-Abfrage
+    # ------------------------------------------------------------------
+
+    async def get_upcoming_dates(self, days_ahead: int = 7) -> list[dict]:
+        """Findet anstehende persoenliche Termine.
+
+        Returns:
+            Liste von Dicts mit: person, date_type, date_mm_dd, year, label,
+            content, days_until, fact_id
+        """
+        if not self.redis:
+            return []
+
+        # Alle personal_date Facts aus Redis laden
+        fact_ids = await self.redis.smembers("mha:facts:category:personal_date")
+        if not fact_ids:
+            return []
+
+        ids_list = []
+        pipe = self.redis.pipeline()
+        for fid in fact_ids:
+            fid_str = fid if isinstance(fid, str) else fid.decode()
+            ids_list.append(fid_str)
+            pipe.hgetall(f"mha:fact:{fid_str}")
+        all_data = await pipe.execute()
+
+        now = datetime.now(timezone.utc)
+        current_year = now.year
+        results = []
+
+        for fid, data in zip(ids_list, all_data):
+            if not data:
+                continue
+
+            # Decode bytes
+            decoded = {}
+            for k, v in data.items():
+                key = k if isinstance(k, str) else k.decode()
+                val = v if isinstance(v, str) else v.decode()
+                decoded[key] = val
+
+            date_mm_dd = decoded.get("date_mm_dd", "")
+            if not date_mm_dd:
+                continue
+
+            try:
+                # Parse Datum (Format: MM-DD oder MM/DD)
+                date_mm_dd_clean = date_mm_dd.replace("/", "-")
+                target = datetime.strptime(
+                    f"{current_year}-{date_mm_dd_clean}", "%Y-%m-%d"
+                ).replace(tzinfo=timezone.utc)
+
+                # Wenn Datum schon vorbei, naechstes Jahr nehmen
+                if target.date() < now.date():
+                    target = target.replace(year=current_year + 1)
+
+                days_until = (target.date() - now.date()).days
+
+                if days_until <= days_ahead:
+                    results.append(
+                        {
+                            "fact_id": fid,
+                            "person": decoded.get("person", ""),
+                            "date_type": decoded.get("date_type", ""),
+                            "date_mm_dd": date_mm_dd,
+                            "year": decoded.get("date_year", decoded.get("year", "")),
+                            "label": decoded.get(
+                                "date_label", decoded.get("label", "")
+                            ),
+                            "content": decoded.get("content", ""),
+                            "days_until": days_until,
+                        }
+                    )
+            except (ValueError, TypeError) as e:
+                logger.debug("Ungültiges Datum '%s': %s", date_mm_dd, e)
+                continue
+
+        return sorted(results, key=lambda r: r["days_until"])
+
+    async def get_person_dates(self, person: str) -> list[dict]:
+        """Findet alle gespeicherten Termine fuer eine Person."""
+        if not self.redis:
+            return []
+
+        # Suche in person-Index
+        fact_ids = await self.redis.smembers(f"mha:facts:person:{person.lower()}")
+        if not fact_ids:
+            return []
+
+        results = []
+        pipe = self.redis.pipeline()
+        ids_list = []
+        for fid in fact_ids:
+            fid_str = fid if isinstance(fid, str) else fid.decode()
+            ids_list.append(fid_str)
+            pipe.hgetall(f"mha:fact:{fid_str}")
+        all_data = await pipe.execute()
+
+        for fid, data in zip(ids_list, all_data):
+            if not data:
+                continue
+            decoded = {}
+            for k, v in data.items():
+                key = k if isinstance(k, str) else k.decode()
+                val = v if isinstance(v, str) else v.decode()
+                decoded[key] = val
+
+            if decoded.get("category") == "personal_date":
+                results.append(
+                    {
+                        "fact_id": fid,
+                        "person": decoded.get("person", ""),
+                        "date_type": decoded.get("date_type", ""),
+                        "date_mm_dd": decoded.get("date_mm_dd", ""),
+                        "year": decoded.get("date_year", decoded.get("year", "")),
+                        "label": decoded.get("date_label", decoded.get("label", "")),
+                        "content": decoded.get("content", ""),
+                    }
+                )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Proaktive Erinnerungen
+    # ------------------------------------------------------------------
+
+    async def check_and_notify(self):
+        """Prueft auf anstehende Termine und sendet Erinnerungen."""
+        if not _ENABLED or not self._notify_callback:
+            return
+
+        max_days = max(_REMIND_DAYS_BEFORE) if _REMIND_DAYS_BEFORE else 3
+        upcoming = await self.get_upcoming_dates(max_days)
+
+        for entry in upcoming:
+            days_until = entry["days_until"]
+            if days_until not in _REMIND_DAYS_BEFORE:
+                continue
+
+            # Pruefen ob schon erinnert
+            date_key = f"{entry['person']}:{entry['date_mm_dd']}:{days_until}"
+            reminded_key = f"mha:personal_dates:reminded:{date_key}"
+
+            if self.redis:
+                already_reminded = await self.redis.exists(reminded_key)
+                if already_reminded:
+                    continue
+
+            # Erinnerung senden
+            message = self._format_reminder(entry)
+            priority = "high" if days_until == 0 else "medium"
+
+            try:
+                await self._notify_callback(
+                    message=message,
+                    priority=priority,
+                )
+            except Exception as e:
+                logger.warning("Fehler bei Geburtstags-Benachrichtigung: %s", e)
+                continue
+
+            # Als erinnert markieren (2 Tage TTL)
+            if self.redis:
+                await self.redis.set(reminded_key, "1", ex=172800)
+
+    def _format_reminder(self, entry: dict) -> str:
+        """Formatiert eine Erinnerungsnachricht."""
+        days_until = entry["days_until"]
+        person = entry.get("person", "").title()
+        date_type = entry.get("date_type", "")
+        label = entry.get("label", "")
+        year = entry.get("year", "")
+
+        type_text = _format_date_type(date_type, label)
+
+        if days_until == 0:
+            age_text = ""
+            if year and date_type == "birthday":
+                try:
+                    age = datetime.now(timezone.utc).year - int(year)
+                    age_text = f" {person} wird heute {age}!"
+                except (ValueError, TypeError):
+                    pass
+            return f"Heute ist {person}s {type_text}!{age_text}"
+        elif days_until == 1:
+            return f"Erinnerung: Morgen ist {person}s {type_text}."
+        else:
+            return f"In {days_until} Tagen ist {person}s {type_text}."
+
+    # ------------------------------------------------------------------
+    # Background Loop
+    # ------------------------------------------------------------------
+
+    async def _check_loop(self):
+        """Periodischer Check auf anstehende Termine."""
+        # Erster Check nach 2 Minuten (System muss erst hochfahren)
+        await asyncio.sleep(120)
+        while True:
+            try:
+                await self.check_and_notify()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Fehler im PersonalDates Check: %s", e)
+            await asyncio.sleep(_CHECK_INTERVAL_HOURS * 3600)
+
+    async def shutdown(self):
+        """Beendet den Check-Loop."""
+        if self._check_task and not self._check_task.done():
+            self._check_task.cancel()
+            try:
+                await self._check_task
+            except asyncio.CancelledError:
+                pass
+
+
+# ------------------------------------------------------------------
+# Hilfsfunktionen
+# ------------------------------------------------------------------
+
+
+def _format_date_type(date_type: str, label: str = "") -> str:
+    """Formatiert den Typ eines persoenlichen Datums leserlich."""
+    if label:
+        return label
+    type_map = {
+        "birthday": "Geburtstag",
+        "anniversary": "Jahrestag",
+        "wedding": "Hochzeitstag",
+        "memorial": "Gedenktag",
+        "nameday": "Namenstag",
+    }
+    return type_map.get(date_type, date_type or "besonderer Tag")

--- a/assistant/assistant/personal_dates.py
+++ b/assistant/assistant/personal_dates.py
@@ -330,6 +330,10 @@ class PersonalDatesManager:
             except asyncio.CancelledError:
                 pass
 
+    async def stop(self):
+        """Alias fuer shutdown (Brain-Kompatibilitaet)."""
+        await self.shutdown()
+
 
 # ------------------------------------------------------------------
 # Hilfsfunktionen

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -5965,8 +5965,9 @@ class ProactiveManager:
             return False
         try:
             rate_key = f"mha:cover:rate_limit:{entity_id}"
-            count = await redis_client.get(rate_key)
-            if count and int(count) >= self._COVER_RATE_LIMIT_MAX:
+            count_raw = await redis_client.get(rate_key)
+            count = int(count_raw.decode() if isinstance(count_raw, bytes) else count_raw) if count_raw else 0
+            if count >= self._COVER_RATE_LIMIT_MAX:
                 logger.warning(
                     "Cover Rate-Limit: %s hat %s Aktionen/h erreicht — blockiert",
                     entity_id,
@@ -6227,11 +6228,26 @@ class ProactiveManager:
                 if redis_client:
                     acting_key = f"mha:cover:jarvis_acting:{entity_id}"
                     await redis_client.set(acting_key, "1", ex=300)
-                await self.brain.ha.call_service(
-                    "cover",
-                    "set_cover_position",
-                    {"entity_id": entity_id, "position": ha_pos},
-                )
+                try:
+                    await self.brain.ha.call_service(
+                        "cover",
+                        "set_cover_position",
+                        {"entity_id": entity_id, "position": ha_pos},
+                    )
+                except Exception as ha_err:
+                    # HA-Call fehlgeschlagen → jarvis_acting Flag aufräumen
+                    # damit Manual Override Detection nicht blockiert wird
+                    if redis_client:
+                        try:
+                            await redis_client.delete(acting_key)
+                        except Exception:
+                            pass
+                    logger.error(
+                        "Cover-Auto: HA call_service fehlgeschlagen für %s: %s",
+                        entity_id,
+                        ha_err,
+                    )
+                    return False
                 logger.info(
                     "Cover-Auto: %s -> %d%% (HA: %d%%) (%s)",
                     entity_id,
@@ -6572,9 +6588,12 @@ class ProactiveManager:
             effective_temp = temp
             if indoor_sensor:
                 indoor_temp = self._get_indoor_temp(states, indoor_sensor)
-                if indoor_temp != 0.0 or any(
+                # indoor_temp pruefen: Nur verwenden wenn Sensor tatsaechlich
+                # vorhanden ist (nicht nur != 0.0, da 0°C ein valider Wert ist)
+                _has_indoor_sensor = any(
                     s.get("entity_id") == indoor_sensor for s in (states or [])
-                ):
+                )
+                if _has_indoor_sensor:
                     effective_temp = max(temp, indoor_temp)
 
             # Feature 14: Sitzsensor — Blendschutz unabhängig von Temperatur
@@ -7181,13 +7200,15 @@ class ProactiveManager:
                                     "cover."
                                 ) and await self.brain.executor._is_safe_cover(eid, cs):
                                     if not self.brain.executor._is_markise(eid, cs):
-                                        await self._auto_cover_action(
+                                        acted = await self._auto_cover_action(
                                             eid,
                                             100,
                                             "Urlaubssimulation (morgens)",
                                             auto_level,
                                             redis_client,
                                         )
+                                        if acted and cycle_acted is not None:
+                                            cycle_acted.add(eid)
                             last_schedule_action = "open"
 
                     # Abends teilweise schliessen (mit Variation)
@@ -7198,13 +7219,15 @@ class ProactiveManager:
                                 "cover."
                             ) and await self.brain.executor._is_safe_cover(eid, cs):
                                 if not self.brain.executor._is_markise(eid, cs):
-                                    await self._auto_cover_action(
+                                    acted = await self._auto_cover_action(
                                         eid,
                                         30,
                                         "Urlaubssimulation (abends, Sichtschutz)",
                                         auto_level,
                                         redis_client,
                                     )
+                                    if acted and cycle_acted is not None:
+                                        cycle_acted.add(eid)
                         last_schedule_action = "close"
 
                     # Nachts komplett zu
@@ -7215,13 +7238,15 @@ class ProactiveManager:
                                 "cover."
                             ) and await self.brain.executor._is_safe_cover(eid, cs):
                                 if not self.brain.executor._is_markise(eid, cs):
-                                    await self._auto_cover_action(
+                                    acted = await self._auto_cover_action(
                                         eid,
                                         0,
                                         "Urlaubssimulation (Nacht)",
                                         auto_level,
                                         redis_client,
                                     )
+                                    if acted and cycle_acted is not None:
+                                        cycle_acted.add(eid)
                         last_schedule_action = "close"
 
         return last_schedule_action
@@ -7626,7 +7651,7 @@ class ProactiveManager:
         if elevation > 0:
             return  # Nur nach Sonnenuntergang
 
-        current_hour = _dt.now(timezone.utc).hour
+        current_hour = _dt.now(_LOCAL_TZ).hour
         cover_cfg = yaml_config.get("seasonal_actions", {}).get("cover_automation", {})
         global_close_hour = cover_cfg.get("privacy_close_hour", None)
 

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -5960,7 +5960,7 @@ class ProactiveManager:
                             reason_data.get("reason", "?"),
                         )
                         reconciled += 1
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, AttributeError):
                     pass
             if reconciled > 0:
                 logger.info(
@@ -6084,29 +6084,33 @@ class ProactiveManager:
         )
 
     async def _track_cover_anomaly(self, entity_id: str, redis_client):
-        """Trackt Anomalien (Ping-Pong-Erkennung): Wenn >4 Anomalien in 2h → Warnung."""
+        """Trackt Anomalien (Ping-Pong-Erkennung): Wenn >=4 Anomalien in 2h → Warnung."""
         if not redis_client:
             return
         try:
             anomaly_key = f"mha:cover:anomaly:{entity_id}"
+            notify_cooldown_key = f"mha:cover:anomaly_notified:{entity_id}"
             count = await redis_client.incr(anomaly_key)
             if count == 1:
                 await redis_client.expire(anomaly_key, 7200)  # 2h Fenster
             if count >= 4:
-                logger.warning(
-                    "Cover Anomalie: %s hat %d unerwartete Positionsänderungen in 2h (Ping-Pong?)",
-                    entity_id,
-                    count,
-                )
-                await self._notify(
-                    "cover_anomaly",
-                    MEDIUM,
-                    {
-                        "message": f"Rollladen {entity_id} zeigt ungewöhnliches Verhalten ({count} Anomalien in 2h) — möglicherweise Ping-Pong",
-                        "entity": entity_id,
-                    },
-                )
-                await redis_client.delete(anomaly_key)  # Reset nach Warnung
+                # Notification-Cooldown: Nur 1x pro Stunde warnen (nicht Counter resetten)
+                already_notified = await redis_client.get(notify_cooldown_key)
+                if not already_notified:
+                    logger.warning(
+                        "Cover Anomalie: %s hat %d unerwartete Positionsänderungen in 2h (Ping-Pong?)",
+                        entity_id,
+                        count,
+                    )
+                    await self._notify(
+                        "cover_anomaly",
+                        MEDIUM,
+                        {
+                            "message": f"Rollladen {entity_id} zeigt ungewöhnliches Verhalten ({count} Anomalien in 2h) — möglicherweise Ping-Pong",
+                            "entity": entity_id,
+                        },
+                    )
+                    await redis_client.set(notify_cooldown_key, "1", ex=3600)  # 1h Cooldown
         except Exception as e:
             logger.warning("Unhandled: %s", e)
 
@@ -9662,6 +9666,23 @@ class ProactiveManager:
                         wind,
                         storm_speed,
                     )
+                    # Sofort-Aktion: Markisen einfahren bei Sturm
+                    auto_level = cover_cfg.get("auto_execute_level", 3)
+                    try:
+                        states = await self.brain.ha.get_states()
+                        for s in states or []:
+                            eid = s.get("entity_id", "")
+                            if eid.startswith("cover.") and self.brain.executor._is_markise(eid, s):
+                                if await self.brain.executor._is_safe_cover(eid, s):
+                                    await self._auto_cover_action(
+                                        eid, 0,
+                                        f"Sofort-Sturmschutz ({wind:.0f} km/h)",
+                                        auto_level, _redis,
+                                        skip_power_lock=True,
+                                        dedup_ttl=300,
+                                    )
+                    except Exception as _storm_err:
+                        logger.error("Sofort-Sturmschutz Fehler: %s", _storm_err)
             except (ValueError, TypeError):
                 pass
 
@@ -9680,6 +9701,26 @@ class ProactiveManager:
             logger.info(
                 "Wetter-Event: Regeneinbruch erkannt — Markisen sofort einfahren"
             )
+            # Sofort-Aktion: Markisen einfahren bei Regen
+            cover_cfg = yaml_config.get("seasonal_actions", {}).get(
+                "cover_automation", {}
+            )
+            auto_level = cover_cfg.get("auto_execute_level", 3)
+            try:
+                states = await self.brain.ha.get_states()
+                for s in states or []:
+                    eid = s.get("entity_id", "")
+                    if eid.startswith("cover.") and self.brain.executor._is_markise(eid, s):
+                        if await self.brain.executor._is_safe_cover(eid, s):
+                            await self._auto_cover_action(
+                                eid, 0,
+                                "Sofort-Regenschutz (Markise einfahren)",
+                                auto_level, _redis,
+                                skip_power_lock=True,
+                                dedup_ttl=300,
+                            )
+            except Exception as _rain_err:
+                logger.error("Sofort-Regenschutz Fehler: %s", _rain_err)
 
     # ------------------------------------------------------------------
     # State-Machine pro Cover

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -1625,31 +1625,67 @@ class ProactiveManager:
                     getattr(self.brain, "memory", None), "redis", None
                 )
                 if redis_client:
-                    acting_key = f"mha:cover:jarvis_acting:{entity_id}"
-                    jarvis_triggered = await redis_client.get(acting_key)
-                    if not jarvis_triggered:
-                        override_hours = (
-                            yaml_config.get("seasonal_actions", {})
-                            .get("cover_automation", {})
-                            .get("manual_override_hours", 2)
+                    # Bug 6 Fix: Deaktivierte Covers nicht tracken
+                    if not await self._is_cover_enabled_for_automation(entity_id):
+                        logger.debug(
+                            "Cover Override ignoriert: %s ist deaktiviert", entity_id
                         )
-                        override_ttl = int(override_hours * 3600)
-                        override_key = f"mha:cover:manual_override:{entity_id}"
-                        await redis_client.set(override_key, "1", ex=override_ttl)
-                        logger.info(
-                            "Cover Manual Override: %s manuell bedient (%s -> %s), Automatik pausiert für %dh",
-                            entity_id,
-                            old_val,
-                            new_val,
-                            override_hours,
+                    # Bug 3 Fix: HA-Gruppen-Entities filtern — Gruppen-State-Changes
+                    # werden durch Einzel-Cover-Bewegungen ausgeloest und sind keine
+                    # echten manuellen Aktionen. Gruppen erkennen wir an ihren
+                    # entity_id Attributes (HA fuellt diese fuer Gruppen).
+                    elif await self._is_ha_group_cover(entity_id):
+                        logger.debug(
+                            "Cover Override ignoriert: %s ist eine HA-Gruppe", entity_id
                         )
                     else:
-                        logger.debug(
-                            "Cover state change %s (%s -> %s) — jarvis_acting gesetzt, kein Override",
-                            entity_id,
-                            old_val,
-                            new_val,
-                        )
+                        # Pruefen ob Jarvis die Aktion ausgeloest hat
+                        acting_key = f"mha:cover:jarvis_acting:{entity_id}"
+                        jarvis_triggered = await redis_client.get(acting_key)
+                        if not jarvis_triggered:
+                            # Auch pruefen ob ein Einzel-Cover in dieser Gruppe
+                            # gerade von Jarvis gesteuert wird (Bug 3 Zusatzschutz)
+                            jarvis_sibling = await self._any_sibling_jarvis_acting(
+                                entity_id, redis_client
+                            )
+                            if jarvis_sibling:
+                                logger.debug(
+                                    "Cover Override ignoriert: %s — Sibling %s hat jarvis_acting",
+                                    entity_id,
+                                    jarvis_sibling,
+                                )
+                            else:
+                                override_hours = (
+                                    yaml_config.get("seasonal_actions", {})
+                                    .get("cover_automation", {})
+                                    .get("manual_override_hours", 2)
+                                )
+                                override_ttl = int(override_hours * 3600)
+                                # Bug 4 Fix: Override auch auf alle Einzel-Covers
+                                # im gleichen Raum setzen, damit die Solar-Automatik
+                                # (die Einzel-Entities steuert) den Override sieht
+                                override_entities = await self._get_override_targets(
+                                    entity_id
+                                )
+                                for oid in override_entities:
+                                    okey = f"mha:cover:manual_override:{oid}"
+                                    await redis_client.set(okey, "1", ex=override_ttl)
+                                logger.info(
+                                    "Cover Manual Override: %s manuell bedient (%s -> %s), "
+                                    "Automatik pausiert für %dh (%d Covers)",
+                                    entity_id,
+                                    old_val,
+                                    new_val,
+                                    override_hours,
+                                    len(override_entities),
+                                )
+                        else:
+                            logger.debug(
+                                "Cover state change %s (%s -> %s) — jarvis_acting gesetzt, kein Override",
+                                entity_id,
+                                old_val,
+                                new_val,
+                            )
             except Exception as e:
                 logger.debug("Cover Manual Override Detection Fehler: %s", e)
 
@@ -2206,6 +2242,14 @@ class ProactiveManager:
                 closed_count = 0
                 for cid in cover_ids:
                     redis_key = f"mha:cover:power_close:{cid}"
+                    # Bug 5 Fix: Lock IMMER setzen wenn Schwelle ueberschritten,
+                    # auch wenn Cover bereits auf Zielposition steht.
+                    # Ohne Lock kann die Solar-Automatik das Cover wieder oeffnen.
+                    if redis_client:
+                        try:
+                            await redis_client.set(redis_key, "1", ex=86400)
+                        except Exception as e:
+                            logger.warning("Unhandled: %s", e)
                     acted = await self._auto_cover_action(
                         cid,
                         close_pos,
@@ -2216,11 +2260,6 @@ class ProactiveManager:
                     )
                     if acted:
                         closed_count += 1
-                        if redis_client:
-                            try:
-                                await redis_client.set(redis_key, "1", ex=86400)
-                            except Exception as e:
-                                logger.warning("Unhandled: %s", e)
                 logger.info(
                     "Power-Close: %s über Schwelle (%s W >= %s W) → %d/%d Covers geschlossen",
                     entity_id,
@@ -5750,6 +5789,106 @@ class ProactiveManager:
                     if s.get("entity_id") == sensor_eid and s.get("state") == "on":
                         return True
         return False
+
+    async def _is_cover_enabled_for_automation(self, entity_id: str) -> bool:
+        """Prueft ob ein Cover in der Config als aktiviert markiert ist (Bug 6 Fix).
+
+        Deaktivierte Covers sollen weder automatisiert noch als Manual Override getrackt werden.
+        """
+        try:
+            from .cover_config import load_cover_configs
+
+            configs = load_cover_configs()
+            if configs and isinstance(configs, dict):
+                conf = configs.get(entity_id, {})
+                if conf.get("enabled") is False:
+                    return False
+        except Exception as e:
+            logger.debug("Cover enabled-Check Fehler fuer %s: %s", entity_id, e)
+        return True
+
+    async def _is_ha_group_cover(self, entity_id: str) -> bool:
+        """Prueft ob eine Cover-Entity eine HA-Gruppe ist (Bug 3 Fix).
+
+        HA-Gruppen haben 'entity_id' in ihren Attributes (Liste der Member-Entities).
+        Zusaetzlich pruefen wir ob die Entity in keinem Cover-Profil als Einzel-Cover definiert ist.
+        """
+        try:
+            state = await self.brain.ha.get_state(entity_id)
+            if state and isinstance(state, dict):
+                attrs = state.get("attributes", {})
+                # HA-Gruppen haben 'entity_id' als Liste von Member-Entities
+                member_ids = attrs.get("entity_id")
+                if isinstance(member_ids, list) and len(member_ids) > 0:
+                    return True
+        except Exception as e:
+            logger.debug("HA-Gruppen-Check Fehler fuer %s: %s", entity_id, e)
+        return False
+
+    async def _any_sibling_jarvis_acting(
+        self, entity_id: str, redis_client
+    ) -> str:
+        """Prueft ob ein verwandtes Cover gerade von Jarvis gesteuert wird (Bug 3 Zusatzschutz).
+
+        Wenn z.B. cover.rollladen_wohnzimmer_2 ein jarvis_acting Flag hat,
+        und cover.rollladen (Gruppe) sich aendert, ist das kein manueller Override.
+        """
+        try:
+            # Raum des Covers ermitteln
+            room = self._get_room_for_cover(entity_id)
+            if not room:
+                return ""
+            # Alle Cover-Profiles durchsuchen
+            profiles = self._load_cover_profiles()
+            for p in profiles:
+                pid = p.get("entity_id", "")
+                if pid == entity_id:
+                    continue
+                p_room = p.get("room", "").lower()
+                # Gleiches Raum-Praefix oder explizit gleicher Raum
+                if p_room == room or room in pid.lower():
+                    key = f"mha:cover:jarvis_acting:{pid}"
+                    acting = await redis_client.get(key)
+                    if acting:
+                        return pid
+        except Exception as e:
+            logger.debug("Sibling jarvis_acting Check Fehler: %s", e)
+        return ""
+
+    async def _get_override_targets(self, entity_id: str) -> list:
+        """Ermittelt alle Entity-IDs die bei einem Manual Override gesperrt werden sollen (Bug 4 Fix).
+
+        Wenn ein Einzel-Cover manuell bedient wird: nur dieses Cover sperren.
+        Wenn der User per HA-Gruppe oder alle Covers eines Raums bedient:
+        auch die Einzel-Covers im gleichen Raum sperren.
+        """
+        targets = [entity_id]
+        try:
+            # Pruefen ob es eine HA-Gruppe ist
+            state = await self.brain.ha.get_state(entity_id)
+            if state and isinstance(state, dict):
+                attrs = state.get("attributes", {})
+                member_ids = attrs.get("entity_id")
+                if isinstance(member_ids, list):
+                    for mid in member_ids:
+                        if mid.startswith("cover.") and mid not in targets:
+                            targets.append(mid)
+                    return targets
+
+            # Fallback: Cover-Profiles nach gleichem Raum durchsuchen
+            room = self._get_room_for_cover(entity_id)
+            if room:
+                profiles = self._load_cover_profiles()
+                for p in profiles:
+                    pid = p.get("entity_id", "")
+                    if pid == entity_id or pid in targets:
+                        continue
+                    p_room = p.get("room", "").lower()
+                    if p_room == room:
+                        targets.append(pid)
+        except Exception as e:
+            logger.debug("Override-Targets Fehler fuer %s: %s", entity_id, e)
+        return targets
 
     async def _startup_reconciliation(self, redis_client):
         """Startup-Reconciliation: Prüft ob Covers nach Neustart im erwarteten Zustand sind.

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -5546,7 +5546,8 @@ class ProactiveManager:
                 )
 
                 # 7. HEIZUNGS-INTEGRATION (Feature 8)
-                if cover_cfg.get("heating_integration", False):
+                # sun muss vorhanden sein — ohne Sonnendaten keine Solar-Entscheidungen
+                if cover_cfg.get("heating_integration", False) and sun:
                     await self._cover_heating_integration(
                         states,
                         sun,
@@ -7345,6 +7346,42 @@ class ProactiveManager:
                     entity_id = cover.get("entity_id")
                     if not entity_id or not cover.get("allow_auto"):
                         continue
+
+                    # Per-Cover Bettsensor-Check: Schlafzimmer-Rollladen
+                    # NICHT oeffnen wenn Bett im gleichen Raum belegt ist.
+                    # (Globaler _is_sleeping Check oben reicht nicht — der
+                    # erkennt nur ob JEMAND schlaeft, nicht OB dieser Raum
+                    # ein Schlafzimmer mit belegtem Bett ist.)
+                    _bed_sensors = []
+                    _cover_bs = cover.get("bed_sensor", "")
+                    if _cover_bs:
+                        _bed_sensors = [_cover_bs]
+                    else:
+                        cover_room = cover.get("room", "")
+                        if cover_room:
+                            _rp = _get_room_profiles_cached()
+                            _room_cfg = (_rp.get("rooms") or {}).get(
+                                cover_room, {}
+                            )
+                            from .config import get_room_bed_sensors
+
+                            _bed_sensors = get_room_bed_sensors(_room_cfg)
+                    _bed_occupied = False
+                    for s in states or []:
+                        if (
+                            s.get("entity_id") in _bed_sensors
+                            and s.get("state") == "on"
+                        ):
+                            _bed_occupied = True
+                            break
+                    if _bed_occupied:
+                        logger.info(
+                            "Passive Solarwärme: %s übersprungen — "
+                            "Bettsensor im Raum aktiv",
+                            entity_id,
+                        )
+                        continue
+
                     start = cover.get("sun_exposure_start", 0)
                     end = cover.get("sun_exposure_end", 360)
                     if start <= end:

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -5784,7 +5784,13 @@ class ProactiveManager:
             sensor_room = ""
             if isinstance(sensor_cfg, dict):
                 sensor_room = sensor_cfg.get("room", "").lower()
-            if (cover_room and cover_room in sensor_lower) or (
+            # Word-Boundary Matching: "wohnzimmer" matcht
+            # "fenster_wohnzimmer" aber nicht "wohnzimmerschrank"
+            _room_in_sensor = cover_room and (
+                f"_{cover_room}" in f"_{sensor_lower}"
+                or f"{cover_room}_" in f"{sensor_lower}_"
+            )
+            if _room_in_sensor or (
                 sensor_room and sensor_room == cover_room
             ):
                 for s in states or []:

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -5822,7 +5822,12 @@ class ProactiveManager:
                 # HA-Gruppen haben 'entity_id' als Liste von Member-Entities
                 member_ids = attrs.get("entity_id")
                 if isinstance(member_ids, list) and len(member_ids) > 0:
-                    return True
+                    # Nur als Cover-Gruppe erkennen wenn mindestens ein Member
+                    # ein Cover ist (gemischte Gruppen ignorieren)
+                    if any(
+                        m.startswith("cover.") for m in member_ids if isinstance(m, str)
+                    ):
+                        return True
         except Exception as e:
             logger.debug("HA-Gruppen-Check Fehler fuer %s: %s", entity_id, e)
         return False
@@ -5848,7 +5853,12 @@ class ProactiveManager:
                     continue
                 p_room = p.get("room", "").lower()
                 # Gleiches Raum-Praefix oder explizit gleicher Raum
-                if p_room == room or room in pid.lower():
+                # Word-Boundary Matching: "wohn" darf nicht "wohnzimmerschrank" matchen
+                pid_lower = pid.lower()
+                _room_in_pid = (
+                    f"_{room}" in f"_{pid_lower}" or f"{room}_" in f"{pid_lower}_"
+                )
+                if p_room == room or _room_in_pid:
                     key = f"mha:cover:jarvis_acting:{pid}"
                     acting = await redis_client.get(key)
                     if acting:

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -1619,6 +1619,7 @@ class ProactiveManager:
             and old_val not in _non_physical
             and new_val not in _non_physical
             and old_val not in _transitional
+            and new_val not in _transitional
         ):
             try:
                 redis_client = getattr(
@@ -10551,9 +10552,7 @@ class ProactiveManager:
                 except Exception as e:
                     logger.debug("Mood comfort action Fehler: %s", e)
         elif mood == "tired":
-            now_hour = datetime.now(timezone.utc).hour
-            # Einfache Zeitzonen-Korrektur (CET = UTC+1/2)
-            local_hour = (now_hour + 1) % 24
+            local_hour = datetime.now(_LOCAL_TZ).hour
             if local_hour >= 21:
                 suggestion = "Du wirkst muede — Zeit fuer die Gute-Nacht-Routine?"
 

--- a/assistant/assistant/proactive.py
+++ b/assistant/assistant/proactive.py
@@ -6226,8 +6226,8 @@ class ProactiveManager:
                     entity_id, position
                 )
                 # Feature 2: Markierung setzen BEVOR HA-Call, damit der State-Change als Jarvis-ausgeloest erkannt wird
+                acting_key = f"mha:cover:jarvis_acting:{entity_id}"
                 if redis_client:
-                    acting_key = f"mha:cover:jarvis_acting:{entity_id}"
                     await redis_client.set(acting_key, "1", ex=300)
                 try:
                     await self.brain.ha.call_service(

--- a/assistant/assistant/routine_engine.py
+++ b/assistant/assistant/routine_engine.py
@@ -315,6 +315,8 @@ class RoutineEngine:
                 return await self._get_device_conflicts_briefing()
             elif module == "night_decisions":
                 return await self._get_night_decisions_briefing()
+            elif module == "personal_dates":
+                return await self._get_personal_dates_briefing()
         except Exception as e:
             logger.debug("Briefing-Modul '%s' fehlgeschlagen: %s", module, e)
         return ""
@@ -390,6 +392,12 @@ class RoutineEngine:
         # Night decisions — informational, after house_status
         if module == "night_decisions":
             return 3
+
+        # Personal dates (birthdays today = high priority)
+        if module == "personal_dates":
+            if "HEUTE" in content.upper() or "heute" in content:
+                return 7
+            return 4
 
         # Personal memory / greeting — informational
         if module == "personal_memory":
@@ -484,6 +492,20 @@ class RoutineEngine:
         except Exception as e:
             logger.debug("Night-Decisions Briefing Fehler: %s", e)
             return ""
+
+    async def _get_personal_dates_briefing(self) -> str:
+        """Liefert anstehende Geburtstage/Jahrestage fuer das Briefing."""
+        try:
+            import assistant.main as main_module
+
+            brain = main_module.brain
+            if hasattr(brain, "personal_dates"):
+                section = await brain.personal_dates.get_briefing_section()
+                if section:
+                    return section
+        except Exception as e:
+            logger.debug("Personal-Dates Briefing Fehler: %s", e)
+        return ""
 
     async def _get_personal_memory_briefing(self, person: str) -> str:
         """Liefert relevante Erinnerungen und anstehende Daten fuer das Briefing."""

--- a/assistant/assistant/state_change_log.py
+++ b/assistant/assistant/state_change_log.py
@@ -3797,6 +3797,7 @@ DEVICE_DEPENDENCIES = [
         "severity": "info",
     },
     # Licht an → Blinds (Kunstlicht bei offenen Jalousien nachts = Einsehbarkeit)
+    # Bug 2 Fix: time_range begrenzt auf Abend/Nacht (16-06 Uhr)
     {
         "role": "light",
         "state": "on",
@@ -3805,6 +3806,7 @@ DEVICE_DEPENDENCIES = [
         "effect": "Licht an nachts + Jalousien offen → Raum einsehbar",
         "hint": "Licht an abends → Jalousien schliessen fuer Privatsphaere",
         "severity": "info",
+        "time_range": (16, 6),  # Nur zwischen 16:00 und 06:00
     },
     {
         "role": "light",
@@ -3814,6 +3816,7 @@ DEVICE_DEPENDENCIES = [
         "effect": "Licht an nachts + Rollladen offen → Raum einsehbar",
         "hint": "Licht an abends → Rollladen runter fuer Privatsphaere",
         "severity": "info",
+        "time_range": (16, 6),
     },
     {
         "role": "light",
@@ -3823,6 +3826,7 @@ DEVICE_DEPENDENCIES = [
         "effect": "Licht an nachts + Vorhaenge offen → Raum einsehbar",
         "hint": "Licht an abends → Vorhaenge zuziehen fuer Privatsphaere",
         "severity": "info",
+        "time_range": (16, 6),
     },
     # =================================================================
     # WETTER → GERAETE — weitere Szenarien
@@ -3996,6 +4000,7 @@ DEVICE_DEPENDENCIES = [
     # BETT-SZENARIEN — erweitert
     # =================================================================
     # Im Bett → Shutter runter
+    # Bug 2 Fix: Nur abends/nachts relevant (20-10 Uhr)
     {
         "role": "bed_occupancy",
         "state": "on",
@@ -4004,6 +4009,7 @@ DEVICE_DEPENDENCIES = [
         "effect": "Im Bett → Rollladen schliessen fuer Dunkelheit",
         "hint": "Schlafenszeit → Rollladen runter, Raum abdunkeln",
         "severity": "info",
+        "time_range": (20, 10),  # Nur zwischen 20:00 und 10:00
     },
     # Im Bett → Thermostat Nacht-Temperatur
     {
@@ -11224,11 +11230,34 @@ class StateChangeLog:
             entity_roles[eid] = self._get_entity_role(eid)
             entity_rooms[eid] = self._get_entity_room(eid)
 
+        # Bug 2 Fix: Aktuelle Stunde fuer time_range Filter
+        try:
+            from helpers import local_now as _local_now
+
+            _current_hour = _local_now().hour
+        except Exception:
+            from datetime import datetime as _dt, timezone as _tz
+
+            _current_hour = _dt.now(_tz.utc).hour
+
         conflicts = []
         for dep in DEVICE_DEPENDENCIES:
             cond_role = dep["role"]
             cond_state = dep["state"]
             same_room = dep.get("same_room", False)
+
+            # Bug 2 Fix: time_range pruefen (z.B. (16, 6) = 16:00-06:00)
+            time_range = dep.get("time_range")
+            if time_range:
+                start_h, end_h = time_range
+                if start_h > end_h:
+                    # Ueber Mitternacht: 16-06 → hour >= 16 OR hour < 6
+                    if not (_current_hour >= start_h or _current_hour < end_h):
+                        continue
+                else:
+                    # Normal: 8-20 → hour >= 8 AND hour < 20
+                    if not (start_h <= _current_hour < end_h):
+                        continue
 
             # Finde alle Entities die diese Rolle + State haben
             matching = [

--- a/assistant/assistant/task_manager.py
+++ b/assistant/assistant/task_manager.py
@@ -107,7 +107,7 @@ class TaskManager:
         target_list = list_entity or (_FAMILY_LIST if not person else _DEFAULT_LIST)
 
         # HA todo.add_item Service aufrufen
-        service_data = {"item": title}
+        service_data = {"entity_id": target_list, "item": title}
         if due_date:
             service_data["due_date"] = due_date
         if description:
@@ -117,7 +117,6 @@ class TaskManager:
             "todo",
             "add_item",
             service_data,
-            target={"entity_id": target_list},
         )
 
         if not success:
@@ -215,8 +214,7 @@ class TaskManager:
         success = await self.ha.call_service(
             "todo",
             "update_item",
-            {"item": title, "status": "completed"},
-            target={"entity_id": target_list},
+            {"entity_id": target_list, "item": title, "status": "completed"},
         )
 
         if not success:
@@ -237,8 +235,7 @@ class TaskManager:
         success = await self.ha.call_service(
             "todo",
             "remove_item",
-            {"item": title},
-            target={"entity_id": target_list},
+            {"entity_id": target_list, "item": title},
         )
 
         if not success:
@@ -479,12 +476,11 @@ class TaskManager:
                 title = decoded.get("title", "")
                 list_entity = decoded.get("list_entity", _FAMILY_LIST)
 
-                service_data = {"item": title}
+                service_data = {"entity_id": list_entity, "item": title}
                 success = await self.ha.call_service(
                     "todo",
                     "add_item",
                     service_data,
-                    target={"entity_id": list_entity},
                 )
 
                 if success:
@@ -507,3 +503,7 @@ class TaskManager:
                 await self._recurring_task
             except asyncio.CancelledError:
                 pass
+
+    async def stop(self):
+        """Alias fuer shutdown (Brain-Kompatibilitaet)."""
+        await self.shutdown()

--- a/assistant/assistant/task_manager.py
+++ b/assistant/assistant/task_manager.py
@@ -1,0 +1,509 @@
+"""
+Task Manager - Aufgabenverwaltung fuer die ganze Familie.
+
+Nutzt Home Assistants todo-Domain fuer persistente Aufgabenlisten.
+Unterstuetzt:
+- Persoenliche und geteilte Aufgabenlisten
+- Wiederkehrende Aufgaben (taeglich, woechentlich, monatlich)
+- Aufgaben pro Person zuweisen
+- Faelligkeitsdaten und Prioritaeten
+- Proaktive Erinnerungen bei faelligen Aufgaben
+
+Redis Keys:
+- mha:tasks:recurring:{task_id}  - Wiederkehrende Aufgaben-Definitionen
+- mha:tasks:assigned:{person}    - Aufgaben pro Person (Referenzen)
+- mha:tasks:meta:{item_uid}      - Metadaten (Prioritaet, Faelligkeit, Person)
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import redis.asyncio as aioredis
+
+from .config import yaml_config
+
+logger = logging.getLogger(__name__)
+
+# Konfiguration
+_cfg = yaml_config.get("task_manager", {})
+_DEFAULT_LIST = _cfg.get("default_list", "todo.einkaufsliste")
+_FAMILY_LIST = _cfg.get("family_list", "todo.familie")
+_RECURRING_CHECK_INTERVAL = _cfg.get("recurring_check_minutes", 60)
+
+_RECURRENCE_TYPES = frozenset({"daily", "weekly", "monthly", "weekday"})
+_PRIORITIES = frozenset({"low", "medium", "high", "urgent"})
+_WEEKDAY_MAP = {
+    "montag": 0,
+    "dienstag": 1,
+    "mittwoch": 2,
+    "donnerstag": 3,
+    "freitag": 4,
+    "samstag": 5,
+    "sonntag": 6,
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+    "mo": 0,
+    "di": 1,
+    "mi": 2,
+    "do": 3,
+    "fr": 4,
+    "sa": 5,
+    "so": 6,
+}
+
+
+class TaskManager:
+    """Aufgabenverwaltung ueber Home Assistant todo-Domain + Redis-Metadaten."""
+
+    def __init__(self, ha_client):
+        self.ha = ha_client
+        self.redis: Optional[aioredis.Redis] = None
+        self._notify_callback = None
+        self._recurring_task: Optional[asyncio.Task] = None
+
+    async def initialize(self, redis_client: Optional[aioredis.Redis] = None):
+        """Initialisiert mit Redis-Verbindung."""
+        self.redis = redis_client
+        # Starte recurring-Check Loop
+        if self.redis:
+            self._recurring_task = asyncio.create_task(self._recurring_loop())
+            self._recurring_task.add_done_callback(
+                lambda t: t.exception() if not t.cancelled() else None
+            )
+        logger.info("TaskManager initialisiert")
+
+    def set_notify_callback(self, callback):
+        """Setzt Callback fuer Aufgaben-Erinnerungen."""
+        self._notify_callback = callback
+
+    # ------------------------------------------------------------------
+    # Oeffentliche API
+    # ------------------------------------------------------------------
+
+    async def add_task(
+        self,
+        title: str,
+        person: str = "",
+        due_date: str = "",
+        priority: str = "medium",
+        list_entity: str = "",
+        description: str = "",
+    ) -> dict:
+        """Fuegt eine neue Aufgabe hinzu."""
+        if not title or not title.strip():
+            return {"success": False, "message": "Kein Aufgabentext angegeben."}
+
+        title = title.strip()
+        priority = priority.lower() if priority.lower() in _PRIORITIES else "medium"
+        target_list = list_entity or (_FAMILY_LIST if not person else _DEFAULT_LIST)
+
+        # HA todo.add_item Service aufrufen
+        service_data = {"item": title}
+        if due_date:
+            service_data["due_date"] = due_date
+        if description:
+            service_data["description"] = description
+
+        success = await self.ha.call_service(
+            "todo",
+            "add_item",
+            service_data,
+            target={"entity_id": target_list},
+        )
+
+        if not success:
+            return {
+                "success": False,
+                "message": f"Konnte Aufgabe nicht hinzufuegen. Ist '{target_list}' verfuegbar?",
+            }
+
+        # Metadaten in Redis speichern
+        if self.redis:
+            meta_id = f"task_{uuid.uuid4().hex[:8]}"
+            meta = {
+                "title": title,
+                "person": person.lower() if person else "",
+                "priority": priority,
+                "due_date": due_date,
+                "list_entity": target_list,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            }
+            await self.redis.hset(f"mha:tasks:meta:{meta_id}", mapping=meta)
+            await self.redis.expire(f"mha:tasks:meta:{meta_id}", 90 * 86400)  # 90 Tage
+
+            if person:
+                await self.redis.sadd(f"mha:tasks:assigned:{person.lower()}", meta_id)
+
+        person_hint = f" (fuer {person})" if person else ""
+        due_hint = f", faellig am {due_date}" if due_date else ""
+        return {
+            "success": True,
+            "message": f"Aufgabe '{title}'{person_hint}{due_hint} hinzugefuegt.",
+        }
+
+    async def list_tasks(
+        self,
+        person: str = "",
+        list_entity: str = "",
+        status: str = "needs_action",
+    ) -> dict:
+        """Listet Aufgaben auf."""
+        target_list = list_entity or _FAMILY_LIST
+
+        # HA todo.get_items aufrufen
+        items = await self._get_todo_items(target_list, status)
+        if items is None:
+            return {
+                "success": False,
+                "message": f"Todo-Liste '{target_list}' nicht verfuegbar.",
+            }
+
+        # Optional nach Person filtern (via Redis-Metadaten)
+        if person and self.redis:
+            assigned_ids = await self.redis.smembers(
+                f"mha:tasks:assigned:{person.lower()}"
+            )
+            if assigned_ids:
+                assigned_titles = set()
+                pipe = self.redis.pipeline()
+                for aid in assigned_ids:
+                    aid_str = aid if isinstance(aid, str) else aid.decode()
+                    pipe.hget(f"mha:tasks:meta:{aid_str}", "title")
+                titles = await pipe.execute()
+                for t in titles:
+                    if t:
+                        assigned_titles.add(t if isinstance(t, str) else t.decode())
+                items = [i for i in items if i.get("summary", "") in assigned_titles]
+
+        if not items:
+            hint = f" fuer {person}" if person else ""
+            return {
+                "success": True,
+                "message": f"Keine offenen Aufgaben{hint}. Alles erledigt!",
+            }
+
+        lines = []
+        for i, item in enumerate(items, 1):
+            summary = item.get("summary", "?")
+            due = item.get("due", "")
+            due_str = f" (faellig: {due})" if due else ""
+            status_icon = "[ ]" if item.get("status") == "needs_action" else "[x]"
+            lines.append(f"{i}. {status_icon} {summary}{due_str}")
+
+        person_hint = f" fuer {person}" if person else ""
+        return {
+            "success": True,
+            "message": f"Aufgaben{person_hint}:\n" + "\n".join(lines),
+        }
+
+    async def complete_task(self, title: str, list_entity: str = "") -> dict:
+        """Markiert eine Aufgabe als erledigt."""
+        if not title:
+            return {"success": False, "message": "Kein Aufgabentext angegeben."}
+
+        target_list = list_entity or _FAMILY_LIST
+
+        success = await self.ha.call_service(
+            "todo",
+            "update_item",
+            {"item": title, "status": "completed"},
+            target={"entity_id": target_list},
+        )
+
+        if not success:
+            return {
+                "success": False,
+                "message": f"Aufgabe '{title}' nicht gefunden oder nicht abschliessbar.",
+            }
+
+        return {"success": True, "message": f"Aufgabe '{title}' erledigt. Gut gemacht!"}
+
+    async def remove_task(self, title: str, list_entity: str = "") -> dict:
+        """Entfernt eine Aufgabe komplett."""
+        if not title:
+            return {"success": False, "message": "Kein Aufgabentext angegeben."}
+
+        target_list = list_entity or _FAMILY_LIST
+
+        success = await self.ha.call_service(
+            "todo",
+            "remove_item",
+            {"item": title},
+            target={"entity_id": target_list},
+        )
+
+        if not success:
+            return {
+                "success": False,
+                "message": f"Aufgabe '{title}' nicht gefunden.",
+            }
+
+        return {"success": True, "message": f"Aufgabe '{title}' entfernt."}
+
+    async def add_recurring_task(
+        self,
+        title: str,
+        recurrence: str,
+        weekday: str = "",
+        person: str = "",
+        list_entity: str = "",
+    ) -> dict:
+        """Erstellt eine wiederkehrende Aufgabe.
+
+        Args:
+            recurrence: daily, weekly, monthly, weekday
+            weekday: Fuer weekly - z.B. 'montag', 'dienstag'
+        """
+        if not title:
+            return {"success": False, "message": "Kein Aufgabentext angegeben."}
+
+        recurrence = recurrence.lower()
+        if recurrence not in _RECURRENCE_TYPES:
+            return {
+                "success": False,
+                "message": f"Unbekannter Wiederholungstyp: {recurrence}. "
+                f"Moeglich: {', '.join(sorted(_RECURRENCE_TYPES))}",
+            }
+
+        weekday_num = None
+        if recurrence == "weekly":
+            if not weekday:
+                return {
+                    "success": False,
+                    "message": "Fuer woechentliche Aufgaben muss ein Wochentag angegeben werden.",
+                }
+            weekday_num = _WEEKDAY_MAP.get(weekday.lower())
+            if weekday_num is None:
+                return {
+                    "success": False,
+                    "message": f"Unbekannter Wochentag: {weekday}",
+                }
+
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        task_id = f"rec_{uuid.uuid4().hex[:8]}"
+        rec_data = {
+            "title": title,
+            "recurrence": recurrence,
+            "weekday": str(weekday_num) if weekday_num is not None else "",
+            "person": person.lower() if person else "",
+            "list_entity": list_entity or _FAMILY_LIST,
+            "last_created": "",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        await self.redis.hset(f"mha:tasks:recurring:{task_id}", mapping=rec_data)
+        await self.redis.sadd("mha:tasks:recurring:all", task_id)
+
+        schedule_hint = {
+            "daily": "jeden Tag",
+            "weekly": f"jeden {weekday}" if weekday else "woechentlich",
+            "monthly": "monatlich (am 1.)",
+            "weekday": "Montag bis Freitag",
+        }.get(recurrence, recurrence)
+
+        return {
+            "success": True,
+            "message": f"Wiederkehrende Aufgabe '{title}' ({schedule_hint}) erstellt.",
+        }
+
+    async def list_recurring_tasks(self) -> dict:
+        """Listet alle wiederkehrenden Aufgaben."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        task_ids = await self.redis.smembers("mha:tasks:recurring:all")
+        if not task_ids:
+            return {
+                "success": True,
+                "message": "Keine wiederkehrenden Aufgaben konfiguriert.",
+            }
+
+        lines = []
+        pipe = self.redis.pipeline()
+        ids_list = []
+        for tid in task_ids:
+            tid_str = tid if isinstance(tid, str) else tid.decode()
+            ids_list.append(tid_str)
+            pipe.hgetall(f"mha:tasks:recurring:{tid_str}")
+        results = await pipe.execute()
+
+        for tid, data in zip(ids_list, results):
+            if not data:
+                continue
+            title = (data.get("title") or data.get(b"title", b"")).strip()
+            if isinstance(title, bytes):
+                title = title.decode()
+            recurrence = (
+                data.get("recurrence") or data.get(b"recurrence", b"")
+            ).strip()
+            if isinstance(recurrence, bytes):
+                recurrence = recurrence.decode()
+            person = (data.get("person") or data.get(b"person", b"")).strip()
+            if isinstance(person, bytes):
+                person = person.decode()
+
+            person_hint = f" [{person}]" if person else ""
+            lines.append(f"- {title} ({recurrence}){person_hint}")
+
+        if not lines:
+            return {"success": True, "message": "Keine wiederkehrenden Aufgaben."}
+
+        return {
+            "success": True,
+            "message": "Wiederkehrende Aufgaben:\n" + "\n".join(lines),
+        }
+
+    async def delete_recurring_task(self, title: str) -> dict:
+        """Loescht eine wiederkehrende Aufgabe nach Titel."""
+        if not self.redis:
+            return {"success": False, "message": "Redis nicht verfuegbar."}
+
+        task_ids = await self.redis.smembers("mha:tasks:recurring:all")
+        for tid in task_ids:
+            tid_str = tid if isinstance(tid, str) else tid.decode()
+            stored_title = await self.redis.hget(
+                f"mha:tasks:recurring:{tid_str}", "title"
+            )
+            if stored_title:
+                if isinstance(stored_title, bytes):
+                    stored_title = stored_title.decode()
+                if stored_title.lower().strip() == title.lower().strip():
+                    await self.redis.delete(f"mha:tasks:recurring:{tid_str}")
+                    await self.redis.srem("mha:tasks:recurring:all", tid_str)
+                    return {
+                        "success": True,
+                        "message": f"Wiederkehrende Aufgabe '{title}' geloescht.",
+                    }
+
+        return {
+            "success": False,
+            "message": f"Wiederkehrende Aufgabe '{title}' nicht gefunden.",
+        }
+
+    def get_context_hints(self) -> list[str]:
+        """Gibt Kontext-Hints fuer den Context Builder zurueck."""
+        return ["TaskManager aktiv: Aufgabenverwaltung ueber HA todo-Domain verfuegbar"]
+
+    # ------------------------------------------------------------------
+    # Interne Helfer
+    # ------------------------------------------------------------------
+
+    async def _get_todo_items(
+        self, entity_id: str, status: str = "needs_action"
+    ) -> Optional[list]:
+        """Ruft Todo-Items von Home Assistant ab."""
+        try:
+            state = await self.ha.get_state(entity_id)
+            if state is None:
+                return None
+
+            # HA todo entities haben Items als Attribute
+            attrs = state.get("attributes", {})
+            items = attrs.get("items", [])
+
+            if status == "all":
+                return items
+            return [i for i in items if i.get("status") == status]
+        except Exception as e:
+            logger.warning(
+                "Fehler beim Abrufen von todo-Items fuer %s: %s", entity_id, e
+            )
+            return None
+
+    async def _recurring_loop(self):
+        """Prueft periodisch ob wiederkehrende Aufgaben erstellt werden muessen."""
+        while True:
+            try:
+                await asyncio.sleep(_RECURRING_CHECK_INTERVAL * 60)
+                await self._process_recurring_tasks()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("Fehler in recurring task loop: %s", e)
+                await asyncio.sleep(300)  # 5 Min Pause bei Fehler
+
+    async def _process_recurring_tasks(self):
+        """Erstellt faellige wiederkehrende Aufgaben."""
+        if not self.redis:
+            return
+
+        task_ids = await self.redis.smembers("mha:tasks:recurring:all")
+        if not task_ids:
+            return
+
+        now = datetime.now(timezone.utc)
+        today_str = now.strftime("%Y-%m-%d")
+
+        for tid in task_ids:
+            tid_str = tid if isinstance(tid, str) else tid.decode()
+            data = await self.redis.hgetall(f"mha:tasks:recurring:{tid_str}")
+            if not data:
+                continue
+
+            # Decode Redis bytes
+            decoded = {}
+            for k, v in data.items():
+                key = k if isinstance(k, str) else k.decode()
+                val = v if isinstance(v, str) else v.decode()
+                decoded[key] = val
+
+            last_created = decoded.get("last_created", "")
+            if last_created == today_str:
+                continue  # Heute schon erstellt
+
+            recurrence = decoded.get("recurrence", "")
+            should_create = False
+
+            if recurrence == "daily":
+                should_create = True
+            elif recurrence == "weekday":
+                should_create = now.weekday() < 5  # Mo-Fr
+            elif recurrence == "weekly":
+                target_day = int(decoded.get("weekday", "-1"))
+                should_create = now.weekday() == target_day
+            elif recurrence == "monthly":
+                should_create = now.day == 1
+
+            if should_create:
+                title = decoded.get("title", "")
+                list_entity = decoded.get("list_entity", _FAMILY_LIST)
+
+                service_data = {"item": title}
+                success = await self.ha.call_service(
+                    "todo",
+                    "add_item",
+                    service_data,
+                    target={"entity_id": list_entity},
+                )
+
+                if success:
+                    await self.redis.hset(
+                        f"mha:tasks:recurring:{tid_str}",
+                        "last_created",
+                        today_str,
+                    )
+                    logger.info(
+                        "Wiederkehrende Aufgabe erstellt: %s (%s)",
+                        title,
+                        recurrence,
+                    )
+
+    async def shutdown(self):
+        """Beendet den recurring loop."""
+        if self._recurring_task and not self._recurring_task.done():
+            self._recurring_task.cancel()
+            try:
+                await self._recurring_task
+            except asyncio.CancelledError:
+                pass

--- a/assistant/config/settings.yaml.example
+++ b/assistant/config/settings.yaml.example
@@ -791,6 +791,7 @@ routines:
     - greeting
     - weather
     - calendar
+    - personal_dates
     - energy
     - house_status
     weekday_style: kurz
@@ -1465,3 +1466,40 @@ web_search:
   searxng_url: http://localhost:8888
   max_results: 5
   timeout_seconds: 10
+
+# ==============================================================
+# Personal Assistant Module
+# ==============================================================
+
+# --- Aufgaben-/Todo-Verwaltung ---
+task_manager:
+  enabled: true
+  default_list: todo.einkaufsliste           # HA todo-Entity fuer persoenliche Aufgaben
+  family_list: todo.familie                   # HA todo-Entity fuer geteilte Familien-Aufgaben
+  recurring_check_minutes: 60                 # Intervall fuer wiederkehrende Aufgaben-Check
+
+# --- Geburtstage & Jahrestage ---
+personal_dates:
+  enabled: true
+  remind_days_before: [3, 1, 0]              # Erinnerung X Tage vorher (0 = am Tag selbst)
+  check_interval_hours: 6                    # Pruefintervall fuer Erinnerungen
+  briefing_lookahead_days: 7                 # Vorschau im Morgen-Briefing
+
+# --- Familien-Profile ---
+family:
+  enabled: true
+  # Initiale Profile (werden beim ersten Start in Redis geladen)
+  # Weitere Profile koennen per Sprache/Chat hinzugefuegt werden
+
+# --- Notiz-System ---
+notes:
+  enabled: true
+  max_notes: 500                             # Maximale Anzahl Notizen
+  archive_after_days: 90                     # Archivierung nach X Tagen
+
+# --- Essensplanung ---
+meal_planner:
+  enabled: true
+  default_portions: 2                        # Standard-Portionenzahl
+  history_max_entries: 100                   # Maximale Mahlzeiten-Historie
+  plan_ttl_days: 14                          # Wie lange Wochenplaene gespeichert werden

--- a/assistant/static/ui/app.js
+++ b/assistant/static/ui/app.js
@@ -150,6 +150,12 @@ const _searchIndex = [
   {tab:'tab-house-status', title:'Humidor', keywords:'humidor feuchtigkeit zigarren sensor', icon:'&#127793;'},
   {tab:'tab-house-status', title:'Wellness', keywords:'wellness trinken pause mahlzeit stress pc break reminder', icon:'&#129505;'},
   {tab:'tab-house-status', title:'Wetterwarnungen', keywords:'wetter warnung temperatur wind sturm hitze kälte', icon:'&#127752;'},
+  // Persoenlicher Assistent (tab-personal)
+  {tab:'tab-personal', title:'Aufgaben / Todo', keywords:'aufgabe todo task liste erledigen wiederkehrend familie person', icon:'&#9745;'},
+  {tab:'tab-personal', title:'Notizen', keywords:'notiz memo merken note suche kategorie idee', icon:'&#128221;'},
+  {tab:'tab-personal', title:'Familie', keywords:'familie mitglied profil beziehung kind partner gruppe nachricht', icon:'&#128106;'},
+  {tab:'tab-personal', title:'Essensplanung', keywords:'essen mahlzeit wochenplan kochen vorrat inventar rezept vorschlag', icon:'&#127869;'},
+  {tab:'tab-personal', title:'Geburtstage & Jahrestage', keywords:'geburtstag jahrestag erinnerung briefing personal date termin', icon:'&#127874;'},
   // Koch-Assistent (tab-cooking)
   {tab:'tab-cooking', title:'Koch-Assistent', keywords:'kochen rezept timer portionen schritte', icon:'&#127859;'},
   // Werkstatt (tab-workshop)
@@ -178,6 +184,7 @@ const _tabLabels = {
   'tab-covers':'Rollläden','tab-vacuum':'Saugroboter','tab-remote':'Fernbedienung',
   'tab-scenes':'Szenen','tab-routines':'Routinen',
   'tab-proactive':'Proaktiv','tab-notifications':'Benachrichtigungen',
+  'tab-personal':'Persönlicher Assistent',
   'tab-cooking':'Koch-Assistent','tab-followme':'Follow-Me',
   'tab-jarvis':'Jarvis-Features','tab-intelligence':'Intelligenz',
   'tab-declarative-tools':'Analyse-Tools','tab-eastereggs':'Easter Eggs',
@@ -750,6 +757,7 @@ document.getElementById('sidebarNav').addEventListener('click', e => {
       'tab-scenes':'Szenen','tab-routines':'Routinen',
       'tab-proactive':'Proaktiv & Vorausdenken',
       'tab-notifications':'Benachrichtigungen',
+      'tab-personal':'Persönlicher Assistent',
       'tab-cooking':'Koch-Assistent','tab-followme':'Follow-Me',
       'tab-jarvis':'Jarvis-Features','tab-intelligence':'Intelligenz — Quick Wins','tab-declarative-tools':'Analyse-Tools',
       'tab-eastereggs':'Easter Eggs',
@@ -1189,6 +1197,7 @@ function renderCurrentTab() {
       case 'tab-routines': c.innerHTML = renderRoutines(); break;
       case 'tab-proactive': c.innerHTML = renderProactive(); break;
       case 'tab-notifications': c.innerHTML = renderNotifications(); loadNotifyChannels(); break;
+      case 'tab-personal': c.innerHTML = renderPersonalAssistant(); loadPersonalTasks(); loadPersonalNotes(); loadFamilyMembers(); loadMealPlan(); break;
       case 'tab-cooking': c.innerHTML = renderCooking(); break;
       case 'tab-workshop': c.innerHTML = renderWorkshop(); break;
       case 'tab-house-status': c.innerHTML = renderHouseStatus(); break;
@@ -5747,6 +5756,282 @@ function renderJarvisFeatures() {
     fSubheading('JSON-Modus für Tools') +
     fToggle('json_mode_tools.enabled', 'JSON-Modus aktiv', 'JSON-Output bei Ollama Tool-Calls für zuverlässigere Gerätesteuerung. Standard: an')
   );
+}
+
+// ---- Persoenlicher Assistent ----
+function renderPersonalAssistant() {
+  return sectionWrap('&#9745;', 'Aufgaben / Todo',
+    fInfo('Aufgabenverwaltung ueber Home Assistants Todo-Listen. Persoenliche und geteilte Familien-Aufgaben, auch wiederkehrend.') +
+    fToggle('task_manager.enabled', 'Aufgaben-Manager aktiv') +
+    fText('task_manager.default_list', 'Persoenliche Todo-Liste (HA Entity)', 'z.B. todo.einkaufsliste') +
+    fText('task_manager.family_list', 'Familien-Todo-Liste (HA Entity)', 'z.B. todo.familie') +
+    fRange('task_manager.recurring_check_minutes', 'Wiederkehrende Tasks pruefen', 15, 240, 15, {15:'15 Min',30:'30 Min',60:'1 Std',120:'2 Std',240:'4 Std'}) +
+    fSubheading('Aktuelle Aufgaben') +
+    '<div id="paTaskList" style="margin-bottom:8px;"><div style="color:var(--text-muted);font-size:13px;">Wird geladen...</div></div>' +
+    '<div style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;">' +
+      '<div style="flex:1;min-width:200px;"><label style="font-size:11px;color:var(--text-muted);">Neue Aufgabe</label>' +
+        '<input type="text" id="paTaskTitle" class="form-input" placeholder="z.B. Milch kaufen" style="font-size:13px;"></div>' +
+      '<div style="min-width:100px;"><label style="font-size:11px;color:var(--text-muted);">Person (opt.)</label>' +
+        '<input type="text" id="paTaskPerson" class="form-input" placeholder="z.B. Lisa" style="font-size:13px;"></div>' +
+      '<div style="min-width:120px;"><label style="font-size:11px;color:var(--text-muted);">Faellig (opt.)</label>' +
+        '<input type="date" id="paTaskDue" class="form-input" style="font-size:13px;"></div>' +
+      '<button class="btn" onclick="addPersonalTask()" style="height:36px;white-space:nowrap;">&#10010; Hinzufuegen</button>' +
+    '</div>' +
+    fSubheading('Wiederkehrende Aufgaben') +
+    '<div id="paRecurringList" style="margin-bottom:8px;"><div style="color:var(--text-muted);font-size:13px;">Wird geladen...</div></div>'
+  ) +
+  sectionWrap('&#128221;', 'Notizen',
+    fInfo('Schnelle Notizen per Sprache oder hier. Kategorisiert und durchsuchbar.') +
+    fToggle('notes.enabled', 'Notiz-System aktiv') +
+    fRange('notes.max_notes', 'Max. Notizen', 100, 2000, 100) +
+    fRange('notes.archive_after_days', 'Archivieren nach Tagen', 30, 365, 30, {30:'1 Monat',60:'2 Monate',90:'3 Monate',180:'6 Monate',365:'1 Jahr'}) +
+    fSubheading('Notizen') +
+    '<div id="paNotesList" style="margin-bottom:8px;"><div style="color:var(--text-muted);font-size:13px;">Wird geladen...</div></div>' +
+    '<div style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;">' +
+      '<div style="flex:2;min-width:200px;"><label style="font-size:11px;color:var(--text-muted);">Neue Notiz</label>' +
+        '<input type="text" id="paNoteContent" class="form-input" placeholder="z.B. Schluesseldienst: 0800-123456" style="font-size:13px;"></div>' +
+      '<div style="min-width:120px;"><label style="font-size:11px;color:var(--text-muted);">Kategorie</label>' +
+        '<select id="paNoteCategory" class="form-input" style="font-size:13px;">' +
+          '<option value="sonstiges">Sonstiges</option><option value="haushalt">Haushalt</option>' +
+          '<option value="arbeit">Arbeit</option><option value="ideen">Ideen</option>' +
+          '<option value="gesundheit">Gesundheit</option><option value="technik">Technik</option>' +
+          '<option value="finanzen">Finanzen</option><option value="familie">Familie</option>' +
+          '<option value="rezept">Rezept</option><option value="einkauf">Einkauf</option>' +
+        '</select></div>' +
+      '<button class="btn" onclick="addPersonalNote()" style="height:36px;white-space:nowrap;">&#10010; Speichern</button>' +
+    '</div>'
+  ) +
+  sectionWrap('&#128106;', 'Familie',
+    fInfo('Familien-Profile fuer personalisierte Kommunikation. Jarvis passt Sprache und Briefing an Alter und Beziehung an.') +
+    '<div id="paFamilyList" style="margin-bottom:8px;"><div style="color:var(--text-muted);font-size:13px;">Wird geladen...</div></div>' +
+    fSubheading('Mitglied hinzufuegen') +
+    '<div style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;">' +
+      '<div style="flex:1;min-width:120px;"><label style="font-size:11px;color:var(--text-muted);">Name</label>' +
+        '<input type="text" id="paFamilyName" class="form-input" placeholder="z.B. Lisa" style="font-size:13px;"></div>' +
+      '<div style="min-width:130px;"><label style="font-size:11px;color:var(--text-muted);">Beziehung</label>' +
+        '<select id="paFamilyRelation" class="form-input" style="font-size:13px;">' +
+          '<option value="partner">Partner/in</option><option value="spouse">Ehepartner/in</option>' +
+          '<option value="child">Kind</option><option value="parent">Elternteil</option>' +
+          '<option value="sibling">Geschwister</option><option value="grandparent">Grosseltern</option>' +
+          '<option value="roommate">Mitbewohner/in</option><option value="friend">Freund/in</option>' +
+          '<option value="other">Andere</option>' +
+        '</select></div>' +
+      '<div style="min-width:90px;"><label style="font-size:11px;color:var(--text-muted);">Geburtsjahr</label>' +
+        '<input type="number" id="paFamilyYear" class="form-input" min="1920" max="2025" placeholder="1990" style="font-size:13px;"></div>' +
+      '<div style="flex:1;min-width:140px;"><label style="font-size:11px;color:var(--text-muted);">Interessen</label>' +
+        '<input type="text" id="paFamilyInterests" class="form-input" placeholder="z.B. Yoga, Kochen" style="font-size:13px;"></div>' +
+      '<button class="btn" onclick="addFamilyMember()" style="height:36px;white-space:nowrap;">&#10010; Hinzufuegen</button>' +
+    '</div>'
+  ) +
+  sectionWrap('&#127869;', 'Essensplanung',
+    fInfo('Wochenplaene, Vorschlaege aus Vorraeten und Mahlzeiten-Historie. Verbindet Koch-Assistent, Einkaufsliste und Inventar.') +
+    fToggle('meal_planner.enabled', 'Essensplanung aktiv') +
+    fRange('meal_planner.default_portions', 'Standard-Portionen', 1, 12, 1) +
+    fRange('meal_planner.history_max_entries', 'Max. Mahlzeiten-Historie', 50, 500, 50) +
+    fSubheading('Aktueller Wochenplan') +
+    '<div id="paMealPlan" style="margin-bottom:8px;"><div style="color:var(--text-muted);font-size:13px;">Wird geladen...</div></div>' +
+    '<button class="btn" onclick="createMealPlan()" style="margin-top:4px;">&#128196; Neuen Wochenplan erstellen</button>' +
+    fSubheading('Letzte Mahlzeiten') +
+    '<div id="paMealHistory" style="margin-bottom:8px;"><div style="color:var(--text-muted);font-size:13px;">Wird geladen...</div></div>'
+  ) +
+  sectionWrap('&#127874;', 'Geburtstage & Jahrestage — Einstellungen',
+    fInfo('Proaktive Erinnerungen an Geburtstage und Jahrestage. Die Daten selbst verwaltest du unter Gedaechtnis → Persoenliche Daten.') +
+    fToggle('personal_dates.enabled', 'Erinnerungen aktiv') +
+    fRange('personal_dates.check_interval_hours', 'Pruef-Intervall', 1, 24, 1, {1:'Stuendlich',3:'3 Std',6:'6 Std (Standard)',12:'12 Std',24:'Taeglich'}) +
+    fRange('personal_dates.briefing_lookahead_days', 'Vorschau im Morgen-Briefing', 1, 30, 1, {1:'1 Tag',3:'3 Tage',7:'1 Woche (Standard)',14:'2 Wochen',30:'1 Monat'})
+  );
+}
+
+// ---- Personal Assistant: Loader-Funktionen ----
+
+async function loadPersonalTasks() {
+  try {
+    const d = await api('/api/ui/tasks');
+    const el = document.getElementById('paTaskList');
+    if (!el) return;
+    if (!d.success || !d.message || d.message.includes('Keine offenen')) {
+      el.innerHTML = '<div style="color:var(--text-muted);font-size:13px;">Keine offenen Aufgaben — alles erledigt! &#127881;</div>';
+    } else {
+      const lines = d.message.split('\n').filter(l => l.trim());
+      const header = lines[0];
+      const items = lines.slice(1);
+      el.innerHTML = items.map(item => {
+        const text = item.replace(/^\d+\.\s*\[.\]\s*/, '').trim();
+        const isDone = item.includes('[x]');
+        return '<div style="display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid var(--border);">' +
+          '<span style="flex:1;font-size:13px;' + (isDone ? 'text-decoration:line-through;color:var(--text-muted);' : '') + '">' + esc(text) + '</span>' +
+          (!isDone ? '<button class="btn btn-sm" onclick="completePersonalTask(\'' + esc(text.replace(/'/g, "\\'")) + '\')" title="Erledigt" style="font-size:11px;padding:2px 8px;">&#10004;</button>' : '') +
+          '<button class="btn btn-sm btn-danger" onclick="removePersonalTask(\'' + esc(text.replace(/'/g, "\\'")) + '\')" title="Entfernen" style="font-size:11px;padding:2px 8px;">&#10006;</button>' +
+        '</div>';
+      }).join('');
+    }
+    // Wiederkehrende
+    const rd = await api('/api/ui/tasks/recurring');
+    const rel = document.getElementById('paRecurringList');
+    if (!rel) return;
+    if (!rd.success || !rd.message || rd.message.includes('Keine')) {
+      rel.innerHTML = '<div style="color:var(--text-muted);font-size:13px;">Keine wiederkehrenden Aufgaben</div>';
+    } else {
+      const lines = rd.message.split('\n').filter(l => l.startsWith('-'));
+      rel.innerHTML = lines.map(l => '<div style="padding:4px 0;font-size:13px;border-bottom:1px solid var(--border);">' + esc(l.replace(/^-\s*/, '')) + '</div>').join('');
+    }
+  } catch(e) { console.error('Tasks load fail:', e); }
+}
+
+async function addPersonalTask() {
+  const title = (document.getElementById('paTaskTitle')?.value || '').trim();
+  const person = (document.getElementById('paTaskPerson')?.value || '').trim();
+  const due = (document.getElementById('paTaskDue')?.value || '').trim();
+  if (!title) { toast('Aufgabe eingeben', 'error'); return; }
+  try {
+    const d = await api('/api/ui/tasks', 'POST', {title, person, due_date: due, priority: 'medium'});
+    if (d.success) {
+      toast(d.message || 'Hinzugefuegt');
+      document.getElementById('paTaskTitle').value = '';
+      document.getElementById('paTaskPerson').value = '';
+      document.getElementById('paTaskDue').value = '';
+      loadPersonalTasks();
+    } else { toast(d.message || 'Fehler', 'error'); }
+  } catch(e) { toast('Fehler beim Hinzufuegen', 'error'); }
+}
+
+async function completePersonalTask(title) {
+  try {
+    const d = await api('/api/ui/tasks/complete', 'POST', {title});
+    if (d.success) { toast(d.message || 'Erledigt'); loadPersonalTasks(); }
+    else { toast(d.message || 'Fehler', 'error'); }
+  } catch(e) { toast('Fehler', 'error'); }
+}
+
+async function removePersonalTask(title) {
+  if (!confirm('Aufgabe "' + title + '" wirklich entfernen?')) return;
+  try {
+    const d = await api('/api/ui/tasks', 'DELETE', {title});
+    if (d.success) { toast('Entfernt'); loadPersonalTasks(); }
+    else { toast(d.message || 'Fehler', 'error'); }
+  } catch(e) { toast('Fehler', 'error'); }
+}
+
+async function loadPersonalNotes() {
+  try {
+    const d = await api('/api/ui/notes?limit=15');
+    const el = document.getElementById('paNotesList');
+    if (!el) return;
+    if (!d.success || !d.message || d.message.includes('Keine')) {
+      el.innerHTML = '<div style="color:var(--text-muted);font-size:13px;">Noch keine Notizen vorhanden</div>';
+    } else {
+      const lines = d.message.split('\n').filter(l => l.startsWith('-'));
+      el.innerHTML = lines.map(l => {
+        const text = l.replace(/^-\s*/, '');
+        return '<div style="padding:5px 0;font-size:13px;border-bottom:1px solid var(--border);">' + esc(text) + '</div>';
+      }).join('');
+    }
+  } catch(e) { console.error('Notes load fail:', e); }
+}
+
+async function addPersonalNote() {
+  const content = (document.getElementById('paNoteContent')?.value || '').trim();
+  const category = document.getElementById('paNoteCategory')?.value || 'sonstiges';
+  if (!content) { toast('Notiz eingeben', 'error'); return; }
+  try {
+    const d = await api('/api/ui/notes', 'POST', {content, category});
+    if (d.success) {
+      toast(d.message || 'Gespeichert');
+      document.getElementById('paNoteContent').value = '';
+      loadPersonalNotes();
+    } else { toast(d.message || 'Fehler', 'error'); }
+  } catch(e) { toast('Fehler beim Speichern', 'error'); }
+}
+
+async function loadFamilyMembers() {
+  try {
+    const d = await api('/api/ui/family');
+    const el = document.getElementById('paFamilyList');
+    if (!el) return;
+    const members = d.members || [];
+    if (members.length === 0) {
+      el.innerHTML = '<div style="color:var(--text-muted);font-size:13px;">Noch keine Familienmitglieder eingetragen</div>';
+    } else {
+      const relLabels = {partner:'Partner/in',spouse:'Ehepartner/in',child:'Kind',parent:'Elternteil',sibling:'Geschwister',grandparent:'Grosseltern',roommate:'Mitbewohner/in',friend:'Freund/in',other:'Andere'};
+      el.innerHTML = members.map(m => {
+        const name = (m.name || '?');
+        const rel = relLabels[m.relationship] || m.relationship || '';
+        const interests = m.interests || '';
+        const year = m.birth_year || '';
+        return '<div style="display:flex;align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid var(--border);">' +
+          '<div style="flex:1;">' +
+            '<div style="font-size:14px;font-weight:600;">' + esc(name) + (rel ? ' <span style="font-size:11px;color:var(--text-muted);font-weight:400;">(' + esc(rel) + ')</span>' : '') + '</div>' +
+            (interests ? '<div style="font-size:12px;color:var(--text-secondary);">Interessen: ' + esc(interests) + '</div>' : '') +
+            (year ? '<div style="font-size:11px;color:var(--text-muted);">Geb. ' + esc(year) + '</div>' : '') +
+          '</div>' +
+          '<button class="btn btn-sm btn-danger" onclick="removeFamilyMember(\'' + esc(name.replace(/'/g, "\\'")) + '\')" title="Entfernen" style="font-size:11px;padding:2px 8px;">&#10006;</button>' +
+        '</div>';
+      }).join('');
+    }
+  } catch(e) { console.error('Family load fail:', e); }
+}
+
+async function addFamilyMember() {
+  const name = (document.getElementById('paFamilyName')?.value || '').trim();
+  const relationship = document.getElementById('paFamilyRelation')?.value || 'other';
+  const birth_year = parseInt(document.getElementById('paFamilyYear')?.value || '0') || 0;
+  const interests = (document.getElementById('paFamilyInterests')?.value || '').trim();
+  if (!name) { toast('Name eingeben', 'error'); return; }
+  try {
+    const d = await api('/api/ui/family', 'POST', {name, relationship, birth_year, interests});
+    if (d.success) {
+      toast(d.message || 'Hinzugefuegt');
+      document.getElementById('paFamilyName').value = '';
+      document.getElementById('paFamilyYear').value = '';
+      document.getElementById('paFamilyInterests').value = '';
+      loadFamilyMembers();
+    } else { toast(d.message || 'Fehler', 'error'); }
+  } catch(e) { toast('Fehler', 'error'); }
+}
+
+async function removeFamilyMember(name) {
+  if (!confirm(name + ' wirklich aus der Familie entfernen?')) return;
+  try {
+    const d = await api('/api/ui/family/' + encodeURIComponent(name), 'DELETE');
+    if (d.success) { toast('Entfernt'); loadFamilyMembers(); }
+    else { toast(d.message || 'Fehler', 'error'); }
+  } catch(e) { toast('Fehler', 'error'); }
+}
+
+async function loadMealPlan() {
+  try {
+    const d = await api('/api/ui/meals/plan');
+    const el = document.getElementById('paMealPlan');
+    if (!el) return;
+    if (!d.success || !d.message || d.message.includes('Kein Wochenplan')) {
+      el.innerHTML = '<div style="color:var(--text-muted);font-size:13px;">Kein Wochenplan vorhanden — klicke unten um einen zu erstellen.</div>';
+    } else {
+      el.innerHTML = '<div style="font-size:13px;white-space:pre-wrap;line-height:1.6;padding:8px;background:var(--bg-input);border-radius:var(--radius-sm);border:1px solid var(--border);">' + esc(d.message) + '</div>';
+    }
+
+    // Mahlzeiten-Historie
+    const hd = await api('/api/ui/meals/history?days=7');
+    const hel = document.getElementById('paMealHistory');
+    if (!hel) return;
+    if (!hd.success || !hd.message || hd.message.includes('Keine Mahlzeiten')) {
+      hel.innerHTML = '<div style="color:var(--text-muted);font-size:13px;">Noch keine Mahlzeiten protokolliert</div>';
+    } else {
+      hel.innerHTML = '<div style="font-size:13px;white-space:pre-wrap;line-height:1.5;">' + esc(hd.message) + '</div>';
+    }
+  } catch(e) { console.error('Meal plan load fail:', e); }
+}
+
+async function createMealPlan() {
+  const btn = event?.target;
+  if (btn) { btn.disabled = true; btn.textContent = 'Wird erstellt...'; }
+  try {
+    const d = await api('/api/ui/meals/plan', 'POST', {preferences: '', portions: 0});
+    if (d.success) {
+      toast('Wochenplan erstellt!');
+      loadMealPlan();
+    } else { toast(d.message || 'Fehler', 'error'); }
+  } catch(e) { toast('Fehler beim Erstellen', 'error'); }
+  finally { if (btn) { btn.disabled = false; btn.textContent = '\u{1F4C4} Neuen Wochenplan erstellen'; } }
 }
 
 // ---- Koch-Assistent (aus Routinen ausgelagert) ----

--- a/assistant/tests/test_family_manager.py
+++ b/assistant/tests/test_family_manager.py
@@ -1,0 +1,166 @@
+"""Tests fuer FamilyManager - Familien-Profile."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from assistant.family_manager import FamilyManager
+
+
+@pytest.fixture
+def ha_mock():
+    return AsyncMock()
+
+
+@pytest.fixture
+def redis_mock():
+    mock = AsyncMock()
+    mock.hset = AsyncMock()
+    mock.sadd = AsyncMock()
+    mock.srem = AsyncMock()
+    mock.delete = AsyncMock(return_value=1)
+    mock.exists = AsyncMock(return_value=0)
+    mock.smembers = AsyncMock(return_value=set())
+    mock.hgetall = AsyncMock(return_value={})
+
+    pipe = MagicMock()
+    pipe.hgetall = MagicMock()
+    pipe.execute = AsyncMock(return_value=[])
+    mock.pipeline = MagicMock(return_value=pipe)
+
+    return mock
+
+
+@pytest.fixture
+def family_mgr(ha_mock, redis_mock):
+    fm = FamilyManager(ha_mock)
+    fm.redis = redis_mock
+    return fm
+
+
+@pytest.mark.asyncio
+async def test_add_member(family_mgr, redis_mock):
+    result = await family_mgr.add_member(
+        name="Lisa",
+        relationship="partner",
+        birth_year=1990,
+        interests="Yoga, Kochen",
+    )
+    assert result["success"] is True
+    assert "Lisa" in result["message"]
+    redis_mock.hset.assert_called()
+    redis_mock.sadd.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_add_member_empty_name(family_mgr):
+    result = await family_mgr.add_member(name="")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_add_member_invalid_relationship(family_mgr, redis_mock):
+    result = await family_mgr.add_member(
+        name="Max",
+        relationship="invalid_type",
+    )
+    assert result["success"] is True  # Fallback auf "other"
+
+
+@pytest.mark.asyncio
+async def test_get_member_not_found(family_mgr, redis_mock):
+    redis_mock.hgetall = AsyncMock(return_value={})
+    member = await family_mgr.get_member("unbekannt")
+    assert member is None
+
+
+@pytest.mark.asyncio
+async def test_get_member_found(family_mgr, redis_mock):
+    redis_mock.hgetall = AsyncMock(
+        return_value={
+            "name": "Lisa",
+            "name_key": "lisa",
+            "relationship": "partner",
+            "birth_year": "1990",
+            "interests": "Yoga",
+        }
+    )
+    member = await family_mgr.get_member("Lisa")
+    assert member is not None
+    assert member["name"] == "Lisa"
+    assert member["relationship"] == "partner"
+
+
+@pytest.mark.asyncio
+async def test_remove_member(family_mgr, redis_mock):
+    result = await family_mgr.remove_member("Lisa")
+    assert result["success"] is True
+    redis_mock.delete.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_remove_member_not_found(family_mgr, redis_mock):
+    redis_mock.delete = AsyncMock(return_value=0)
+    result = await family_mgr.remove_member("Unbekannt")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_age_group_adult(family_mgr, redis_mock):
+    redis_mock.hgetall = AsyncMock(
+        return_value={
+            "name": "Lisa",
+            "birth_year": "1990",
+        }
+    )
+    group = await family_mgr.get_age_group("Lisa")
+    assert group == "adult"
+
+
+@pytest.mark.asyncio
+async def test_get_age_group_child(family_mgr, redis_mock):
+    redis_mock.hgetall = AsyncMock(
+        return_value={
+            "name": "Max Jr",
+            "birth_year": "2020",
+        }
+    )
+    group = await family_mgr.get_age_group("Max Jr")
+    assert group == "child"
+
+
+@pytest.mark.asyncio
+async def test_get_age_group_no_profile(family_mgr, redis_mock):
+    redis_mock.hgetall = AsyncMock(return_value={})
+    group = await family_mgr.get_age_group("ghost")
+    assert group == "adult"
+
+
+@pytest.mark.asyncio
+async def test_communication_style_child(family_mgr, redis_mock):
+    redis_mock.hgetall = AsyncMock(
+        return_value={
+            "name": "Max Jr",
+            "birth_year": "2020",
+        }
+    )
+    style = await family_mgr.get_communication_style("Max Jr")
+    assert style["formality"] == "informal"
+    assert style["vocabulary"] == "simple"
+
+
+@pytest.mark.asyncio
+async def test_send_family_message_no_callback(family_mgr):
+    result = await family_mgr.send_family_message(message="Test")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_all_members_empty(family_mgr, redis_mock):
+    members = await family_mgr.get_all_members()
+    assert members == []
+
+
+def test_context_hints():
+    fm = FamilyManager(AsyncMock())
+    hints = fm.get_context_hints()
+    assert len(hints) > 0

--- a/assistant/tests/test_function_calling_safety.py
+++ b/assistant/tests/test_function_calling_safety.py
@@ -146,7 +146,7 @@ class TestAllowedFunctions:
     def test_total_count_reasonable(self):
         """Whitelist sollte nicht leer und nicht uebertrieben gross sein."""
         count = len(FunctionExecutor._ALLOWED_FUNCTIONS)
-        assert 20 <= count <= 95, f"Whitelist hat {count} Eintraege — pruefen!"
+        assert 20 <= count <= 100, f"Whitelist hat {count} Eintraege — pruefen!"
 
     def test_internal_methods_excluded(self):
         """Private/interne Methoden duerfen nicht in der Whitelist sein."""

--- a/assistant/tests/test_meal_planner.py
+++ b/assistant/tests/test_meal_planner.py
@@ -1,0 +1,157 @@
+"""Tests fuer MealPlanner - Essensplanung."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from assistant.meal_planner import MealPlanner
+
+
+@pytest.fixture
+def ollama_mock():
+    mock = AsyncMock()
+    mock.generate = AsyncMock(
+        return_value="1. Spaghetti Carbonara\n2. Gemuesesuppe\n3. Omelette"
+    )
+    return mock
+
+
+@pytest.fixture
+def redis_mock():
+    mock = AsyncMock()
+    mock.hset = AsyncMock()
+    mock.zadd = AsyncMock()
+    mock.zcard = AsyncMock(return_value=5)
+    mock.zrangebyscore = AsyncMock(return_value=[])
+    mock.hgetall = AsyncMock(return_value={})
+    mock.expire = AsyncMock()
+    mock.zrange = AsyncMock(return_value=[])
+    mock.delete = AsyncMock()
+    mock.zrem = AsyncMock()
+
+    pipe = MagicMock()
+    pipe.hget = MagicMock()
+    pipe.hgetall = MagicMock()
+    pipe.execute = AsyncMock(return_value=[])
+    mock.pipeline = MagicMock(return_value=pipe)
+
+    return mock
+
+
+@pytest.fixture
+def inventory_mock():
+    mock = AsyncMock()
+    mock.list_items = AsyncMock(
+        return_value={
+            "items": [
+                {"name": "Spaghetti", "expiry_date": "2026-04-01"},
+                {"name": "Eier", "expiry_date": "2026-03-25"},
+                {"name": "Parmesan", "expiry_date": ""},
+            ]
+        }
+    )
+    return mock
+
+
+@pytest.fixture
+def meal_planner(ollama_mock, redis_mock, inventory_mock):
+    mp = MealPlanner(ollama_mock)
+    mp.redis = redis_mock
+    mp.inventory = inventory_mock
+    mp.ha = AsyncMock()
+    mp.ha.call_service = AsyncMock(return_value=True)
+    return mp
+
+
+@pytest.mark.asyncio
+async def test_suggest_from_inventory(meal_planner, ollama_mock):
+    result = await meal_planner.suggest_from_inventory()
+    assert result["success"] is True
+    ollama_mock.generate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_suggest_no_inventory(ollama_mock, redis_mock):
+    mp = MealPlanner(ollama_mock)
+    mp.redis = redis_mock
+    result = await mp.suggest_from_inventory()
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_suggest_empty_inventory(meal_planner, inventory_mock):
+    inventory_mock.list_items = AsyncMock(return_value={"items": []})
+    result = await meal_planner.suggest_from_inventory()
+    assert result["success"] is True
+    assert "Keine Vorraete" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_log_meal(meal_planner, redis_mock):
+    result = await meal_planner.log_meal(
+        meal="Spaghetti Carbonara",
+        meal_type="abendessen",
+        rating=4,
+    )
+    assert result["success"] is True
+    assert "protokolliert" in result["message"]
+    redis_mock.hset.assert_called()
+    redis_mock.zadd.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_log_meal_empty(meal_planner):
+    result = await meal_planner.log_meal(meal="")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_log_meal_invalid_type(meal_planner, redis_mock):
+    """Ungueltiger Mahlzeitentyp -> Fallback auf 'abendessen'."""
+    result = await meal_planner.log_meal(
+        meal="Pizza",
+        meal_type="brunch",
+    )
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_meal_history_empty(meal_planner, redis_mock):
+    result = await meal_planner.get_meal_history()
+    assert result["success"] is True
+    assert "Keine Mahlzeiten" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_get_current_plan_empty(meal_planner, redis_mock):
+    result = await meal_planner.get_current_plan()
+    assert result["success"] is True
+    assert "Kein Wochenplan" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_add_missing_to_shopping(meal_planner):
+    result = await meal_planner.add_missing_to_shopping(
+        recipe_ingredients=["Mehl", "Butter", "Spaghetti"]
+    )
+    assert result["success"] is True
+    assert "2" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_add_missing_empty_list(meal_planner):
+    result = await meal_planner.add_missing_to_shopping(recipe_ingredients=[])
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_weekly_plan(meal_planner, ollama_mock):
+    result = await meal_planner.create_weekly_plan(preferences="viel Gemuese")
+    assert result["success"] is True
+    ollama_mock.generate.assert_called()
+
+
+def test_context_hints():
+    mp = MealPlanner(AsyncMock())
+    hints = mp.get_context_hints()
+    assert len(hints) > 0
+    assert "MealPlanner" in hints[0]

--- a/assistant/tests/test_note_manager.py
+++ b/assistant/tests/test_note_manager.py
@@ -1,0 +1,135 @@
+"""Tests fuer NoteManager - Notiz-System."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from assistant.note_manager import NoteManager
+
+
+@pytest.fixture
+def redis_mock():
+    mock = AsyncMock()
+    mock.hset = AsyncMock()
+    mock.zadd = AsyncMock()
+    mock.sadd = AsyncMock()
+    mock.zcard = AsyncMock(return_value=5)
+    mock.zrevrange = AsyncMock(return_value=[])
+    mock.zrangebyscore = AsyncMock(return_value=[])
+    mock.smembers = AsyncMock(return_value=set())
+    mock.scard = AsyncMock(return_value=0)
+    mock.hgetall = AsyncMock(return_value={})
+    mock.zrem = AsyncMock()
+    mock.srem = AsyncMock()
+    mock.delete = AsyncMock()
+
+    pipe = MagicMock()
+    pipe.hgetall = MagicMock()
+    pipe.hget = MagicMock()
+    pipe.execute = AsyncMock(return_value=[])
+    mock.pipeline = MagicMock(return_value=pipe)
+
+    return mock
+
+
+@pytest.fixture
+def note_mgr(redis_mock):
+    nm = NoteManager()
+    nm.redis = redis_mock
+    return nm
+
+
+@pytest.mark.asyncio
+async def test_add_note_success(note_mgr, redis_mock):
+    result = await note_mgr.add_note(
+        content="Schluesseldienst: 0800-123456",
+        category="haushalt",
+    )
+    assert result["success"] is True
+    assert "note_id" in result
+    redis_mock.hset.assert_called()
+    redis_mock.zadd.assert_called()
+    redis_mock.sadd.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_add_note_empty_content(note_mgr):
+    result = await note_mgr.add_note(content="")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_add_note_with_person(note_mgr, redis_mock):
+    result = await note_mgr.add_note(
+        content="Zahnarzt am Dienstag",
+        category="gesundheit",
+        person="lisa",
+    )
+    assert result["success"] is True
+    assert redis_mock.sadd.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_add_note_invalid_category(note_mgr, redis_mock):
+    """Ungueltige Kategorie -> Fallback auf 'sonstiges'."""
+    result = await note_mgr.add_note(
+        content="Test",
+        category="invalid_cat",
+    )
+    assert result["success"] is True
+    calls = redis_mock.sadd.call_args_list
+    assert any("sonstiges" in str(c) for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_list_notes_empty(note_mgr, redis_mock):
+    result = await note_mgr.list_notes()
+    assert result["success"] is True
+    assert "Keine" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_search_notes_empty(note_mgr, redis_mock):
+    result = await note_mgr.search_notes(query="test")
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_search_notes_no_query(note_mgr):
+    result = await note_mgr.search_notes(query="")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_note_not_found(note_mgr, redis_mock):
+    result = await note_mgr.delete_note("nonexistent_id")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_note_success(note_mgr, redis_mock):
+    redis_mock.hgetall = AsyncMock(
+        return_value={
+            "id": "note_abc123",
+            "content": "Test",
+            "category": "haushalt",
+            "person": "max",
+        }
+    )
+    result = await note_mgr.delete_note("note_abc123")
+    assert result["success"] is True
+    redis_mock.delete.assert_called()
+    redis_mock.zrem.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_get_categories_empty(note_mgr, redis_mock):
+    result = await note_mgr.get_note_categories()
+    assert result["success"] is True
+    assert "Noch keine" in result["message"]
+
+
+def test_context_hints():
+    nm = NoteManager()
+    hints = nm.get_context_hints()
+    assert len(hints) > 0
+    assert "NoteManager" in hints[0]

--- a/assistant/tests/test_personal_dates.py
+++ b/assistant/tests/test_personal_dates.py
@@ -1,0 +1,109 @@
+"""Tests fuer PersonalDatesManager - Geburtstags-/Jahrestags-Automatik."""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from assistant.personal_dates import PersonalDatesManager, _format_date_type
+
+
+@pytest.fixture
+def redis_mock():
+    mock = AsyncMock()
+    mock.smembers = AsyncMock(return_value=set())
+    mock.exists = AsyncMock(return_value=0)
+    mock.set = AsyncMock()
+
+    pipe = MagicMock()
+    pipe.hgetall = MagicMock()
+    pipe.execute = AsyncMock(return_value=[])
+    mock.pipeline = MagicMock(return_value=pipe)
+
+    return mock
+
+
+@pytest.fixture
+def pd_mgr(redis_mock):
+    pdm = PersonalDatesManager()
+    pdm.redis = redis_mock
+    return pdm
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_empty(pd_mgr):
+    result = await pd_mgr.get_upcoming_dates(30)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_with_dates(pd_mgr, redis_mock):
+    now = datetime.now(timezone.utc)
+    today_mm_dd = now.strftime("%m-%d")
+
+    redis_mock.smembers = AsyncMock(return_value={"fact_123"})
+    pipe = MagicMock()
+    pipe.hgetall = MagicMock()
+    pipe.execute = AsyncMock(
+        return_value=[
+            {
+                "person": "lisa",
+                "date_type": "birthday",
+                "date_mm_dd": today_mm_dd,
+                "date_year": "1990",
+                "content": "Lisas Geburtstag",
+            }
+        ]
+    )
+    redis_mock.pipeline = MagicMock(return_value=pipe)
+
+    result = await pd_mgr.get_upcoming_dates(7)
+    assert len(result) >= 1
+    assert result[0]["person"] == "lisa"
+
+
+@pytest.mark.asyncio
+async def test_get_briefing_section_empty(pd_mgr):
+    section = await pd_mgr.get_briefing_section()
+    assert section == ""
+
+
+@pytest.mark.asyncio
+async def test_get_person_dates_empty(pd_mgr, redis_mock):
+    result = await pd_mgr.get_person_dates("max")
+    assert result == []
+
+
+def test_format_date_type():
+    assert _format_date_type("birthday") == "Geburtstag"
+    assert _format_date_type("anniversary") == "Jahrestag"
+    assert _format_date_type("wedding") == "Hochzeitstag"
+    assert _format_date_type("", "Namenstag") == "Namenstag"
+    assert _format_date_type("unknown_type") == "unknown_type"
+
+
+@pytest.mark.asyncio
+async def test_check_and_notify_no_callback(pd_mgr):
+    """Ohne Callback sollte nichts passieren."""
+    await pd_mgr.check_and_notify()  # Kein Fehler
+
+
+def test_format_reminder():
+    pdm = PersonalDatesManager()
+    entry = {
+        "person": "lisa",
+        "date_type": "birthday",
+        "label": "",
+        "year": "1990",
+        "days_until": 0,
+    }
+    msg = pdm._format_reminder(entry)
+    assert "Heute" in msg
+    assert "Lisa" in msg
+
+    entry["days_until"] = 1
+    msg = pdm._format_reminder(entry)
+    assert "Morgen" in msg
+
+    entry["days_until"] = 5
+    msg = pdm._format_reminder(entry)
+    assert "5 Tagen" in msg

--- a/assistant/tests/test_proactive_comprehensive.py
+++ b/assistant/tests/test_proactive_comprehensive.py
@@ -782,7 +782,8 @@ class TestAnomalyDetection:
     async def test_anomaly_triggers_notification_at_4(self, pm):
         redis = AsyncMock()
         redis.incr = AsyncMock(return_value=4)
-        redis.delete = AsyncMock()
+        redis.get = AsyncMock(return_value=None)  # Kein Notification-Cooldown aktiv
+        redis.set = AsyncMock()
         with patch.object(pm, "_notify", new_callable=AsyncMock) as mock_notify:
             await pm._track_cover_anomaly("cover.test", redis)
             mock_notify.assert_called_once()

--- a/assistant/tests/test_task_manager.py
+++ b/assistant/tests/test_task_manager.py
@@ -1,0 +1,152 @@
+"""Tests fuer TaskManager - Aufgabenverwaltung."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from assistant.task_manager import TaskManager
+
+
+@pytest.fixture
+def ha_mock():
+    mock = AsyncMock()
+    mock.call_service = AsyncMock(return_value=True)
+    mock.get_state = AsyncMock(
+        return_value={
+            "state": "2",
+            "attributes": {
+                "items": [
+                    {"summary": "Milch kaufen", "status": "needs_action"},
+                    {
+                        "summary": "Zahnarzt anrufen",
+                        "status": "needs_action",
+                        "due": "2026-03-25",
+                    },
+                ]
+            },
+        }
+    )
+    return mock
+
+
+@pytest.fixture
+def redis_mock():
+    mock = AsyncMock()
+    mock.hset = AsyncMock()
+    mock.expire = AsyncMock()
+    mock.sadd = AsyncMock()
+    mock.smembers = AsyncMock(return_value=set())
+    mock.hgetall = AsyncMock(return_value={})
+    mock.hget = AsyncMock(return_value=None)
+    mock.srem = AsyncMock()
+    mock.delete = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def task_mgr(ha_mock, redis_mock):
+    tm = TaskManager(ha_mock)
+    tm.redis = redis_mock
+    return tm
+
+
+@pytest.mark.asyncio
+async def test_add_task_success(task_mgr, ha_mock, redis_mock):
+    task_mgr.redis = redis_mock
+    await task_mgr.initialize(redis_client=redis_mock)
+    if task_mgr._recurring_task:
+        task_mgr._recurring_task.cancel()
+    result = await task_mgr.add_task(title="Milch kaufen", person="max")
+    assert result["success"] is True
+    assert "Milch kaufen" in result["message"]
+    ha_mock.call_service.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_add_task_empty_title(task_mgr):
+    result = await task_mgr.add_task(title="")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_add_task_with_due_date(task_mgr, ha_mock, redis_mock):
+    task_mgr.redis = redis_mock
+    result = await task_mgr.add_task(
+        title="Steuer abgeben",
+        due_date="2026-04-15",
+        priority="high",
+    )
+    assert result["success"] is True
+    assert "faellig" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks(task_mgr):
+    result = await task_mgr.list_tasks()
+    assert result["success"] is True
+    assert "Milch kaufen" in result["message"]
+    assert "Zahnarzt anrufen" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_complete_task(task_mgr, ha_mock):
+    result = await task_mgr.complete_task(title="Milch kaufen")
+    assert result["success"] is True
+    assert "erledigt" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_complete_task_empty(task_mgr):
+    result = await task_mgr.complete_task(title="")
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_remove_task(task_mgr, ha_mock):
+    result = await task_mgr.remove_task(title="Milch kaufen")
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_add_recurring_task(task_mgr, redis_mock):
+    result = await task_mgr.add_recurring_task(
+        title="Papiertonne raus",
+        recurrence="weekly",
+        weekday="montag",
+    )
+    assert result["success"] is True
+    assert "montag" in result["message"].lower()
+    redis_mock.hset.assert_called()
+    redis_mock.sadd.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_add_recurring_invalid_type(task_mgr):
+    result = await task_mgr.add_recurring_task(
+        title="Test",
+        recurrence="hourly",
+    )
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_add_recurring_weekly_no_weekday(task_mgr):
+    result = await task_mgr.add_recurring_task(
+        title="Test",
+        recurrence="weekly",
+    )
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_recurring_empty(task_mgr, redis_mock):
+    redis_mock.smembers = AsyncMock(return_value=set())
+    result = await task_mgr.list_recurring_tasks()
+    assert result["success"] is True
+    assert "Keine" in result["message"]
+
+
+def test_context_hints():
+    tm = TaskManager(AsyncMock())
+    hints = tm.get_context_hints()
+    assert len(hints) > 0
+    assert "TaskManager" in hints[0]


### PR DESCRIPTION
Neue Module:
- TaskManager: Aufgabenverwaltung ueber HA todo-Domain (persoenlich + Familie,
  wiederkehrende Tasks, Prioritaeten, Faelligkeitsdaten)
- PersonalDatesManager: Geburtstags-/Jahrestags-Automatik mit proaktiven
  Erinnerungen (3 Tage, 1 Tag, am Tag) und Morgen-Briefing Integration
- FamilyManager: Familien-Profile mit Beziehungstypen, Altersgruppen,
  personalisierter Kommunikation und Gruppen-Nachrichten
- NoteManager: Persistentes Notiz-System mit Kategorien, semantischer Suche
  via ChromaDB und Redis-Fallback
- MealPlanner: Essensplanung die Cooking, Shopping und Inventory verbindet
  (Wochenplaene, Vorrats-basierte Vorschlaege, Mahlzeiten-Historie)

Integration:
- Brain.py: Alle 5 Module registriert mit _safe_init und Post-Init Wiring
- Function Calling: 5 neue Tools (manage_tasks, manage_notes, manage_family,
  get_personal_dates, manage_meals) mit vollstaendigen Exec-Handlern
- FastAPI: UI-Endpoints fuer alle Module (/api/ui/tasks, /api/ui/notes,
  /api/ui/family, /api/ui/meals) - alles im Assistant konfigurierbar
- Settings: Konfiguration in settings.yaml.example, personal_dates im
  Morgen-Briefing Modulen

Tests: 56 neue Tests (alle bestanden)

https://claude.ai/code/session_019wk7SQ5NMRfj6K5VGtKskj